### PR TITLE
feat(join): add hash join optimizer rules

### DIFF
--- a/src/logical_optimizer/plan_nodes/physical_join.rs
+++ b/src/logical_optimizer/plan_nodes/physical_join.rs
@@ -8,6 +8,7 @@ use crate::binder::BoundJoinOperator;
 #[derive(Clone, PartialEq, Debug)]
 pub enum PhysicalJoinType {
     NestedLoop,
+    HashJoin,
 }
 // The phyiscal plan of join
 #[derive(Clone, PartialEq, Debug)]


### PR DESCRIPTION
When I try to write the code to decide whether we can used hash join or not.
I found that we cannot decide if the two column references come from the left or right table.
We may need schema for each node now.
@skyzh Any idea?