### PR TITLE
fix: panic on joining empty column

### DIFF
--- a/src/executor/nested_loop_join.rs
+++ b/src/executor/nested_loop_join.rs
@@ -11,6 +11,76 @@ pub struct NestedLoopJoinExecutor {
 }
 
 impl NestedLoopJoinExecutor {
+    pub fn execute_inner(
+        join_op: BoundJoinOperator,
+        left_chunks: Vec<DataChunk>,
+        right_chunks: Vec<DataChunk>,
+    ) -> Result<Option<DataChunk>, ExecutorError> {
+        if left_chunks.is_empty() || right_chunks.is_empty() {
+            return Ok(None);
+        }
+
+        let mut left_row = left_chunks[0].get_row_by_idx(0);
+        let mut right_row = right_chunks[0].get_row_by_idx(0);
+        left_row.append(&mut right_row);
+        let mut chunk_builders: Vec<ArrayBuilderImpl> = left_row
+            .iter()
+            .map(|v| ArrayBuilderImpl::from_type_of_value(v))
+            .collect();
+
+        for left_chunk in left_chunks.iter() {
+            for left_idx in 0..left_chunk.cardinality() {
+                for right_chunk in right_chunks.iter() {
+                    for right_idx in 0..right_chunk.cardinality() {
+                        let mut left_row = left_chunk.get_row_by_idx(left_idx);
+                        let mut right_row = right_chunk.get_row_by_idx(right_idx);
+                        left_row.append(&mut right_row);
+                        let mut builders: Vec<ArrayBuilderImpl> = left_row
+                            .iter()
+                            .map(|v| ArrayBuilderImpl::from_type_of_value(v))
+                            .collect();
+                        for (idx, builder) in builders.iter_mut().enumerate() {
+                            builder.push(&left_row[idx]);
+                        }
+
+                        let chunk: DataChunk = builders
+                            .into_iter()
+                            .map(|builder| builder.finish())
+                            .collect();
+                        match &join_op {
+                            BoundJoinOperator::Inner(constraint) => match constraint {
+                                BoundJoinConstraint::On(expr) => {
+                                    let arr_impl = expr.eval_array(&chunk)?;
+                                    let value = arr_impl.get(0);
+                                    match value {
+                                        DataValue::Bool(true) => {
+                                            for (idx, builder) in
+                                                chunk_builders.iter_mut().enumerate()
+                                            {
+                                                builder.push(&left_row[idx]);
+                                            }
+                                        }
+                                        DataValue::Bool(false) => {}
+                                        _ => {
+                                            panic!("unsupported value from join condition")
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(Some(
+            chunk_builders
+                .into_iter()
+                .map(|builder| builder.finish())
+                .collect(),
+        ))
+    }
+
     pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
         try_stream! {
             let mut left_chunks: Vec<DataChunk> = vec![];
@@ -23,55 +93,10 @@ impl NestedLoopJoinExecutor {
                 right_chunks.push(batch?);
             }
 
-            if left_chunks.len() == 0 || right_chunks.len() == 0 {
-               return ;
+            let chunk = Self::execute_inner(self.join_op, left_chunks, right_chunks)?;
+            if let Some(chunk) = chunk {
+                yield chunk;
             }
-            let mut left_row = left_chunks[0].get_row_by_idx(0);
-            let mut right_row = right_chunks[0].get_row_by_idx(0);
-            left_row.append(&mut right_row);
-            let mut chunk_builders: Vec<ArrayBuilderImpl> = left_row.iter()
-                                                   .map(|v|
-                                                    ArrayBuilderImpl::from_type_of_value(v))
-                                                    .collect();
-
-            for left_chunk in left_chunks.iter() {
-                for left_idx in 0..left_chunk.cardinality() {
-                    for right_chunk in right_chunks.iter() {
-                        for right_idx in 0..right_chunk.cardinality() {
-                            let mut left_row = left_chunk.get_row_by_idx(left_idx);
-                            let mut right_row = right_chunk.get_row_by_idx(right_idx);
-                            left_row.append(&mut right_row);
-                            let mut builders: Vec<ArrayBuilderImpl> = left_row.iter()
-                                                   .map(|v|
-                                                    ArrayBuilderImpl::from_type_of_value(v))
-                                                    .collect();
-                            for (idx, builder) in builders.iter_mut().enumerate() {
-                                builder.push(&left_row[idx]);
-                            }
-
-                            let chunk: DataChunk = builders.into_iter().map(|builder| builder.finish()).collect();
-                            match &self.join_op {
-                                BoundJoinOperator::Inner(constraint) => match constraint {
-                                    BoundJoinConstraint::On(expr) => {
-                                        let arr_impl = expr.eval_array(&chunk)?;
-                                        let value = arr_impl.get(0);
-                                        match value {
-                                            DataValue::Bool(true) => {
-                                                    for (idx, builder) in chunk_builders.iter_mut().enumerate() {
-                                                        builder.push(&left_row[idx]);
-                                                    }
-                                            }
-                                            _ => {}
-                                        }
-                                    }
-                                },
-                            }
-                        }
-                    }
-                }
-            }
-            let chunk: DataChunk = chunk_builders.into_iter().map(|builder| builder.finish()).collect();
-            yield chunk;
         }
     }
 }

--- a/src/executor/seq_scan.rs
+++ b/src/executor/seq_scan.rs
@@ -52,7 +52,9 @@ impl<S: Storage> SeqScanExecutor<S> {
     pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
         try_stream! {
             let chunk = self.execute_inner().await?;
-            yield chunk;
+            if chunk.cardinality() != 0 {
+                yield chunk;
+            }
         }
     }
 }

--- a/tests/sql/join.slt
+++ b/tests/sql/join.slt
@@ -7,6 +7,10 @@ create table y(c int, d int);
 statement ok
 insert into x values (1, 2), (1, 3);
 
+query IIII
+select a, b, c, d from x join y on a = c;
+----
+
 statement ok
 insert into y values (1, 5), (1, 6), (2, 7);
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

Currently, join will panic if one column do not contain any data. This PR fixes this by disabling yielding of empty `DataChunk` from `SeqScanExecutor`.

This PR also moves join logic in `try_stream` out and applied some clippy fixes.