### PR TITLE
refactor: split insert and values executor

### DIFF
--- a/src/binder/statement/insert.rs
+++ b/src/binder/statement/insert.rs
@@ -78,7 +78,7 @@ impl Binder {
                     bound_row.reserve(row.len());
                     for (idx, expr) in row.iter().enumerate() {
                         // Bind expression
-                        let expr = self.bind_expr(expr)?;
+                        let mut expr = self.bind_expr(expr)?;
 
                         if let Some(data_type) = &expr.return_type {
                             // TODO: support valid type cast
@@ -95,6 +95,7 @@ impl Binder {
                                     "Can not insert null to non null column".into(),
                                 ));
                             }
+                            expr.return_type = Some(column_types[idx].clone());
                         }
                         bound_row.push(expr);
                     }

--- a/src/executor/values.rs
+++ b/src/executor/values.rs
@@ -1,0 +1,66 @@
+use super::*;
+use crate::array::{ArrayBuilderImpl, DataChunk};
+use crate::binder::BoundExpr;
+
+/// The executor of `values`.
+pub struct ValuesExecutor {
+    /// Each row is composed of multiple values,
+    /// each value is represented by an expression.
+    pub values: Vec<Vec<BoundExpr>>,
+}
+
+impl ValuesExecutor {
+    pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
+        try_stream! {
+            let cardinality = self.values.len();
+            assert!(cardinality > 0);
+
+            let mut array_builders = self.values[0]
+                .iter()
+                .map(|expr| ArrayBuilderImpl::new(expr.return_type.as_ref().unwrap()))
+                .collect::<Vec<ArrayBuilderImpl>>();
+            for row in &self.values {
+                for (expr, builder) in row.iter().zip(&mut array_builders) {
+                    let value = expr.eval();
+                    builder.push(&value);
+                }
+            }
+            let chunk = array_builders
+                .into_iter()
+                .map(|builder| builder.finish())
+                .collect::<DataChunk>();
+            yield chunk;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::ArrayImpl;
+    use crate::binder::BoundExpr;
+    use crate::types::DataValue;
+
+    #[tokio::test]
+    async fn values() {
+        let values = [[0, 100], [1, 101], [2, 102], [3, 103]];
+        let executor = ValuesExecutor {
+            values: values
+                .iter()
+                .map(|row| {
+                    row.iter()
+                        .map(|&v| BoundExpr::constant(DataValue::Int32(v)))
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>(),
+        };
+        let output = executor.execute().boxed().next().await.unwrap().unwrap();
+        let expected = [
+            ArrayImpl::Int32((0..4).collect()),
+            ArrayImpl::Int32((100..104).collect()),
+        ]
+        .into_iter()
+        .collect::<DataChunk>();
+        assert_eq!(output, expected);
+    }
+}

--- a/src/physical_planner/insert.rs
+++ b/src/physical_planner/insert.rs
@@ -4,15 +4,17 @@ use crate::catalog::TableRefId;
 use crate::logical_planner::LogicalInsert;
 use crate::types::ColumnId;
 
-/// The physical plan of `insert values`.
+/// The physical plan of `insert`.
 #[derive(Debug, PartialEq, Clone)]
 pub struct PhysicalInsert {
     pub table_ref_id: TableRefId,
     pub column_ids: Vec<ColumnId>,
-    /// The rows to be inserted.
-    ///
-    /// Each row is composed of multiple values,
-    /// each value is represented by an expression.
+    pub child: Box<PhysicalPlan>,
+}
+
+/// The physical plan of `values`.
+#[derive(Debug, PartialEq, Clone)]
+pub struct PhysicalValues {
     pub values: Vec<Vec<BoundExpr>>,
 }
 
@@ -21,7 +23,9 @@ impl PhysicalPlaner {
         Ok(PhysicalPlan::Insert(PhysicalInsert {
             table_ref_id: stmt.table_ref_id,
             column_ids: stmt.column_ids,
-            values: stmt.values,
+            child: Box::new(PhysicalPlan::Values(PhysicalValues {
+                values: stmt.values,
+            })),
         }))
     }
 }

--- a/src/physical_planner/mod.rs
+++ b/src/physical_planner/mod.rs
@@ -33,6 +33,7 @@ pub enum PhysicalPlan {
     Dummy,
     SeqScan(PhysicalSeqScan),
     Insert(PhysicalInsert),
+    Values(PhysicalValues),
     CreateTable(PhysicalCreateTable),
     Drop(PhysicalDrop),
     Projection(PhysicalProjection),


### PR DESCRIPTION
This PR splits the `insert` executor into `insert` and `values`:
* `insert`: get chunks from child then insert them into a table
* `values`: evaluate expressions then output chunks

It is a preparation for `insert into .. select ..` and `copy .. from ..`, where the `insert` executor requires a data source other than `values`.