### PR TITLE
refactor: remove cardinality field from DataChunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,7 +971,6 @@ dependencies = [
  "test-case",
  "thiserror",
  "tokio",
- "typed-builder",
 ]
 
 [[package]]
@@ -1227,17 +1226,6 @@ name = "tokio-macros"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "typed-builder"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46ee5bd706ff79131be9c94e7edcb82b703c487766a114434e5790361cf08c5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ smallvec = {version = "1.6.1", features = ["serde"]}
 sqlparser = "0.10"
 thiserror = "1.0"
 tokio = {version = "1", features = ["full"]}
-typed-builder = "0.9.1"
 
 [dev-dependencies]
 criterion = {version = "0.3", features = ["async_tokio"]}

--- a/src/executor/create.rs
+++ b/src/executor/create.rs
@@ -18,7 +18,7 @@ impl<S: Storage> CreateTableExecutor<S> {
                 &self.plan.table_name,
                 &self.plan.columns,
             )?;
-            yield DataChunk::builder().cardinality(1).build();
+            yield DataChunk::single();
         }
     }
 }

--- a/src/executor/drop.rs
+++ b/src/executor/drop.rs
@@ -14,7 +14,7 @@ impl<S: Storage> DropExecutor<S> {
             match self.plan.object {
                 Object::Table(ref_id) => self.storage.drop_table(ref_id)?,
             }
-            yield DataChunk::builder().cardinality(1).build();
+            yield DataChunk::single();
         }
     }
 }

--- a/src/executor/dummy_scan.rs
+++ b/src/executor/dummy_scan.rs
@@ -6,7 +6,7 @@ pub struct DummyScanExecutor;
 impl DummyScanExecutor {
     pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
         try_stream! {
-            yield DataChunk::builder().cardinality(1).build();
+            yield DataChunk::single();
         }
     }
 }

--- a/src/executor/explain.rs
+++ b/src/executor/explain.rs
@@ -10,7 +10,7 @@ impl ExplainExecutor {
     pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
         println!("{:?}", self.plan.plan);
         try_stream! {
-            yield DataChunk::builder().cardinality(1).build();
+            yield DataChunk::single();
         }
     }
 }

--- a/src/storage/memory/iterator.rs
+++ b/src/storage/memory/iterator.rs
@@ -1,7 +1,6 @@
 use crate::array::{DataChunk, DataChunkRef};
 use crate::storage::{StorageResult, TxnIterator};
 use async_trait::async_trait;
-use itertools::Itertools;
 
 /// An iterator over all data in a transaction.
 ///
@@ -32,16 +31,11 @@ impl TxnIterator for InMemoryTxnIterator {
         } else {
             let selected_chunk = &self.chunks[self.cnt];
             // TODO(chi): DataChunk should store Arc to array, so as to reduce costly clones.
-            let arrays = self
+            let chunk = self
                 .col_idx
                 .iter()
                 .map(|idx| selected_chunk.array_at(*idx as usize).clone())
-                .collect_vec();
-
-            let chunk = DataChunk::builder()
-                .cardinality(selected_chunk.cardinality())
-                .arrays(arrays.into())
-                .build();
+                .collect::<DataChunk>();
             self.cnt += 1;
 
             Ok(Some(chunk))

--- a/src/storage/secondary/iterator.rs
+++ b/src/storage/secondary/iterator.rs
@@ -1,7 +1,6 @@
 use crate::array::{DataChunk, DataChunkRef};
 use crate::storage::{StorageResult, TxnIterator};
 use async_trait::async_trait;
-use itertools::Itertools;
 
 /// An iterator over all data in a transaction.
 ///
@@ -32,16 +31,11 @@ impl TxnIterator for SecondaryTxnIterator {
         } else {
             let selected_chunk = &self.chunks[self.cnt];
             // TODO(chi): DataChunk should store Arc to array, so as to reduce costly clones.
-            let arrays = self
+            let chunk = self
                 .col_idx
                 .iter()
                 .map(|idx| selected_chunk.array_at(*idx as usize).clone())
-                .collect_vec();
-
-            let chunk = DataChunk::builder()
-                .cardinality(selected_chunk.cardinality())
-                .arrays(arrays.into())
-                .build();
+                .collect::<DataChunk>();
             self.cnt += 1;
 
             Ok(Some(chunk))

--- a/src/storage/secondary/rowset/mem_rowset.rs
+++ b/src/storage/secondary/rowset/mem_rowset.rs
@@ -40,12 +40,11 @@ impl SecondaryMemRowset {
         directory: impl AsRef<Path>,
         column_options: ColumnBuilderOptions,
     ) -> StorageResult<DiskRowset> {
-        let arrays = self
+        let chunk = self
             .builders
             .into_iter()
             .map(|builder| builder.finish())
-            .collect_vec();
-        let chunk = DataChunk::builder().arrays(arrays.into()).build();
+            .collect::<DataChunk>();
         let directory = directory.as_ref().to_path_buf();
         let mut builder = RowsetBuilder::new(self.columns, &directory, column_options);
         builder.append(chunk);

--- a/src/storage/secondary/rowset/rowset_builder.rs
+++ b/src/storage/secondary/rowset/rowset_builder.rs
@@ -170,15 +170,12 @@ mod tests {
 
         for _ in 0..1000 {
             builder.append(
-                DataChunk::builder()
-                    .arrays(
-                        vec![I32Array::from_iter(
-                            [1, 2, 3].iter().cycle().cloned().take(1000).map(Some),
-                        )
-                        .into()]
+                [
+                    I32Array::from_iter([1, 2, 3].iter().cycle().cloned().take(1000).map(Some))
                         .into(),
-                    )
-                    .build(),
+                ]
+                .into_iter()
+                .collect(),
             )
         }
 

--- a/tests/sqllogictest.rs
+++ b/tests/sqllogictest.rs
@@ -94,6 +94,7 @@ pub enum ParseError {
 }
 
 impl ColumnValues {
+    #[allow(dead_code)]
     fn len(&self) -> usize {
         match self {
             ColumnValues::Int(c) => c.len(),
@@ -264,10 +265,7 @@ impl SqlLogicTester {
                 let actual = output
                     .get(0)
                     .expect("expect result from query, but no output");
-                let expected = DataChunk::builder()
-                    .cardinality(expected_results[0].len())
-                    .arrays(expected_results.into_iter().map(ArrayImpl::from).collect())
-                    .build();
+                let expected = expected_results.into_iter().map(ArrayImpl::from).collect();
                 if *actual != expected {
                     panic!(
                         "query result mismatch:\nSQL:\n{}\n\nExpected:\n{}\nActual:\n{}",


### PR DESCRIPTION
Since the cardinality can be inferred from any array of the chunk, we can remove the field and no longer need to calculate the cardinality when building a chunk.
Now `DataChunk` has only one `arrays` field, we implement `IntoIterator<ArrayImpl>` for it so that we can easily build a chunk from an iterator of arrays. Additional check will be made to ensure all arrays have the same length.