### PR TITLE
feat(storage): remove length indicator for char encoding

### DIFF
--- a/src/storage/secondary/column/char_column_builder.rs
+++ b/src/storage/secondary/column/char_column_builder.rs
@@ -123,7 +123,7 @@ mod tests {
         let item_each_block = (128 - 16) / 8;
         let mut builder = CharColumnBuilder::new(
             false,
-            Some(7),
+            Some(8),
             ColumnBuilderOptions::default_for_block_test(),
         );
         for _ in 0..10 {


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

This PR removes the leading bytes of `char` encoding. As UTF8 string won't have `\0` inside, we can scan the char region to find the first `\0`, and get the string out of the buffer.

This fix also removes the constraint of maximum char size.