### PR TITLE
fix: casting between different varchar length

### DIFF
--- a/src/binder/statement/insert.rs
+++ b/src/binder/statement/insert.rs
@@ -73,6 +73,8 @@ impl Binder {
                                     // For char types, no need to cast
                                     (DataTypeKind::Char(_), DataTypeKind::Varchar(_)) => {}
                                     (DataTypeKind::Varchar(_), DataTypeKind::Char(_)) => {}
+                                    (DataTypeKind::Varchar(_), DataTypeKind::Varchar(_)) => {}
+                                    (DataTypeKind::Char(_), DataTypeKind::Char(_)) => {}
                                     _ => todo!("type cast: {} {}", left_kind, right_kind),
                                 }
                             }


### PR DESCRIPTION
This PR fixes the following varchar casting problem.
```
> create table t (v1 varchar(10));
+---+
| 0 |
+---+
> insert into t values('123');
thread 'main' panicked at 'not yet implemented: type cast: CHARACTER VARYING(256) CHARACTER VARYING(10)', src/binder/statement/insert.rs:76:42
```