### PR TITLE
style: change comment_width fmt option

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-comment_width = 100
+comment_width = 120
 format_code_in_doc_comments = true
 format_macro_bodies = true
 format_macro_matchers = true


### PR DESCRIPTION
To keep consistent with RisingWave(see: https://github.com/singularity-data/risingwave/pull/1332), the comment_width=120 can be adopted.
