### PR TITLE
feat(executor): add SeqScan and Project Executor

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -158,6 +158,17 @@ impl ArrayBuilderImpl {
             Self::UTF8(a) => ArrayImpl::UTF8(a.finish()),
         }
     }
+
+    /// Appends a DataArrayImpl
+    pub fn append(&mut self, array_impl: &ArrayImpl) {
+        match (self, array_impl) {
+            (Self::Bool(builder), ArrayImpl::Bool(arr)) => builder.append(arr),
+            (Self::Int32(builder), ArrayImpl::Int32(arr)) => builder.append(arr),
+            (Self::Float64(builder), ArrayImpl::Float64(arr)) => builder.append(arr),
+            (Self::UTF8(builder), ArrayImpl::UTF8(arr)) => builder.append(arr),
+            _ => panic!("failed to push value: type mismatch"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/executor/create.rs
+++ b/src/executor/create.rs
@@ -7,14 +7,14 @@ pub struct CreateTableExecutor {
 }
 
 impl CreateTableExecutor {
-    pub async fn execute(self) -> Result<(), ExecutorError> {
+    pub async fn execute(self) -> Result<ExecutorResult, ExecutorError> {
         self.env.storage.create_table(
             self.plan.database_id,
             self.plan.schema_id,
             &self.plan.table_name,
             &self.plan.column_descs,
         )?;
-        Ok(())
+        Ok(ExecutorResult::Empty)
     }
 }
 

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -1,3 +1,6 @@
+use crate::array::DataChunk;
+use crate::array::{ArrayBuilderImpl, ArrayImpl};
+
 use crate::{parser::*, types::DataValue};
 
 impl Expression {
@@ -5,6 +8,17 @@ impl Expression {
     pub fn eval(&self) -> DataValue {
         match &self.kind {
             ExprKind::Constant(v) => v.clone(),
+            _ => todo!("evaluate expression"),
+        }
+    }
+
+    pub fn eval_array(&self, chunk: &DataChunk) -> ArrayImpl {
+        match &self.kind {
+            ExprKind::ColumnRef(col_ref) => {
+                let mut builder = ArrayBuilderImpl::new(self.return_type.unwrap());
+                builder.append(chunk.array_at(col_ref.column_index.unwrap() as usize));
+                builder.finish()
+            }
             _ => todo!("evaluate expression"),
         }
     }

--- a/src/executor/insert.rs
+++ b/src/executor/insert.rs
@@ -1,4 +1,4 @@
-use super::ExecutorError;
+use super::{ExecutorError, ExecutorResult};
 use crate::array::{ArrayBuilderImpl, ArrayImpl, DataChunk};
 use crate::physical_plan::InsertPhysicalPlan;
 use crate::storage::StorageRef;
@@ -9,7 +9,7 @@ pub struct InsertExecutor {
 }
 
 impl InsertExecutor {
-    pub async fn execute(self) -> Result<(), ExecutorError> {
+    pub async fn execute(self) -> Result<ExecutorResult, ExecutorError> {
         let cardinality = self.plan.values.len();
         assert!(cardinality > 0);
 
@@ -34,7 +34,7 @@ impl InsertExecutor {
             .arrays(arrays.into())
             .build();
         table.append(chunk)?;
-        Ok(())
+        Ok(ExecutorResult::Empty)
     }
 }
 

--- a/src/executor/project.rs
+++ b/src/executor/project.rs
@@ -1,0 +1,31 @@
+use super::*;
+use crate::array::{ArrayImpl, DataChunk};
+use crate::parser::Expression;
+use crate::physical_plan::ProjectionPhysicalPlan;
+
+pub struct ProjectionExecutor {
+    pub project_expressions: Vec<Expression>,
+    pub child_executor: BoxedExecutor,
+}
+
+impl ProjectionExecutor {
+    pub async fn execute(self) -> Result<ExecutorResult, ExecutorError> {
+        let child_res = self.child_executor.await?;
+        match &child_res {
+            ExecutorResult::Batch(batch) => {
+                let arrays = self
+                    .project_expressions
+                    .iter()
+                    .map(|expr| expr.eval_array(batch))
+                    .collect::<Vec<ArrayImpl>>();
+
+                let result = DataChunk::builder()
+                    .cardinality(batch.cardinality())
+                    .arrays(arrays.into())
+                    .build();
+                Ok(ExecutorResult::Batch(result))
+            }
+            ExecutorResult::Empty => Ok(ExecutorResult::Empty),
+        }
+    }
+}

--- a/src/executor/seq_scan.rs
+++ b/src/executor/seq_scan.rs
@@ -1,0 +1,43 @@
+use super::*;
+use crate::array::{ArrayBuilderImpl, ArrayImpl, DataChunk};
+use crate::physical_plan::SeqScanPhysicalPlan;
+use crate::storage::StorageRef;
+use crate::storage::Table;
+
+pub struct SeqScanExecutor {
+    pub plan: SeqScanPhysicalPlan,
+    pub storage: StorageRef,
+}
+
+impl SeqScanExecutor {
+    pub async fn execute(self) -> Result<ExecutorResult, ExecutorError> {
+        let table = self.storage.get_table(self.plan.table_ref_id)?;
+        let col_descs = table.column_descs(&self.plan.column_ids)?;
+        // Get n array builders
+        let mut builders = col_descs
+            .iter()
+            .map(|desc| ArrayBuilderImpl::new(desc.datatype()))
+            .collect::<Vec<ArrayBuilderImpl>>();
+
+        let chunks = table.get_all_chunks()?;
+        let mut cardinality: usize = 0;
+        // Notice: The column ids may not be ordered.
+        for chunk in chunks {
+            cardinality += chunk.cardinality();
+
+            for (idx, column_id) in self.plan.column_ids.iter().enumerate() {
+                // For idx-th builder, we need column_id-th array in the chunk
+                builders[idx].append(chunk.array_at(*column_id as usize));
+            }
+        }
+        let arrays = builders
+            .into_iter()
+            .map(|builder| builder.finish())
+            .collect::<Vec<ArrayImpl>>();
+        let result = DataChunk::builder()
+            .cardinality(cardinality)
+            .arrays(arrays.into())
+            .build();
+        Ok(ExecutorResult::Batch(result))
+    }
+}

--- a/tests/select.rs
+++ b/tests/select.rs
@@ -1,0 +1,9 @@
+use risinglight::{Database, Error};
+
+#[test]
+fn simple_select1() {
+    let db = Database::new();
+    db.run("create table t(v1 int, v2 int, v3 int)").unwrap();
+    db.run("insert into t values (1,10,100)").unwrap();
+    db.run("select v1, v2 from t").unwrap();
+}


### PR DESCRIPTION
1. Add `SeqScan` and `Project` executor.
2. Add `append` method for `ArrayBuilderImpl`, which could be very useless in query execution.