### PR TITLE
ci: only bench on main

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+      - name: Bench
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,16 +43,3 @@ jobs:
         with:
           command: test
           args: --release --no-fail-fast --all-features
-
-  bench:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-      - name: Bench
-        uses: actions-rs/cargo@v1
-        with:
-          command: bench
-          args: --all-features


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

As we are having more and more benches, it may now take ~12 mins to run all the benches, which is tremendous for a PR job. So here I only allow benchmark on main.