### PR TITLE
chore(executor): use `futures_async_stream` for all executors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,8 +642,7 @@ dependencies = [
 [[package]]
 name = "futures-async-stream"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b492e1173b06145d9324d105cca85fb9249f48676800a2c085138f0d9bae19e6"
+source = "git+https://github.com/taiki-e/futures-async-stream?rev=944f407#944f407c90f5ec86f4d90fdca1dc0cf6b20d47dc"
 dependencies = [
  "futures-async-stream-macro",
  "futures-core",
@@ -653,8 +652,7 @@ dependencies = [
 [[package]]
 name = "futures-async-stream-macro"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6716fcdbbcebe690099a18cad71b61fbba10a0a3f8a8c0c1ed36583b42b06590"
+source = "git+https://github.com/taiki-e/futures-async-stream?rev=944f407#944f407c90f5ec86f4d90fdca1dc0cf6b20d47dc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ csv = "1.1"
 downcast-rs = "1.2"
 enum_dispatch = "0.3"
 env_logger = "0.9"
-futures-async-stream = "0.2"
+futures-async-stream = { git = "https://github.com/taiki-e/futures-async-stream", rev = "944f407" }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 indicatif = { version = "0.16" }
 itertools = "0.10"

--- a/src/executor/create.rs
+++ b/src/executor/create.rs
@@ -11,16 +11,17 @@ pub struct CreateTableExecutor<S: Storage> {
 }
 
 impl<S: Storage> CreateTableExecutor<S> {
-    pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
-        try_stream! {
-            self.storage.create_table(
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self) {
+        self.storage
+            .create_table(
                 self.plan.database_id,
                 self.plan.schema_id,
                 &self.plan.table_name,
                 &self.plan.columns,
-            ).await?;
-            yield DataChunk::single(0);
-        }
+            )
+            .await?;
+        yield DataChunk::single(0);
     }
 }
 

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -13,25 +13,28 @@ pub struct DeleteExecutor<S: Storage> {
 }
 
 impl<S: Storage> DeleteExecutor<S> {
-    pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
-        try_stream! {
-            let table = self.storage.get_table(self.table_ref_id)?;
-            let mut txn = table.update().await?;
-            let mut cnt = 0;
-            for await chunk in self.child {
-                // TODO: we do not need a filter executor. We can simply get the boolean value from
-                // the child.
-                let chunk = chunk?;
-                let row_handlers = chunk.array_at(chunk.column_count() - 1);
-                for row_handler_idx in 0..row_handlers.len() {
-                    let row_handler = <S::TransactionType as Transaction>::RowHandlerType::from_column(row_handlers, row_handler_idx);
-                    txn.delete(&row_handler).await?;
-                    cnt += 1;
-                }
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self) {
+        let table = self.storage.get_table(self.table_ref_id)?;
+        let mut txn = table.update().await?;
+        let mut cnt = 0;
+        #[for_await]
+        for chunk in self.child {
+            // TODO: we do not need a filter executor. We can simply get the boolean value from
+            // the child.
+            let chunk = chunk?;
+            let row_handlers = chunk.array_at(chunk.column_count() - 1);
+            for row_handler_idx in 0..row_handlers.len() {
+                let row_handler = <S::TransactionType as Transaction>::RowHandlerType::from_column(
+                    row_handlers,
+                    row_handler_idx,
+                );
+                txn.delete(&row_handler).await?;
+                cnt += 1;
             }
-            txn.commit().await?;
-
-            yield DataChunk::single(cnt);
         }
+        txn.commit().await?;
+
+        yield DataChunk::single(cnt);
     }
 }

--- a/src/executor/drop.rs
+++ b/src/executor/drop.rs
@@ -11,12 +11,11 @@ pub struct DropExecutor<S: Storage> {
 }
 
 impl<S: Storage> DropExecutor<S> {
-    pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
-        try_stream! {
-            match self.plan.object {
-                Object::Table(ref_id) => self.storage.drop_table(ref_id).await?,
-            }
-            yield DataChunk::single(0);
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self) {
+        match self.plan.object {
+            Object::Table(ref_id) => self.storage.drop_table(ref_id).await?,
         }
+        yield DataChunk::single(0);
     }
 }

--- a/src/executor/dummy_scan.rs
+++ b/src/executor/dummy_scan.rs
@@ -4,9 +4,8 @@ use super::*;
 pub struct DummyScanExecutor;
 
 impl DummyScanExecutor {
-    pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
-        try_stream! {
-            yield DataChunk::single(0);
-        }
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self) {
+        yield DataChunk::single(0);
     }
 }

--- a/src/executor/explain.rs
+++ b/src/executor/explain.rs
@@ -8,15 +8,16 @@ pub struct ExplainExecutor {
 }
 
 impl ExplainExecutor {
-    pub fn execute(self) -> impl Stream<Item = Result<DataChunk, ExecutorError>> {
+    pub fn execute(self) -> BoxedExecutor {
         let mut explain_result = String::new();
         self.plan.plan.explain(0, &mut explain_result).unwrap();
         let chunk = DataChunk::from_iter([ArrayImpl::Utf8(Utf8Array::from_iter([Some(
             explain_result,
         )]))]);
 
-        try_stream! {
+        async_stream::try_stream! {
             yield chunk;
         }
+        .boxed()
     }
 }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -12,8 +12,8 @@
 
 use std::sync::Arc;
 
-use async_stream::try_stream;
-use futures::stream::{BoxStream, Stream, StreamExt};
+use futures::stream::{BoxStream, StreamExt};
+use futures_async_stream::try_stream;
 
 use crate::array::DataChunk;
 use crate::optimizer::plan_nodes::*;
@@ -104,7 +104,7 @@ pub struct ExecutorBuilder {
 
 impl Visitor for ExecutorBuilder {
     fn visit_dummy(&mut self, _plan: &Dummy) {
-        self.executor = Some(DummyScanExecutor.execute().boxed());
+        self.executor = Some(DummyScanExecutor.execute());
     }
     fn visit_physical_create_table(&mut self, plan: &PhysicalCreateTable) {
         match &self.env.storage {
@@ -114,8 +114,7 @@ impl Visitor for ExecutorBuilder {
                         plan: plan.clone(),
                         storage: storage.clone(),
                     }
-                    .execute()
-                    .boxed(),
+                    .execute(),
                 )
             }
             StorageImpl::SecondaryStorage(storage) => {
@@ -124,8 +123,7 @@ impl Visitor for ExecutorBuilder {
                         plan: plan.clone(),
                         storage: storage.clone(),
                     }
-                    .execute()
-                    .boxed(),
+                    .execute(),
                 )
             }
         }
@@ -136,14 +134,12 @@ impl Visitor for ExecutorBuilder {
                 plan: plan.clone(),
                 storage: storage.clone(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
             StorageImpl::SecondaryStorage(storage) => DropExecutor {
                 plan: plan.clone(),
                 storage: storage.clone(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         });
     }
 
@@ -155,16 +151,14 @@ impl Visitor for ExecutorBuilder {
                 storage: storage.clone(),
                 child: self.executor.take().unwrap(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
             StorageImpl::SecondaryStorage(storage) => InsertExecutor {
                 table_ref_id: plan.table_ref_id,
                 column_ids: plan.column_ids.clone(),
                 storage: storage.clone(),
                 child: self.executor.take().unwrap(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         });
     }
 
@@ -183,8 +177,7 @@ impl Visitor for ExecutorBuilder {
                 join_op: plan.join_op,
                 condition: plan.condition.clone(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         );
     }
 
@@ -194,14 +187,12 @@ impl Visitor for ExecutorBuilder {
                 plan: plan.clone(),
                 storage: storage.clone(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
             StorageImpl::SecondaryStorage(storage) => SeqScanExecutor {
                 plan: plan.clone(),
                 storage: storage.clone(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         });
     }
 
@@ -211,8 +202,7 @@ impl Visitor for ExecutorBuilder {
                 project_expressions: plan.project_expressions.clone(),
                 child: self.executor.take().unwrap(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         );
     }
 
@@ -222,8 +212,7 @@ impl Visitor for ExecutorBuilder {
                 expr: plan.expr.clone(),
                 child: self.executor.take().unwrap(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         );
     }
 
@@ -233,8 +222,7 @@ impl Visitor for ExecutorBuilder {
                 comparators: plan.comparators.clone(),
                 child: self.executor.take().unwrap(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         );
     }
 
@@ -245,13 +233,12 @@ impl Visitor for ExecutorBuilder {
                 offset: plan.offset,
                 limit: plan.limit,
             }
-            .execute()
-            .boxed(),
+            .execute(),
         );
     }
 
     fn visit_physical_explain(&mut self, plan: &PhysicalExplain) {
-        self.executor = Some(ExplainExecutor { plan: plan.clone() }.execute().boxed());
+        self.executor = Some(ExplainExecutor { plan: plan.clone() }.execute());
     }
 
     fn visit_physical_hash_agg(&mut self, plan: &PhysicalHashAgg) {
@@ -261,8 +248,7 @@ impl Visitor for ExecutorBuilder {
                 group_keys: plan.group_keys.clone(),
                 child: self.executor.take().unwrap(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         );
     }
 
@@ -272,8 +258,7 @@ impl Visitor for ExecutorBuilder {
                 agg_calls: plan.agg_calls.clone(),
                 child: self.executor.take().unwrap(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         );
     }
 
@@ -284,15 +269,13 @@ impl Visitor for ExecutorBuilder {
                 table_ref_id: plan.table_ref_id,
                 storage: storage.clone(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
             StorageImpl::SecondaryStorage(storage) => DeleteExecutor {
                 child: self.executor.take().unwrap(),
                 table_ref_id: plan.table_ref_id,
                 storage: storage.clone(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         });
     }
 
@@ -302,17 +285,12 @@ impl Visitor for ExecutorBuilder {
                 column_types: plan.column_types.clone(),
                 values: plan.values.clone(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         );
     }
 
     fn visit_physical_copy_from_file(&mut self, plan: &PhysicalCopyFromFile) {
-        self.executor = Some(
-            CopyFromFileExecutor { plan: plan.clone() }
-                .execute()
-                .boxed(),
-        );
+        self.executor = Some(CopyFromFileExecutor { plan: plan.clone() }.execute());
     }
 
     fn visit_physical_copy_to_file(&mut self, plan: &PhysicalCopyToFile) {
@@ -322,8 +300,7 @@ impl Visitor for ExecutorBuilder {
                 path: plan.path.clone(),
                 format: plan.format.clone(),
             }
-            .execute()
-            .boxed(),
+            .execute(),
         );
     }
 }

--- a/src/executor/seq_scan.rs
+++ b/src/executor/seq_scan.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use futures_async_stream::try_stream;
 use itertools::Itertools;
 
 use super::*;
@@ -52,7 +51,7 @@ impl<S: Storage> SeqScanExecutor<S> {
         Ok(chunk)
     }
 
-    #[try_stream(ok = DataChunk, error = ExecutorError)]
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
     pub async fn execute(self) {
         let table = self.storage.get_table(self.plan.table_ref_id)?;
 


### PR DESCRIPTION
Following #263, this PR migrates all executors to the `futures_async_stream` crate.