### PR TITLE
refactor(executor): make the executor itself an async-stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +699,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 name = "risinglight"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "bitvec",
  "criterion",
  "env_logger",
@@ -691,7 +713,6 @@ dependencies = [
  "sqlparser",
  "test-case",
  "thiserror",
- "tokio",
  "typed-builder",
 ]
 
@@ -895,17 +916,6 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "tokio"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
-dependencies = [
- "autocfg",
- "num_cpus",
- "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ smallvec = { version = "1.6.1", features = ["serde"] }
 bitvec = { version = "0.22", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 futures = "0.3"
+async-stream = "0.3"
 jemallocator = "0.3"
-tokio = { version = "1.0", features = ["rt-multi-thread", "sync"] }
 prettytable-rs = { version = "0.8", default-features = false }
 
 [dev-dependencies]

--- a/src/executor/drop.rs
+++ b/src/executor/drop.rs
@@ -4,14 +4,15 @@ use crate::{binder::Object, physical_plan::PhysicalDrop};
 pub struct DropExecutor {
     pub plan: PhysicalDrop,
     pub storage: StorageRef,
-    pub output: mpsc::Sender<DataChunk>,
 }
 
 impl DropExecutor {
-    pub async fn execute(self) -> Result<(), ExecutorError> {
-        match self.plan.object {
-            Object::Table(ref_id) => self.storage.drop_table(ref_id)?,
+    pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
+        try_stream! {
+            match self.plan.object {
+                Object::Table(ref_id) => self.storage.drop_table(ref_id)?,
+            }
+            yield DataChunk::builder().cardinality(1).build();
         }
-        Ok(())
     }
 }

--- a/src/executor/dummy_scan.rs
+++ b/src/executor/dummy_scan.rs
@@ -1,14 +1,11 @@
 use super::*;
-use crate::array::DataChunk;
 
-pub struct DummyScanExecutor {
-    pub output: mpsc::Sender<DataChunk>,
-}
+pub struct DummyScanExecutor;
 
 impl DummyScanExecutor {
-    pub async fn execute(self) -> Result<(), ExecutorError> {
-        let result = DataChunk::builder().cardinality(1).build();
-        self.output.send(result).await.ok().unwrap();
-        Ok(())
+    pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
+        try_stream! {
+            yield DataChunk::builder().cardinality(1).build();
+        }
     }
 }

--- a/src/executor/seq_scan.rs
+++ b/src/executor/seq_scan.rs
@@ -6,39 +6,38 @@ use crate::storage::StorageRef;
 pub struct SeqScanExecutor {
     pub plan: PhysicalSeqScan,
     pub storage: StorageRef,
-    pub output: mpsc::Sender<DataChunk>,
 }
 
 impl SeqScanExecutor {
-    pub async fn execute(self) -> Result<(), ExecutorError> {
-        let table = self.storage.get_table(self.plan.table_ref_id)?;
-        let col_descs = table.column_descs(&self.plan.column_ids)?;
-        // Get n array builders
-        let mut builders = col_descs
-            .iter()
-            .map(|desc| ArrayBuilderImpl::new(desc.datatype().clone()))
-            .collect::<Vec<ArrayBuilderImpl>>();
+    pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
+        try_stream! {
+            let table = self.storage.get_table(self.plan.table_ref_id)?;
+            let col_descs = table.column_descs(&self.plan.column_ids)?;
+            // Get n array builders
+            let mut builders = col_descs
+                .iter()
+                .map(|desc| ArrayBuilderImpl::new(desc.datatype().clone()))
+                .collect::<Vec<ArrayBuilderImpl>>();
 
-        let chunks = table.get_all_chunks()?;
-        let mut cardinality: usize = 0;
-        // Notice: The column ids may not be ordered.
-        for chunk in chunks {
-            cardinality += chunk.cardinality();
+            let chunks = table.get_all_chunks()?;
+            let mut cardinality: usize = 0;
+            // Notice: The column ids may not be ordered.
+            for chunk in chunks {
+                cardinality += chunk.cardinality();
 
-            for (idx, column_id) in self.plan.column_ids.iter().enumerate() {
-                // For idx-th builder, we need column_id-th array in the chunk
-                builders[idx].append(chunk.array_at(*column_id as usize));
+                for (idx, column_id) in self.plan.column_ids.iter().enumerate() {
+                    // For idx-th builder, we need column_id-th array in the chunk
+                    builders[idx].append(chunk.array_at(*column_id as usize));
+                }
             }
+            let arrays = builders
+                .into_iter()
+                .map(|builder| builder.finish())
+                .collect::<Vec<ArrayImpl>>();
+            yield DataChunk::builder()
+                .cardinality(cardinality)
+                .arrays(arrays.into())
+                .build();
         }
-        let arrays = builders
-            .into_iter()
-            .map(|builder| builder.finish())
-            .collect::<Vec<ArrayImpl>>();
-        let result = DataChunk::builder()
-            .cardinality(cardinality)
-            .arrays(arrays.into())
-            .build();
-        self.output.send(result).await.ok().unwrap();
-        Ok(())
     }
 }


### PR DESCRIPTION
Previously we used async-channel to connect the executors (#30).

This solution has a limitation that we must spawn each executor to the async runtime and attach a channel to it.
A more serious problem is **error handling**. Currently the channel only passes data without errors, so errors generated by the inner executor can not be propagated to the top level. Rust's `?` syntax does not work here either.

As @skyzh said:
> It's better to refactor the executor to return an async stream and let the user decide whether to spawn a new future to parallelly run executors, or sequentially run them.

This PR proposes a way to turn the executor into an async-stream.

Async-steam is a special future that generates a stream of data, just like iterator, but in async way.
It is composable like futures, which means the entire executor tree can be made into a single `Stream` object.
With the help of [`async-stream`](https://docs.rs/async-stream/0.3.2/async_stream/) crate, we can write async-stream in async-await style (with `try_stream!` macro), instead of handwriting state machine.

I think it's a good solution to building executors.
@skyzh @TennyZhuang Any comments?