### PR TITLE
docs: fix some doc comments

### DIFF
--- a/src/executor/hash_join.rs
+++ b/src/executor/hash_join.rs
@@ -5,7 +5,8 @@ use super::*;
 use crate::array::{ArrayBuilderImpl, DataChunk};
 use crate::binder::{BoundExpr, BoundJoinOperator};
 use crate::types::{DataType, DataValue};
-// The executor for hash join
+
+/// The executor for hash join
 pub struct HashJoinExecutor {
     pub left_child: BoxedExecutor,
     pub right_child: BoxedExecutor,

--- a/src/executor/nested_loop_join.rs
+++ b/src/executor/nested_loop_join.rs
@@ -7,7 +7,8 @@ use super::*;
 use crate::array::{ArrayBuilderImpl, DataChunk};
 use crate::binder::{BoundExpr, BoundJoinOperator};
 use crate::types::{DataType, DataValue};
-// The executor for nested loop join
+
+/// The executor for nested loop join.
 pub struct NestedLoopJoinExecutor {
     pub left_child: BoxedExecutor,
     pub right_child: BoxedExecutor,

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -2,8 +2,8 @@ use std::fmt::{Display, Formatter};
 
 use chrono::{Datelike, NaiveDate};
 
-// The same as NaiveDate::from_ymd(1970, 1, 1).num_days_from_ce().
-// Minus this magic number to store the number of days since 1970-01-01.
+/// The same as NaiveDate::from_ymd(1970, 1, 1).num_days_from_ce().
+/// Minus this magic number to store the number of days since 1970-01-01.
 pub const UNIX_EPOCH_DAYS: i32 = 719_163;
 
 /// Date type


### PR DESCRIPTION
Wrong doc comments found by `^// .*\n(pub|type|fn|enum|type)`

Signed-off-by: TennyZhuang <zty0826@gmail.com>