### PR TITLE
style: rename UTF8 to Utf8

### DIFF
--- a/src/array/internal_ext.rs
+++ b/src/array/internal_ext.rs
@@ -19,7 +19,7 @@ impl ArrayImplValidExt for ArrayImpl {
             Self::Int32(a) => a.get_valid_bitmap(),
             Self::Int64(a) => a.get_valid_bitmap(),
             Self::Float64(a) => a.get_valid_bitmap(),
-            Self::UTF8(a) => a.get_valid_bitmap(),
+            Self::Utf8(a) => a.get_valid_bitmap(),
         }
     }
 }
@@ -41,7 +41,7 @@ impl ArrayImplEstimateExt for ArrayImpl {
             Self::Int32(a) => a.get_estimated_size(),
             Self::Int64(a) => a.get_estimated_size(),
             Self::Float64(a) => a.get_estimated_size(),
-            Self::UTF8(a) => a.get_estimated_size(),
+            Self::Utf8(a) => a.get_estimated_size(),
         }
     }
 }

--- a/src/array/shuffle_ext.rs
+++ b/src/array/shuffle_ext.rs
@@ -75,7 +75,7 @@ impl ArrayImplBuilderPickExt for ArrayBuilderImpl {
             (Self::Float64(builder), ArrayImpl::Float64(arr)) => {
                 builder.pick_from(arr, logical_rows)
             }
-            (Self::UTF8(builder), ArrayImpl::UTF8(arr)) => builder.pick_from(arr, logical_rows),
+            (Self::Utf8(builder), ArrayImpl::Utf8(arr)) => builder.pick_from(arr, logical_rows),
             _ => panic!("failed to push value: type mismatch"),
         }
     }
@@ -160,7 +160,7 @@ impl ArrayImplSortExt for ArrayImpl {
             Self::Int32(a) => a.get_sorted_indices(),
             Self::Int64(a) => a.get_sorted_indices(),
             Self::Float64(a) => a.get_sorted_indices(),
-            Self::UTF8(a) => a.get_sorted_indices(),
+            Self::Utf8(a) => a.get_sorted_indices(),
         }
     }
 }

--- a/src/array/utf8_array.rs
+++ b/src/array/utf8_array.rs
@@ -5,15 +5,15 @@ use std::iter::FromIterator;
 
 /// A collection of Rust UTF8 `String`s.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct UTF8Array {
+pub struct Utf8Array {
     offset: Vec<usize>,
     valid: BitVec,
     data: Vec<u8>,
 }
 
-impl Array for UTF8Array {
+impl Array for Utf8Array {
     type Item = str;
-    type Builder = UTF8ArrayBuilder;
+    type Builder = Utf8ArrayBuilder;
 
     fn get(&self, idx: usize) -> Option<&str> {
         if self.valid[idx] {
@@ -29,27 +29,27 @@ impl Array for UTF8Array {
     }
 }
 
-impl ArrayValidExt for UTF8Array {
+impl ArrayValidExt for Utf8Array {
     fn get_valid_bitmap(&self) -> &BitVec {
         &self.valid
     }
 }
 
-impl ArrayEstimateExt for UTF8Array {
+impl ArrayEstimateExt for Utf8Array {
     fn get_estimated_size(&self) -> usize {
         self.data.len() + self.offset.len() + self.valid.len() / 8
     }
 }
 
 /// A builder that uses `&str` to build an [`UTF8Array`].
-pub struct UTF8ArrayBuilder {
+pub struct Utf8ArrayBuilder {
     offset: Vec<usize>,
     valid: BitVec,
     data: Vec<u8>,
 }
 
-impl ArrayBuilder for UTF8ArrayBuilder {
-    type Array = UTF8Array;
+impl ArrayBuilder for Utf8ArrayBuilder {
+    type Array = Utf8Array;
 
     fn new(capacity: usize) -> Self {
         let mut offset = Vec::with_capacity(capacity + 1);
@@ -69,7 +69,7 @@ impl ArrayBuilder for UTF8ArrayBuilder {
         self.offset.push(self.data.len());
     }
 
-    fn append(&mut self, other: &UTF8Array) {
+    fn append(&mut self, other: &Utf8Array) {
         self.valid.extend_from_bitslice(&other.valid);
         self.data.extend_from_slice(&other.data);
         let start = *self.offset.last().unwrap();
@@ -78,8 +78,8 @@ impl ArrayBuilder for UTF8ArrayBuilder {
         }
     }
 
-    fn finish(self) -> UTF8Array {
-        UTF8Array {
+    fn finish(self) -> Utf8Array {
+        Utf8Array {
             valid: self.valid,
             data: self.data,
             offset: self.offset,
@@ -88,7 +88,7 @@ impl ArrayBuilder for UTF8ArrayBuilder {
 }
 
 // Enable `collect()` an array from iterator of `Option<&str>` or `Option<String>`.
-impl<Str: AsRef<str>> FromIterator<Option<Str>> for UTF8Array {
+impl<Str: AsRef<str>> FromIterator<Option<Str>> for Utf8Array {
     fn from_iter<I: IntoIterator<Item = Option<Str>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
@@ -108,7 +108,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_utf8_builder() {
-        let mut builder = UTF8ArrayBuilder::new(0);
+        let mut builder = Utf8ArrayBuilder::new(0);
         for i in 0..100 {
             if i % 2 == 0 {
                 builder.push(Some(&format!("{}", i)));

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,5 +1,5 @@
 use crate::{
-    array::{ArrayBuilder, DataChunk, I32ArrayBuilder, UTF8ArrayBuilder},
+    array::{ArrayBuilder, DataChunk, I32ArrayBuilder, Utf8ArrayBuilder},
     binder::{BindError, Binder},
     catalog::RootCatalogRef,
     executor::{ExecutorBuilder, ExecutorError, GlobalEnv},
@@ -66,11 +66,11 @@ impl Database {
 
     fn run_dt(&self) -> Result<Vec<DataChunk>, Error> {
         let mut db_id_vec = I32ArrayBuilder::new(0);
-        let mut db_vec = UTF8ArrayBuilder::new(0);
+        let mut db_vec = Utf8ArrayBuilder::new(0);
         let mut schema_id_vec = I32ArrayBuilder::new(0);
-        let mut schema_vec = UTF8ArrayBuilder::new(0);
+        let mut schema_vec = Utf8ArrayBuilder::new(0);
         let mut table_id_vec = I32ArrayBuilder::new(0);
-        let mut table_vec = UTF8ArrayBuilder::new(0);
+        let mut table_vec = Utf8ArrayBuilder::new(0);
         for (_, database) in self.catalog.all_databases() {
             for (_, schema) in database.all_schemas() {
                 for (_, table) in schema.all_tables() {
@@ -124,8 +124,8 @@ impl Database {
                             StorageColumnRef::Idx(col_id),
                         ),
                     ]);
-                    let mut stat_name = UTF8ArrayBuilder::new(0);
-                    let mut stat_value = UTF8ArrayBuilder::new(0);
+                    let mut stat_name = Utf8ArrayBuilder::new(0);
+                    let mut stat_value = Utf8ArrayBuilder::new(0);
                     stat_name.push(Some("RowCount"));
                     stat_value.push(Some(&format!("{:?}", row_count[0])));
                     stat_name.push(Some("DistinctValue"));

--- a/src/executor/copy_from_file.rs
+++ b/src/executor/copy_from_file.rs
@@ -166,7 +166,7 @@ mod tests {
         let expected: DataChunk = [
             ArrayImpl::Int32([1, 2].into_iter().collect()),
             ArrayImpl::Float64([1.5, 2.5].into_iter().collect()),
-            ArrayImpl::UTF8(["one", "two"].iter().map(Some).collect()),
+            ArrayImpl::Utf8(["one", "two"].iter().map(Some).collect()),
         ]
         .into_iter()
         .collect();

--- a/src/executor/copy_to_file.rs
+++ b/src/executor/copy_to_file.rs
@@ -84,7 +84,7 @@ mod tests {
                 yield [
                     ArrayImpl::Int32([1, 2].into_iter().collect()),
                     ArrayImpl::Float64([1.5, 2.5].into_iter().collect()),
-                    ArrayImpl::UTF8(["one", "two"].iter().map(Some).collect()),
+                    ArrayImpl::Utf8(["one", "two"].iter().map(Some).collect()),
                 ]
                 .into_iter()
                 .collect();

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -146,7 +146,7 @@ impl ArrayImpl {
                     (A::Int32(a), A::Int32(b)) => A::Bool(binary_op(a, b, |a, b| a $op b)),
                     #[allow(clippy::float_cmp)]
                     (A::Float64(a), A::Float64(b)) => A::Bool(binary_op(a, b, |a, b| a $op b)),
-                    (A::UTF8(a), A::UTF8(b)) => A::Bool(binary_op(a, b, |a, b| a $op b)),
+                    (A::Utf8(a), A::Utf8(b)) => A::Bool(binary_op(a, b, |a, b| a $op b)),
                     _ => todo!("Support more types for {}", stringify!($op)),
                 }
             }
@@ -196,7 +196,7 @@ impl ArrayImpl {
                 Type::Int(_) => Self::Int32(unary_op(a, |&b| b as i32)),
                 Type::Float(_) | Type::Double => Self::Float64(unary_op(a, |&b| b as u8 as f64)),
                 Type::String | Type::Char(_) | Type::Varchar(_) => {
-                    Self::UTF8(unary_op(a, |&b| if b { "true" } else { "false" }))
+                    Self::Utf8(unary_op(a, |&b| if b { "true" } else { "false" }))
                 }
                 _ => todo!("cast array"),
             },
@@ -205,7 +205,7 @@ impl ArrayImpl {
                 Type::Int(_) => Self::Int32(a.clone()),
                 Type::Float(_) | Type::Double => Self::Float64(unary_op(a, |&i| i as f64)),
                 Type::String | Type::Char(_) | Type::Varchar(_) => {
-                    Self::UTF8(unary_op(a, |&i| i.to_string()))
+                    Self::Utf8(unary_op(a, |&i| i.to_string()))
                 }
                 _ => todo!("cast array"),
             },
@@ -214,7 +214,7 @@ impl ArrayImpl {
                 Type::Int(_) => Self::Int64(a.clone()),
                 Type::Float(_) | Type::Double => Self::Float64(unary_op(a, |&i| i as f64)),
                 Type::String | Type::Char(_) | Type::Varchar(_) => {
-                    Self::UTF8(unary_op(a, |&i| i.to_string()))
+                    Self::Utf8(unary_op(a, |&i| i.to_string()))
                 }
                 _ => todo!("cast array"),
             },
@@ -223,11 +223,11 @@ impl ArrayImpl {
                 Type::Int(_) => Self::Int32(unary_op(a, |&f| f as i32)),
                 Type::Float(_) | Type::Double => Self::Float64(a.clone()),
                 Type::String | Type::Char(_) | Type::Varchar(_) => {
-                    Self::UTF8(unary_op(a, |&f| f.to_string()))
+                    Self::Utf8(unary_op(a, |&f| f.to_string()))
                 }
                 _ => todo!("cast array"),
             },
-            Self::UTF8(a) => match data_type {
+            Self::Utf8(a) => match data_type {
                 Type::Boolean => Self::Bool(try_unary_op(a, |s| {
                     s.parse::<bool>()
                         .map_err(|e| ConvertError::ParseBool(s.to_string(), e))
@@ -240,7 +240,7 @@ impl ArrayImpl {
                     s.parse::<f64>()
                         .map_err(|e| ConvertError::ParseFloat(s.to_string(), e))
                 })?),
-                Type::String | Type::Char(_) | Type::Varchar(_) => Self::UTF8(a.clone()),
+                Type::String | Type::Char(_) | Type::Varchar(_) => Self::Utf8(a.clone()),
                 _ => todo!("cast array"),
             },
         })

--- a/src/executor/explain.rs
+++ b/src/executor/explain.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::array::{ArrayImpl, UTF8Array};
+use crate::array::{ArrayImpl, Utf8Array};
 use crate::physical_planner::PhysicalExplain;
 
 /// The executor of `explain` statement.
@@ -10,7 +10,7 @@ pub struct ExplainExecutor {
 impl ExplainExecutor {
     pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
         let explain_result = format!("{}", self.plan.plan);
-        let chunk = DataChunk::from_iter([ArrayImpl::UTF8(UTF8Array::from_iter([Some(
+        let chunk = DataChunk::from_iter([ArrayImpl::Utf8(Utf8Array::from_iter([Some(
             explain_result,
         )]))]);
 

--- a/src/expr/mod.rs
+++ b/src/expr/mod.rs
@@ -74,7 +74,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::{I32Array, UTF8Array};
+    use crate::array::{I32Array, Utf8Array};
     use std::iter::FromIterator;
 
     #[test]
@@ -97,12 +97,12 @@ mod tests {
 
     #[test]
     fn test_vec_concat() {
-        let expr = BinaryVectorizedExpression::<UTF8Array, I32Array, UTF8Array, _>::new(|x, y| {
+        let expr = BinaryVectorizedExpression::<Utf8Array, I32Array, Utf8Array, _>::new(|x, y| {
             x.and_then(|x| y.map(|y| format!("{}{}", x, y)))
         });
-        let result: UTF8Array = expr
+        let result: Utf8Array = expr
             .eval_chunk(
-                &UTF8Array::from_iter([Some("1"), Some("2"), Some("3")]).into(),
+                &Utf8Array::from_iter([Some("1"), Some("2"), Some("3")]).into(),
                 &I32Array::from_iter([Some(1), Some(2), Some(3)]).into(),
             )
             .try_into()

--- a/src/storage/secondary/block/char_block_builder.rs
+++ b/src/storage/secondary/block/char_block_builder.rs
@@ -1,7 +1,7 @@
 use bytes::BufMut;
 
 use super::BlockBuilder;
-use crate::array::UTF8Array;
+use crate::array::Utf8Array;
 
 /// Encodes fixed-width char into a block.
 ///
@@ -28,7 +28,7 @@ impl PlainCharBlockBuilder {
     }
 }
 
-impl BlockBuilder<UTF8Array> for PlainCharBlockBuilder {
+impl BlockBuilder<Utf8Array> for PlainCharBlockBuilder {
     fn append(&mut self, item: Option<&str>) {
         let item = item
             .expect("nullable item found in non-nullable block builder")

--- a/src/storage/secondary/block/char_block_iterator.rs
+++ b/src/storage/secondary/block/char_block_iterator.rs
@@ -1,5 +1,5 @@
 use super::{Block, BlockIterator};
-use crate::array::{ArrayBuilder, UTF8Array, UTF8ArrayBuilder};
+use crate::array::{ArrayBuilder, Utf8Array, Utf8ArrayBuilder};
 use bytes::Buf;
 
 /// Scans one or several arrays from the block content.
@@ -28,11 +28,11 @@ impl PlainCharBlockIterator {
     }
 }
 
-impl BlockIterator<UTF8Array> for PlainCharBlockIterator {
+impl BlockIterator<Utf8Array> for PlainCharBlockIterator {
     fn next_batch(
         &mut self,
         expected_size: Option<usize>,
-        builder: &mut UTF8ArrayBuilder,
+        builder: &mut Utf8ArrayBuilder,
     ) -> usize {
         if self.next_row >= self.row_count {
             return 0;
@@ -80,7 +80,7 @@ mod tests {
     use bytes::Bytes;
 
     use crate::array::ArrayToVecExt;
-    use crate::array::{ArrayBuilder, UTF8ArrayBuilder};
+    use crate::array::{ArrayBuilder, Utf8ArrayBuilder};
     use crate::storage::secondary::block::{BlockBuilder, PlainCharBlockBuilder};
     use crate::storage::secondary::BlockIterator;
 
@@ -96,7 +96,7 @@ mod tests {
 
         let mut scanner = PlainCharBlockIterator::new(Bytes::from(data), 3, 20);
 
-        let mut builder = UTF8ArrayBuilder::new(0);
+        let mut builder = Utf8ArrayBuilder::new(0);
 
         scanner.skip(1);
         assert_eq!(scanner.remaining_items(), 2);
@@ -104,12 +104,12 @@ mod tests {
         assert_eq!(scanner.next_batch(Some(1), &mut builder), 1);
         assert_eq!(builder.finish().to_vec(), vec![Some("2333".to_string())]);
 
-        let mut builder = UTF8ArrayBuilder::new(0);
+        let mut builder = Utf8ArrayBuilder::new(0);
         assert_eq!(scanner.next_batch(Some(2), &mut builder), 1);
 
         assert_eq!(builder.finish().to_vec(), vec![Some("23333".to_string())]);
 
-        let mut builder = UTF8ArrayBuilder::new(0);
+        let mut builder = Utf8ArrayBuilder::new(0);
         assert_eq!(scanner.next_batch(None, &mut builder), 0);
     }
 }

--- a/src/storage/secondary/block/varchar_block_builder.rs
+++ b/src/storage/secondary/block/varchar_block_builder.rs
@@ -1,6 +1,6 @@
 use bytes::BufMut;
 
-use crate::array::UTF8Array;
+use crate::array::Utf8Array;
 
 use super::BlockBuilder;
 
@@ -26,7 +26,7 @@ impl PlainVarcharBlockBuilder {
     }
 }
 
-impl BlockBuilder<UTF8Array> for PlainVarcharBlockBuilder {
+impl BlockBuilder<Utf8Array> for PlainVarcharBlockBuilder {
     fn append(&mut self, item: Option<&str>) {
         let item = item.expect("nullable item found in non-nullable block builder");
         self.data.extend(item.as_bytes());

--- a/src/storage/secondary/column/char_column_builder.rs
+++ b/src/storage/secondary/column/char_column_builder.rs
@@ -4,7 +4,7 @@ use risinglight_proto::rowset::BlockIndex;
 
 use super::super::{BlockBuilder, PlainCharBlockBuilder, PlainVarcharBlockBuilder};
 use super::{append_one_by_one, ColumnBuilder};
-use crate::array::{Array, UTF8Array};
+use crate::array::{Array, Utf8Array};
 use crate::storage::secondary::{BlockHeader, ColumnBuilderOptions, BLOCK_HEADER_SIZE};
 
 /// All supported block builders for char types.
@@ -93,8 +93,8 @@ impl CharColumnBuilder {
     }
 }
 
-impl ColumnBuilder<UTF8Array> for CharColumnBuilder {
-    fn append(&mut self, array: &UTF8Array) {
+impl ColumnBuilder<Utf8Array> for CharColumnBuilder {
+    fn append(&mut self, array: &Utf8Array) {
         let mut iter = array.iter().peekable();
 
         while iter.peek().is_some() {
@@ -163,7 +163,7 @@ mod tests {
             },
         );
         for _ in 0..10 {
-            builder.append(&UTF8Array::from_iter(
+            builder.append(&Utf8Array::from_iter(
                 [Some("2333")].iter().cycle().cloned().take(item_each_block),
             ));
         }
@@ -184,7 +184,7 @@ mod tests {
             },
         );
         for _ in 0..10 {
-            builder.append(&UTF8Array::from_iter([Some("2333")]));
+            builder.append(&Utf8Array::from_iter([Some("2333")]));
         }
         let (index, _) = builder.finish();
         assert_eq!(index.len(), 10);

--- a/src/storage/secondary/column/char_column_iterator.rs
+++ b/src/storage/secondary/column/char_column_iterator.rs
@@ -1,4 +1,4 @@
-use crate::array::{ArrayBuilder, UTF8Array, UTF8ArrayBuilder};
+use crate::array::{ArrayBuilder, Utf8Array, Utf8ArrayBuilder};
 use crate::storage::secondary::block::PlainCharBlockIterator;
 
 use super::super::{Block, BlockIterator};
@@ -66,7 +66,7 @@ impl CharColumnIterator {
     pub async fn next_batch_inner(
         &mut self,
         expected_size: Option<usize>,
-    ) -> Option<(u32, UTF8Array)> {
+    ) -> Option<(u32, Utf8Array)> {
         if self.finished {
             return None;
         }
@@ -79,7 +79,7 @@ impl CharColumnIterator {
             }
         };
 
-        let mut builder = UTF8ArrayBuilder::new(capacity);
+        let mut builder = Utf8ArrayBuilder::new(capacity);
         let mut total_cnt = 0;
         let first_row_id = self.current_row_id;
 
@@ -135,8 +135,8 @@ impl CharColumnIterator {
 }
 
 #[async_trait]
-impl ColumnIterator<UTF8Array> for CharColumnIterator {
-    async fn next_batch(&mut self, expected_size: Option<usize>) -> Option<(u32, UTF8Array)> {
+impl ColumnIterator<Utf8Array> for CharColumnIterator {
+    async fn next_batch(&mut self, expected_size: Option<usize>) -> Option<(u32, Utf8Array)> {
         self.next_batch_inner(expected_size).await
     }
 

--- a/src/storage/secondary/column/column_builder.rs
+++ b/src/storage/secondary/column/column_builder.rs
@@ -13,7 +13,7 @@ pub enum ColumnBuilderImpl {
     Int32(I32ColumnBuilder),
     Float64(F64ColumnBuilder),
     Bool(BoolColumnBuilder),
-    UTF8(CharColumnBuilder),
+    Utf8(CharColumnBuilder),
 }
 
 impl ColumnBuilderImpl {
@@ -28,14 +28,14 @@ impl ColumnBuilderImpl {
             DataTypeKind::Float(_) | DataTypeKind::Double => {
                 Self::Float64(F64ColumnBuilder::new(datatype.is_nullable(), options))
             }
-            DataTypeKind::Char(char_width) => Self::UTF8(CharColumnBuilder::new(
+            DataTypeKind::Char(char_width) => Self::Utf8(CharColumnBuilder::new(
                 datatype.is_nullable(),
                 char_width,
                 options,
             )),
             DataTypeKind::Varchar(_) => {
                 // TODO: why varchar have char_width???
-                Self::UTF8(CharColumnBuilder::new(
+                Self::Utf8(CharColumnBuilder::new(
                     datatype.is_nullable(),
                     None,
                     options,
@@ -50,7 +50,7 @@ impl ColumnBuilderImpl {
             (Self::Int32(builder), ArrayImpl::Int32(array)) => builder.append(array),
             (Self::Bool(builder), ArrayImpl::Bool(array)) => builder.append(array),
             (Self::Float64(builder), ArrayImpl::Float64(array)) => builder.append(array),
-            (Self::UTF8(builder), ArrayImpl::UTF8(array)) => builder.append(array),
+            (Self::Utf8(builder), ArrayImpl::Utf8(array)) => builder.append(array),
             _ => todo!(),
         }
     }
@@ -60,7 +60,7 @@ impl ColumnBuilderImpl {
             Self::Int32(builder) => builder.finish(),
             Self::Bool(builder) => builder.finish(),
             Self::Float64(builder) => builder.finish(),
-            Self::UTF8(builder) => builder.finish(),
+            Self::Utf8(builder) => builder.finish(),
         }
     }
 }

--- a/tests/sqllogictest.rs
+++ b/tests/sqllogictest.rs
@@ -337,7 +337,7 @@ impl SqlLogicTester {
                     for (array, type_char) in chunk.arrays().iter().zip(type_string.chars()) {
                         match (type_char, array) {
                             ('B', ArrayImpl::Bool(_)) => {}
-                            ('T', ArrayImpl::UTF8(_)) => {}
+                            ('T', ArrayImpl::Utf8(_)) => {}
                             ('I', ArrayImpl::Int32(_) | ArrayImpl::Int64(_)) => {}
                             ('R', ArrayImpl::Float64(_)) => {}
                             _ => panic!(


### PR DESCRIPTION
According to [Rust naming conventions](https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case), it tends to use `UpperCamelCase` and ...
> acronyms and contractions of compound words count as one word: use `Uuid` rather than `UUID`, `Usize` rather than `USize` or `Stdin` rather than `StdIn`.

So we should use `Utf8` rather than `UTF8`.