### PR TITLE
fix(storage): return 0 hint for finished iterators

### DIFF
--- a/src/storage/secondary/column.rs
+++ b/src/storage/secondary/column.rs
@@ -54,7 +54,8 @@ pub trait ColumnIterator<A: Array> {
     /// get an array of NO MORE THAN the `expected_size` on supported column types.
     async fn next_batch(&mut self, expected_size: Option<usize>) -> Option<(u32, A)>;
 
-    /// Number of items that can be fetched without I/O
+    /// Number of items that can be fetched without I/O. When the column iterator has finished
+    /// iterating, the returned value should be 0.
     fn fetch_hint(&self) -> usize;
 }
 

--- a/src/storage/secondary/column/char_column_iterator.rs
+++ b/src/storage/secondary/column/char_column_iterator.rs
@@ -126,6 +126,9 @@ impl CharColumnIterator {
     }
 
     fn fetch_hint_inner(&self) -> usize {
+        if self.finished {
+            return 0;
+        }
         let index = self.column.index().index(self.current_block_id);
         (index.row_count - (self.current_row_id - index.first_rowid)) as usize
     }

--- a/src/storage/secondary/column/primitive_column_iterator.rs
+++ b/src/storage/secondary/column/primitive_column_iterator.rs
@@ -127,6 +127,9 @@ impl<T: PrimitiveFixedWidthEncode> PrimitiveColumnIterator<T> {
     }
 
     fn fetch_hint_inner(&self) -> usize {
+        if self.finished {
+            return 0;
+        }
         let index = self.column.index().index(self.current_block_id);
         (index.row_count - (self.current_row_id - index.first_rowid)) as usize
     }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

If `fetch_hint` is called for a finished iterator, it will panic as accessing index out of bound on the `indexes` vector. Now we will return 0 for finished iterators.