### PR TITLE
feat(storage): add char column builder

### DIFF
--- a/proto/src/proto/rowset.proto
+++ b/proto/src/proto/rowset.proto
@@ -17,6 +17,8 @@ message BlockIndex {
     RunLength = 1;
     ZstdCompress = 2;
     PlainNullable = 3;
+    PlainFixedChar = 4;
+    PlainVarchar = 5;
   }
   BlockType block_type = 1;
   uint64 offset = 2;

--- a/src/binder/statement/insert.rs
+++ b/src/binder/statement/insert.rs
@@ -1,3 +1,5 @@
+use sqlparser::ast::DataType;
+
 use super::*;
 use crate::parser::{SetExpr, Statement};
 use crate::types::ColumnId;
@@ -85,8 +87,17 @@ impl Binder {
                             // table t1(a float, b float)
                             // for example: insert into values (1, 1);
                             // 1 should be casted to float.
-                            if data_type.kind() != column_types[idx].kind() {
-                                todo!("type cast");
+                            let left_kind = data_type.kind();
+                            let right_kind = column_types[idx].kind();
+                            if left_kind != right_kind {
+                                match (&left_kind, &right_kind) {
+                                    // For char types, no need to cast
+                                    (DataType::Char(_), DataType::Char(_)) => {}
+                                    (DataType::Char(_), DataType::Varchar(_)) => {}
+                                    (DataType::Varchar(_), DataType::Char(_)) => {}
+                                    (DataType::Varchar(_), DataType::Varchar(_)) => {}
+                                    _ => todo!("type cast: {} {}", left_kind, right_kind),
+                                }
                             }
                         } else {
                             // If the data value is null, the column must be nullable.

--- a/src/storage/secondary/block/char_block_builder.rs
+++ b/src/storage/secondary/block/char_block_builder.rs
@@ -10,11 +10,11 @@ pub struct PlainCharBlockBuilder {
 
 impl PlainCharBlockBuilder {
     #[allow(dead_code)]
-    pub fn new(target_size: usize, char_width: usize) -> Self {
+    pub fn new(target_size: usize, char_width: u64) -> Self {
         let data = Vec::with_capacity(target_size);
         Self {
             data,
-            char_width,
+            char_width: char_width as usize,
             target_size,
         }
     }

--- a/src/storage/secondary/column.rs
+++ b/src/storage/secondary/column.rs
@@ -5,6 +5,7 @@
 //! blocks might not be the same. For example, a column could contains several
 //! compressed blocks, and several RLE blocks.
 
+mod char_column_builder;
 mod column_builder;
 mod column_iterator;
 mod primitive_column_builder;

--- a/src/storage/secondary/column/char_column_builder.rs
+++ b/src/storage/secondary/column/char_column_builder.rs
@@ -1,0 +1,187 @@
+use risinglight_proto::rowset::block_checksum::ChecksumType;
+use risinglight_proto::rowset::block_index::BlockType;
+use risinglight_proto::rowset::BlockIndex;
+
+use super::super::{BlockBuilder, PlainCharBlockBuilder, PlainVarcharBlockBuilder};
+use super::{append_one_by_one, ColumnBuilder};
+use crate::array::{Array, UTF8Array};
+use crate::storage::secondary::{BlockHeader, ColumnBuilderOptions, BLOCK_HEADER_SIZE};
+
+/// All supported block builders for char types.
+pub(super) enum CharBlockBuilderImpl {
+    PlainFixedChar(PlainCharBlockBuilder),
+    PlainVarchar(PlainVarcharBlockBuilder),
+}
+
+/// Column builder of char types.
+pub struct CharColumnBuilder {
+    data: Vec<u8>,
+    index: Vec<BlockIndex>,
+    options: ColumnBuilderOptions,
+
+    /// Current block builder
+    current_builder: Option<CharBlockBuilderImpl>,
+
+    /// Count of rows which has been sent to builder
+    row_count: usize,
+
+    /// Begin row count of the current block
+    last_row_count: usize,
+
+    /// Indicates whether the current column accepts null elements
+    nullable: bool,
+
+    /// Width of the char column
+    char_width: Option<u64>,
+}
+
+impl CharColumnBuilder {
+    pub fn new(nullable: bool, char_width: Option<u64>, options: ColumnBuilderOptions) -> Self {
+        Self {
+            data: vec![],
+            index: vec![],
+            options,
+            current_builder: None,
+            row_count: 0,
+            last_row_count: 0,
+            nullable,
+            char_width,
+        }
+    }
+
+    fn finish_builder(&mut self) {
+        let (block_type, mut block_data) = match self.current_builder.take().unwrap() {
+            CharBlockBuilderImpl::PlainFixedChar(builder) => {
+                (BlockType::PlainFixedChar, builder.finish())
+            }
+            CharBlockBuilderImpl::PlainVarchar(builder) => {
+                (BlockType::PlainVarchar, builder.finish())
+            }
+        };
+
+        self.index.push(BlockIndex {
+            block_type: block_type.into(),
+            offset: self.data.len() as u64,
+            length: (block_data.len() + BLOCK_HEADER_SIZE) as u64,
+            first_rowid: self.last_row_count as u32,
+            row_count: (self.row_count - self.last_row_count) as u32,
+            /// TODO(chi): support sort key
+            first_key: "".into(),
+        });
+
+        // the new block will begin at the current row count
+        self.last_row_count = self.row_count;
+
+        let mut block_header = vec![0; BLOCK_HEADER_SIZE];
+
+        let mut block_header_ref = &mut block_header[..];
+
+        BlockHeader {
+            block_type,
+            checksum_type: ChecksumType::None,
+            // TODO(chi): add checksum support
+            checksum: 0,
+        }
+        .encode(&mut block_header_ref);
+
+        assert!(block_header_ref.is_empty());
+
+        // add data to the column file
+        self.data.append(&mut block_header);
+        self.data.append(&mut block_data);
+    }
+}
+
+impl ColumnBuilder<UTF8Array> for CharColumnBuilder {
+    fn append(&mut self, array: &UTF8Array) {
+        let mut iter = array.iter().peekable();
+
+        while iter.peek().is_some() {
+            if self.current_builder.is_none() {
+                match (self.char_width, self.nullable) {
+                    (Some(char_width), false) => {
+                        self.current_builder = Some(CharBlockBuilderImpl::PlainFixedChar(
+                            PlainCharBlockBuilder::new(
+                                self.options.target_block_size - 16,
+                                char_width,
+                            ),
+                        ));
+                    }
+                    (None, false) => {
+                        self.current_builder = Some(CharBlockBuilderImpl::PlainVarchar(
+                            PlainVarcharBlockBuilder::new(self.options.target_block_size - 16),
+                        ));
+                    }
+                    _ => unimplemented!(),
+                }
+            }
+
+            let (row_count, should_finish) = match self.current_builder.as_mut().unwrap() {
+                CharBlockBuilderImpl::PlainFixedChar(builder) => {
+                    append_one_by_one(&mut iter, builder)
+                }
+                CharBlockBuilderImpl::PlainVarchar(builder) => {
+                    append_one_by_one(&mut iter, builder)
+                }
+            };
+
+            self.row_count += row_count;
+
+            // finish the current block
+            if should_finish {
+                self.finish_builder();
+            }
+        }
+    }
+
+    fn finish(mut self) -> (Vec<BlockIndex>, Vec<u8>) {
+        self.finish_builder();
+
+        (self.index, self.data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::FromIterator;
+
+    use super::*;
+
+    #[test]
+    fn test_char_column_builder() {
+        let item_each_block = (128 - 16) / 8;
+        let mut builder = CharColumnBuilder::new(
+            false,
+            Some(8),
+            ColumnBuilderOptions {
+                target_block_size: 128,
+            },
+        );
+        for _ in 0..10 {
+            builder.append(&UTF8Array::from_iter(
+                [Some("2333")].iter().cycle().cloned().take(item_each_block),
+            ));
+        }
+        let (index, _) = builder.finish();
+        assert_eq!(index.len(), 10);
+        assert_eq!(index[3].first_rowid as usize, item_each_block * 3);
+        assert_eq!(index[3].row_count as usize, item_each_block);
+    }
+
+    #[test]
+    fn test_char_column_builder_large_block() {
+        // We set char width to 233, which is larger than target block size
+        let mut builder = CharColumnBuilder::new(
+            false,
+            Some(233),
+            ColumnBuilderOptions {
+                target_block_size: 128,
+            },
+        );
+        for _ in 0..10 {
+            builder.append(&UTF8Array::from_iter([Some("2333")]));
+        }
+        let (index, _) = builder.finish();
+        assert_eq!(index.len(), 10);
+    }
+}

--- a/src/storage/secondary/column/column_builder.rs
+++ b/src/storage/secondary/column/column_builder.rs
@@ -1,6 +1,7 @@
 use risinglight_proto::rowset::BlockIndex;
 
 use super::super::ColumnBuilderOptions;
+use super::char_column_builder::CharColumnBuilder;
 use super::{BoolColumnBuilder, ColumnBuilder};
 use crate::array::ArrayImpl;
 use crate::types::{DataType, DataTypeKind};
@@ -12,6 +13,7 @@ pub enum ColumnBuilderImpl {
     Int32(I32ColumnBuilder),
     Float64(F64ColumnBuilder),
     Bool(BoolColumnBuilder),
+    UTF8(CharColumnBuilder),
 }
 
 impl ColumnBuilderImpl {
@@ -26,6 +28,19 @@ impl ColumnBuilderImpl {
             DataTypeKind::Float(_) => {
                 Self::Float64(F64ColumnBuilder::new(datatype.is_nullable(), options))
             }
+            DataTypeKind::Char(char_width) => Self::UTF8(CharColumnBuilder::new(
+                datatype.is_nullable(),
+                char_width,
+                options,
+            )),
+            DataTypeKind::Varchar(_) => {
+                // TODO: why varchar have char_width???
+                Self::UTF8(CharColumnBuilder::new(
+                    datatype.is_nullable(),
+                    None,
+                    options,
+                ))
+            }
             _ => todo!(),
         }
     }
@@ -35,6 +50,7 @@ impl ColumnBuilderImpl {
             (Self::Int32(builder), ArrayImpl::Int32(array)) => builder.append(array),
             (Self::Bool(builder), ArrayImpl::Bool(array)) => builder.append(array),
             (Self::Float64(builder), ArrayImpl::Float64(array)) => builder.append(array),
+            (Self::UTF8(builder), ArrayImpl::UTF8(array)) => builder.append(array),
             _ => todo!(),
         }
     }
@@ -44,6 +60,7 @@ impl ColumnBuilderImpl {
             Self::Int32(builder) => builder.finish(),
             Self::Bool(builder) => builder.finish(),
             Self::Float64(builder) => builder.finish(),
+            Self::UTF8(builder) => builder.finish(),
         }
     }
 }

--- a/src/storage/secondary/column/primitive_column_builder.rs
+++ b/src/storage/secondary/column/primitive_column_builder.rs
@@ -103,9 +103,9 @@ impl<T: PrimitiveFixedWidthEncode> PrimitiveColumnBuilder<T> {
 /// In the future, for integer data, we should be able to skip the `should_finish`
 /// check, as we can calculate expected number of items to add simply by
 /// `size_of::<T>() * N`.
-fn append_one_by_one<'a, T: PrimitiveFixedWidthEncode>(
-    iter: &mut Peekable<impl Iterator<Item = Option<&'a T>>>,
-    builder: &mut impl BlockBuilder<T::ArrayType>,
+pub fn append_one_by_one<'a, A: Array>(
+    iter: &mut Peekable<impl Iterator<Item = Option<&'a A::Item>>>,
+    builder: &mut impl BlockBuilder<A>,
 ) -> (usize, bool) {
     let mut cnt = 0;
     while let Some(to_be_appended) = iter.peek() {


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

As we now have char column builder, we can store char items on disk.

This PR also allows passing the type casting check if insert item and table column are both of char / varchar.

As read path is not implemented, data could not be selected for now.

```
create table c (name CHAR(10) NOT NULL)
insert into c values ('233'), ('23333'), ('2333333')
```

ref https://github.com/singularity-data/risinglight/issues/115