### PR TITLE
chore: switch to tikv-jemallocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,27 +866,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
-dependencies = [
- "cc",
- "fs_extra",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,7 +1526,6 @@ dependencies = [
  "futures-async-stream",
  "indicatif",
  "itertools",
- "jemallocator",
  "log",
  "moka",
  "num-traits",
@@ -1565,6 +1543,7 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -1915,6 +1894,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.4.2+5.2.1-patched.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5844e429d797c62945a566f8da4e24c7fe3fbd5d6617fd8bf7a0b7dc1ee0f22e"
+dependencies = [
+ "cc",
+ "fs_extra",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c14a5a604eb8715bc5785018a37d00739b180bcf609916ddf4393d33d49ccdf"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 [features]
 default = ["jemalloc"]
 simd = []
-jemalloc = ["jemallocator"]
+jemalloc = ["tikv-jemallocator"]
 
 [dependencies]
 anyhow = "1"
@@ -31,7 +31,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = { git = "https://github.com/taiki-e/futures-async-stream", rev = "944f407" }
 indicatif = { version = "0.16" }
 itertools = "0.10"
-jemallocator = { version = "0.3", optional = true }
+tikv-jemallocator = { version = "0.4", optional = true }
 log = "0.4"
 moka = { version = "0.6", features = ["future"] }
 num-traits = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub mod storage;
 pub mod types;
 
 #[cfg(feature = "jemalloc")]
-use jemallocator::Jemalloc;
+use tikv_jemallocator::Jemalloc;
 
 pub use self::db::{Database, Error};
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

The original jemallocator seems not maintained actively any more. We can move to tikv-jemallocator.