### PR TITLE
feat: use i32 for date encoding

### DIFF
--- a/src/storage/secondary/column/column_iterator.rs
+++ b/src/storage/secondary/column/column_iterator.rs
@@ -4,6 +4,7 @@ use super::{
 };
 use crate::array::{Array, ArrayImpl};
 use crate::catalog::ColumnCatalog;
+use crate::storage::secondary::column::DateColumnIterator;
 use crate::types::DataTypeKind;
 
 /// [`ColumnIteratorImpl`] of all types
@@ -13,6 +14,7 @@ pub enum ColumnIteratorImpl {
     Bool(BoolColumnIterator),
     Char(CharColumnIterator),
     Decimal(DecimalColumnIterator),
+    Date(DateColumnIterator),
 }
 
 impl ColumnIteratorImpl {
@@ -50,6 +52,10 @@ impl ColumnIteratorImpl {
                 DecimalColumnIterator::new(column, start_pos, PrimitiveBlockIteratorFactory::new())
                     .await,
             ),
+            DataTypeKind::Date => Self::Date(
+                DateColumnIterator::new(column, start_pos, PrimitiveBlockIteratorFactory::new())
+                    .await,
+            ),
             other_datatype => todo!(
                 "column iterator for {:?} is not implemented",
                 other_datatype
@@ -70,6 +76,7 @@ impl ColumnIteratorImpl {
             Self::Bool(it) => Self::erase_concrete_type(it.next_batch(expected_size).await),
             Self::Char(it) => Self::erase_concrete_type(it.next_batch(expected_size).await),
             Self::Decimal(it) => Self::erase_concrete_type(it.next_batch(expected_size).await),
+            Self::Date(it) => Self::erase_concrete_type(it.next_batch(expected_size).await),
         }
     }
 
@@ -80,6 +87,7 @@ impl ColumnIteratorImpl {
             Self::Bool(it) => it.fetch_hint(),
             Self::Char(it) => it.fetch_hint(),
             Self::Decimal(it) => it.fetch_hint(),
+            Self::Date(it) => it.fetch_hint(),
         }
     }
 }

--- a/src/storage/secondary/column/primitive_column_factory.rs
+++ b/src/storage/secondary/column/primitive_column_factory.rs
@@ -10,6 +10,7 @@ use super::super::{
 };
 use super::{BlockIteratorFactory, ConcreteColumnIterator};
 use crate::array::Array;
+use crate::types::Date;
 
 /// All supported block iterators for primitive types.
 pub enum PrimitiveBlockIteratorImpl<T: PrimitiveFixedWidthEncode> {
@@ -66,6 +67,7 @@ pub type I32ColumnIterator = PrimitiveColumnIterator<i32>;
 pub type F64ColumnIterator = PrimitiveColumnIterator<f64>;
 pub type BoolColumnIterator = PrimitiveColumnIterator<bool>;
 pub type DecimalColumnIterator = PrimitiveColumnIterator<Decimal>;
+pub type DateColumnIterator = PrimitiveColumnIterator<Date>;
 
 impl<T: PrimitiveFixedWidthEncode> BlockIteratorFactory<T::ArrayType>
     for PrimitiveBlockIteratorFactory<T>

--- a/src/storage/secondary/encode.rs
+++ b/src/storage/secondary/encode.rs
@@ -79,21 +79,16 @@ impl PrimitiveFixedWidthEncode for Decimal {
 }
 
 impl PrimitiveFixedWidthEncode for Date {
-    const WIDTH: usize = std::mem::size_of::<Date>();
-    const DEAFULT_VALUE: &'static Self = &Date::const_default();
+    const WIDTH: usize = std::mem::size_of::<i32>();
+    const DEAFULT_VALUE: &'static Self = &Date::new(0);
 
     type ArrayType = DateArray;
 
     fn encode(&self, buffer: &mut impl BufMut) {
-        buffer.put_i32(self.year());
-        buffer.put_u32(self.month());
-        buffer.put_u32(self.day());
+        buffer.put_i32(self.get_inner());
     }
 
     fn decode(buffer: &mut impl Buf) -> Self {
-        let year = buffer.get_i32();
-        let month = buffer.get_u32();
-        let day = buffer.get_u32();
-        Date::from_ymd(year, month, day)
+        Date::new(buffer.get_i32())
     }
 }

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -1,45 +1,40 @@
 use std::fmt::{Display, Formatter};
-use std::str::FromStr;
 
 use chrono::{Datelike, NaiveDate};
 
-/// A wrapper for [`NaiveDate`]
-#[derive(PartialOrd, PartialEq, Debug, Copy, Clone)]
-pub struct Date(NaiveDate);
+// The same as NaiveDate::from_ymd(1970, 1, 1).num_days_from_ce().
+// Minus this magic number to store the number of days since 1970-01-01.
+pub const UNIX_EPOCH_DAYS: i32 = 719_163;
 
-// TODO: implement customized Date type
+/// Date type
+#[derive(PartialOrd, PartialEq, Debug, Copy, Clone, Default)]
+pub struct Date(i32);
+
 impl Date {
-    pub fn from_ymd(year: i32, month: u32, day: u32) -> Self {
-        Date(NaiveDate::from_ymd(year, month, day))
+    pub const fn new(inner: i32) -> Self {
+        Date(inner)
     }
-    pub fn from_str(s: &str) -> chrono::ParseResult<Date> {
-        match NaiveDate::from_str(s) {
-            Ok(d) => Ok(Date(d)),
-            Err(e) => Err(e),
-        }
-    }
-    pub fn year(&self) -> i32 {
-        self.0.year()
-    }
-    pub fn month(&self) -> u32 {
-        self.0.month()
-    }
-    pub fn day(&self) -> u32 {
-        self.0.day()
-    }
-    pub const fn const_default() -> Self {
-        Date(chrono::naive::MIN_DATE)
-    }
-}
 
-impl Default for Date {
-    fn default() -> Self {
-        Date(chrono::naive::MIN_DATE)
+    /// Convert string to date
+    pub fn from_str(s: &str) -> chrono::ParseResult<Date> {
+        NaiveDate::parse_from_str(s, "%Y-%m-%d")
+            .map(|ret| Date(ret.num_days_from_ce() - UNIX_EPOCH_DAYS))
+    }
+
+    /// Get the inner value of date type
+    pub fn get_inner(&self) -> i32 {
+        self.0
     }
 }
 
 impl Display for Date {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{}", self.0)
+        write!(
+            f,
+            "{}",
+            NaiveDate::from_num_days_from_ce_opt(self.0 + UNIX_EPOCH_DAYS)
+                .unwrap()
+                .format("%Y-%m-%d")
+        )
     }
 }

--- a/tests/sql/type.slt
+++ b/tests/sql/type.slt
@@ -16,3 +16,18 @@ true
 
 statement ok
 drop table test1
+
+# date
+statement ok
+create table t (v1 date not null);
+
+statement ok
+insert into t values('2020-01-01');
+
+query I
+select v1 from t
+----
+2020-01-01
+
+statement ok
+drop table t


### PR DESCRIPTION
fix #259 
Date is encoded as a single `i32` now. It's implemented as the number of days since 1970-01-01, refer to [the implementation in risingwave](https://github.com/singularity-data/risingwave/blob/399640192b42cb371b3cab6a1d5d8bbb9a3189e5/rust/common/src/vector_op/cast.rs#L48-L53).