### PR TITLE
feat: use tokio executors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
+ "futures",
  "itertools",
  "lazy_static",
  "num-traits",
@@ -205,6 +206,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -358,7 +360,6 @@ checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -382,34 +383,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
-dependencies = [
- "autocfg",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -430,18 +407,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
- "slab",
 ]
 
 [[package]]
@@ -513,6 +483,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,10 +582,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num-traits"
@@ -629,6 +648,31 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.10",
+ "smallvec",
+ "winapi",
+]
 
 [[package]]
 name = "petgraph"
@@ -698,18 +742,6 @@ dependencies = [
  "term",
  "unicode-width",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -936,6 +968,7 @@ dependencies = [
  "sqlparser",
  "test-case",
  "thiserror",
+ "tokio",
  "typed-builder",
 ]
 
@@ -1038,10 +1071,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.5"
+name = "signal-hook-registry"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "smallvec"
@@ -1162,6 +1198,37 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "tokio-macros",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ bitvec = {version = "0.22", features = ["serde"]}
 bytes = "1"
 enum_dispatch = "0.3"
 env_logger = "0.9"
-futures = "0.3"
+futures = {version = "0.3", default-features = false, features = ["alloc"]}
 itertools = "0.10"
 jemallocator = "0.3"
 log = "0.4"
@@ -25,10 +25,11 @@ serde = {version = "1.0", features = ["derive"]}
 smallvec = {version = "1.6.1", features = ["serde"]}
 sqlparser = "0.10"
 thiserror = "1.0"
+tokio = {version = "1", features = ["full"]}
 typed-builder = "0.9.1"
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = {version = "0.3", features = ["async_tokio"]}
 test-case = "1.2"
 
 [[bench]]

--- a/src/executor/create.rs
+++ b/src/executor/create.rs
@@ -31,8 +31,8 @@ mod tests {
     use crate::types::{DataTypeExt, DataTypeKind};
     use std::sync::Arc;
 
-    #[test]
-    fn test_create() {
+    #[tokio::test]
+    async fn test_create() {
         let storage = Arc::new(InMemoryStorage::new());
         let catalog = storage.catalog().clone();
         let plan = PhysicalCreateTable {
@@ -45,9 +45,7 @@ mod tests {
             ],
         };
         let mut executor = CreateTableExecutor { plan, storage }.execute().boxed();
-        futures::executor::block_on(executor.next())
-            .unwrap()
-            .unwrap();
+        executor.next().await.unwrap().unwrap();
 
         let id = TableRefId {
             database_id: 0,

--- a/src/executor/insert.rs
+++ b/src/executor/insert.rs
@@ -57,9 +57,9 @@ mod tests {
     use crate::types::{DataTypeExt, DataTypeKind, DataValue};
     use std::sync::Arc;
 
-    #[test]
-    fn simple() {
-        let env = create_table();
+    #[tokio::test]
+    async fn simple() {
+        let env = create_table().await;
         let values = [[0, 100], [1, 101], [2, 102], [3, 103]];
         let values = values
             .iter()
@@ -84,12 +84,10 @@ mod tests {
         }
         .execute()
         .boxed();
-        futures::executor::block_on(executor.next())
-            .unwrap()
-            .unwrap();
+        executor.next().await.unwrap().unwrap();
     }
 
-    fn create_table() -> GlobalEnvRef {
+    async fn create_table() -> GlobalEnvRef {
         let env = Arc::new(GlobalEnv {
             storage: StorageImpl::InMemoryStorage(Arc::new(InMemoryStorage::new())),
         });
@@ -108,9 +106,7 @@ mod tests {
         }
         .execute()
         .boxed();
-        futures::executor::block_on(executor.next())
-            .unwrap()
-            .unwrap();
+        executor.next().await.unwrap().unwrap();
         env
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@ use std::io::Write;
 
 use risinglight::Database;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     env_logger::init();
     let db = Database::new_in_memory();
     loop {
@@ -12,7 +13,7 @@ fn main() {
         std::io::stdout().lock().flush().unwrap();
         let mut input = String::new();
         std::io::stdin().read_line(&mut input).unwrap();
-        let ret = db.run(&input);
+        let ret = db.run(&input).await;
         match ret {
             Ok(chunks) => {
                 for chunk in chunks {


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

In the future, we will use Tokio's filesystem API in storage engine. So we change the whole project to use tokio instead of futures-rs's executors.