### PR TITLE
chore: refine cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,6 @@ dependencies = [
  "paste",
  "prettytable-rs",
  "prost",
- "prost-types",
  "risinglight_proto",
  "rust_decimal",
  "rustyline",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,17 @@ async-stream = "0.3"
 async-trait = "0.1"
 bit-set = "0.5"
 bitvec = { version = "0.22", features = ["serde"] }
-btreemultimap = "0.1.0"
+btreemultimap = "0.1"
 bytes = "1"
-crc32fast = "1.3.0"
-csv = "1.1"
+chrono = "0.4"
+crc32fast = "1"
+csv = "1"
 dirs = "4"
-downcast-rs = "1.2"
+downcast-rs = "1"
 enum_dispatch = "0.3"
 env_logger = "0.9"
-futures-async-stream = { git = "https://github.com/taiki-e/futures-async-stream", rev = "944f407" }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-async-stream = { git = "https://github.com/taiki-e/futures-async-stream", rev = "944f407" }
 indicatif = { version = "0.16" }
 itertools = "0.10"
 jemallocator = "0.3"
@@ -34,23 +35,21 @@ parking_lot = "0.11"
 paste = "1"
 prettytable-rs = { version = "0.8", default-features = false }
 prost = "0.9"
-prost-types = "0.9"
 risinglight_proto = { path = "proto" }
+rust_decimal = "1"
 rustyline = "9"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-smallvec = { version = "1.6.1", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+smallvec = { version = "1", features = ["serde"] }
 sqlparser = { git = "https://github.com/wangrunji0408/sqlparser-rs", rev = "6e35a32", features = ["serde"] }
-thiserror = "1.0"
+thiserror = "1"
 tokio = { version = "1", features = ["full"] }
-rust_decimal = "1.18.0"
-chrono = "0.4"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio"] }
 sqllogictest = "0.1"
 tempfile = "3"
-test-case = "1.2"
+test-case = "1"
 
 [[bench]]
 harness = false


### PR DESCRIPTION
use cargo sort/udeps, and use more general version numbers.

Signed-off-by: TennyZhuang <zty0826@gmail.com>