### PR TITLE
feat(executor): support explain join

### DIFF
--- a/src/binder/expression/mod.rs
+++ b/src/binder/expression/mod.rs
@@ -52,12 +52,12 @@ impl std::fmt::Debug for BoundExpr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Constant(expr) => write!(f, "{:?} (const)", expr)?,
-            Self::ColumnRef(expr) => write!(f, "#{:?}", expr)?,
+            Self::ColumnRef(expr) => write!(f, "Column #{:?}", expr)?,
             Self::BinaryOp(expr) => write!(f, "{:?}", expr)?,
             Self::UnaryOp(expr) => write!(f, "{:?}", expr)?,
             Self::TypeCast(expr) => write!(f, "{:?} (cast)", expr)?,
             Self::AggCall(expr) => write!(f, "{:?} (agg)", expr)?,
-            Self::InputRef(expr) => write!(f, "#{:?}", expr)?,
+            Self::InputRef(expr) => write!(f, "InputRef #{:?}", expr)?,
             Self::IsNull(expr) => write!(f, "{:?} (isnull)", expr)?,
         }
         Ok(())

--- a/src/binder/table_ref/mod.rs
+++ b/src/binder/table_ref/mod.rs
@@ -7,6 +7,7 @@ pub struct BoundedSingleJoinTableRef {
     pub table_ref: Box<BoundTableRef>,
     pub join_op: BoundJoinOperator,
 }
+
 /// A bound table reference.
 #[derive(Debug, PartialEq, Clone)]
 pub enum BoundTableRef {
@@ -21,13 +22,30 @@ pub enum BoundTableRef {
     },
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(PartialEq, Clone)]
 pub enum BoundJoinConstraint {
     On(BoundExpr),
 }
-#[derive(Debug, PartialEq, Clone)]
+
+impl std::fmt::Debug for BoundJoinConstraint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::On(expr) => write!(f, "On {:?}", expr),
+        }
+    }
+}
+
+#[derive(PartialEq, Clone)]
 pub enum BoundJoinOperator {
     Inner(BoundJoinConstraint),
+}
+
+impl std::fmt::Debug for BoundJoinOperator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Inner(constraint) => write!(f, "Inner {:?}", constraint),
+        }
+    }
 }
 
 impl Binder {

--- a/src/physical_planner/join.rs
+++ b/src/physical_planner/join.rs
@@ -37,7 +37,7 @@ impl PhysicalPlaner {
 
 impl PlanExplainable for PhysicalJoin {
     fn explain_inner(&self, level: usize, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Join: type {:?}", self.join_type)?;
+        writeln!(f, "Join: type {:?}, op {:?}", self.join_type, self.join_op)?;
         self.left_plan.explain(level + 1, f)?;
         self.right_plan.explain(level + 1, f)
     }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

```
> explain select count(*) from t1 join t2 on v2=v3;
+---------------------------------------------------------------------------------+
| Projection: exprs [InputRef #0]                                                 |
|   SimpleAgg: [RowCount([InputRef #1]) -> Int(None)]                             |
|     Join: type NestedLoop, op inner on Eq(InputRef #0, InputRef #1)             |
|       SeqScan: table #0, columns [1], with_row_handler: false, is_sorted: false |
|       SeqScan: table #1, columns [0], with_row_handler: false, is_sorted: false |
+---------------------------------------------------------------------------------+
```