### PR TITLE
chore(executor): compile simd ops by default

### DIFF
--- a/benches/array.rs
+++ b/benches/array.rs
@@ -10,9 +10,20 @@ fn array_mul(c: &mut Criterion) {
             let a1: I32Array = (0..size).collect();
             let a2: I32Array = (0..size).collect();
             b.iter(|| {
-                #[cfg(not(feature = "simd"))]
                 let _: I32Array = evaluator::binary_op(&a1, &a2, |a, b| a * b);
-                #[cfg(feature = "simd")]
+            });
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("array mul simd");
+    group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+    for size in [1, 16, 256, 4096, 65536] {
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
+            use risinglight::executor::evaluator;
+            let a1: I32Array = (0..size).collect();
+            let a2: I32Array = (0..size).collect();
+            b.iter(|| {
                 let _: I32Array = evaluator::simd_op::<_, _, _, 32>(&a1, &a2, |a, b| a * b);
             });
         });
@@ -21,17 +32,26 @@ fn array_mul(c: &mut Criterion) {
 }
 
 fn array_sum(c: &mut Criterion) {
-    let mut group = c.benchmark_group("array_sum");
+    let mut group = c.benchmark_group("array sum");
     group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
     for size in [1, 16, 256, 4096, 65536, 1048576] {
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-            #[cfg(not(feature = "simd"))]
-            use risinglight::{array::Array, executor::sum_i32};
+            use risinglight::array::Array;
+            use risinglight::executor::sum_i32;
             let a1: I32Array = (0..size).collect();
             b.iter(|| {
-                #[cfg(not(feature = "simd"))]
                 a1.iter().fold(None, sum_i32);
-                #[cfg(feature = "simd")]
+            })
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("array sum simd");
+    group.plot_config(PlotConfiguration::default().summary_scale(AxisScale::Logarithmic));
+    for size in [1, 16, 256, 4096, 65536, 1048576] {
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
+            let a1: I32Array = (0..size).collect();
+            b.iter(|| {
                 a1.batch_iter::<32>().sum::<i32>();
             })
         });

--- a/src/array/primitive_array.rs
+++ b/src/array/primitive_array.rs
@@ -6,9 +6,7 @@ use serde::{Deserialize, Serialize};
 use super::{Array, ArrayBuilder, ArrayEstimateExt, ArrayValidExt};
 use crate::types::NativeType;
 
-#[cfg(feature = "simd")]
 mod simd;
-#[cfg(feature = "simd")]
 pub use self::simd::*;
 
 /// A collection of primitive types, such as `i32`, `f32`.

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -260,17 +260,14 @@ impl ArrayImpl {
     }
 }
 
-#[cfg(feature = "simd")]
 use std::simd::{LaneCount, Simd, SimdElement, SupportedLaneCount};
 
 use num_traits::ToPrimitive;
 use rust_decimal::prelude::FromStr;
 use rust_decimal::Decimal;
 
-#[cfg(feature = "simd")]
 use crate::types::NativeType;
 
-#[cfg(feature = "simd")]
 pub fn simd_op<T, O, F, const N: usize>(
     a: &PrimitiveArray<T>,
     b: &PrimitiveArray<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::explicit_into_iter_loop)]
 #![deny(clippy::explicit_iter_loop)]
 #![deny(unused_must_use)]
-#![cfg_attr(feature = "simd", feature(portable_simd))]
+#![feature(portable_simd)]
 
 // Enable macros for logging.
 #[macro_use]


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

This PR brings `simd` related module to compile no matter whether `simd` feature is enabled or not. Therefore, we can spot compile error in advance before commit and creating pull requests.

Note that `simd` executors will not be enabled and used by default in runtime -- this is still controlled by `simd` feature.

ref https://github.com/singularity-data/risinglight/issues/243