### PR TITLE
feat(storage): support sorted flush to disk

### DIFF
--- a/src/array/valid_ext.rs
+++ b/src/array/valid_ext.rs
@@ -6,8 +6,12 @@ pub trait ArrayValidExt: Array {
     fn get_valid_bitmap(&self) -> &BitVec;
 }
 
-impl ArrayImpl {
-    pub fn get_valid_bitmap(&self) -> &BitVec {
+pub trait ArrayImplValidExt {
+    fn get_valid_bitmap(&self) -> &BitVec;
+}
+
+impl ArrayImplValidExt for ArrayImpl {
+    fn get_valid_bitmap(&self) -> &BitVec {
         match self {
             Self::Bool(a) => a.get_valid_bitmap(),
             Self::Int32(a) => a.get_valid_bitmap(),

--- a/src/executor/seq_scan.rs
+++ b/src/executor/seq_scan.rs
@@ -38,7 +38,7 @@ impl<S: Storage> SeqScanExecutor<S> {
         }
 
         let txn = table.read().await?;
-        let mut it = txn.scan(None, None, &col_idx, false).await?;
+        let mut it = txn.scan(None, None, &col_idx, false, false).await?;
 
         // Notice: The column ids may not be ordered.
         while let Some(chunk) = it.next_batch(None).await? {

--- a/src/storage/memory/transaction.rs
+++ b/src/storage/memory/transaction.rs
@@ -56,6 +56,7 @@ impl Transaction for InMemoryTransaction {
         begin_sort_key: Option<&[u8]>,
         end_sort_key: Option<&[u8]>,
         col_idx: &[StorageColumnRef],
+        is_sorted: bool,
         reversed: bool,
     ) -> StorageResult<Self::TxnIteratorType> {
         assert!(
@@ -67,6 +68,7 @@ impl Transaction for InMemoryTransaction {
             "sort_key is not supported in InMemoryEngine for now"
         );
         assert!(!reversed, "reverse iterator is not supported for now");
+        assert!(!is_sorted, "sorted iterator is not supported for now");
 
         Ok(InMemoryTxnIterator::new(
             self.snapshot.clone(),

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -114,6 +114,7 @@ pub trait Transaction: Sync + Send + 'static {
         begin_sort_key: Option<&[u8]>,
         end_sort_key: Option<&[u8]>,
         col_idx: &[StorageColumnRef],
+        is_sorted: bool,
         reversed: bool,
     ) -> StorageResult<Self::TxnIteratorType>;
 

--- a/src/storage/secondary/rowset/mod.rs
+++ b/src/storage/secondary/rowset/mod.rs
@@ -39,3 +39,18 @@ mod disk_rowset;
 pub use disk_rowset::*;
 mod rowset_iterator;
 pub use rowset_iterator::*;
+
+use crate::catalog::ColumnCatalog;
+
+pub fn find_sort_key_id(column_infos: &[ColumnCatalog]) -> Option<usize> {
+    let mut key = None;
+    for (id, column_info) in column_infos.iter().enumerate() {
+        if column_info.is_primary() {
+            if key.is_some() {
+                panic!("only one primary key is supported");
+            }
+            key = Some(id);
+        }
+    }
+    key
+}

--- a/src/storage/secondary/transaction.rs
+++ b/src/storage/secondary/transaction.rs
@@ -136,6 +136,7 @@ impl Transaction for SecondaryTransaction {
         begin_sort_key: Option<&[u8]>,
         end_sort_key: Option<&[u8]>,
         col_idx: &[StorageColumnRef],
+        is_sorted: bool,
         reversed: bool,
     ) -> StorageResult<Self::TxnIteratorType> {
         assert!(
@@ -147,6 +148,7 @@ impl Transaction for SecondaryTransaction {
             "sort_key is not supported in SecondaryEngine for now"
         );
         assert!(!reversed, "reverse iterator is not supported for now");
+        assert!(!is_sorted, "sorted iterator is not supported for now");
 
         let mut iters: Vec<RowSetIterator> = vec![];
         for rowset in &self.snapshot {


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

In this PR, we added `is_sorted` to txn's scan option, though not supported for now. And when flushing data to disk, it will now be automatically sorted by the primary key.

ref https://github.com/singularity-data/risinglight/issues/114