### PR TITLE
refactor(executor): split chunks

### DIFF
--- a/src/array/data_chunk.rs
+++ b/src/array/data_chunk.rs
@@ -28,6 +28,12 @@ impl FromIterator<ArrayImpl> for DataChunk {
     }
 }
 
+impl FromIterator<ArrayBuilderImpl> for DataChunk {
+    fn from_iter<I: IntoIterator<Item = ArrayBuilderImpl>>(iter: I) -> Self {
+        iter.into_iter().map(|b| b.finish()).collect()
+    }
+}
+
 impl DataChunk {
     /// Return a [`DataChunk`] with 1 element in 1 array.
     pub fn single(item: i32) -> Self {

--- a/src/array/data_chunk.rs
+++ b/src/array/data_chunk.rs
@@ -4,22 +4,20 @@ use std::fmt;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 
-use smallvec::SmallVec;
-
 use super::*;
 use crate::types::DataValue;
 
 /// A collection of arrays.
 ///
 /// A chunk is a horizontal subset of a query result.
-#[derive(Default, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub struct DataChunk {
-    arrays: SmallVec<[ArrayImpl; 16]>,
+    arrays: Arc<[ArrayImpl]>,
 }
 
 impl FromIterator<ArrayImpl> for DataChunk {
     fn from_iter<I: IntoIterator<Item = ArrayImpl>>(iter: I) -> Self {
-        let arrays: SmallVec<[ArrayImpl; 16]> = iter.into_iter().collect();
+        let arrays: Arc<[ArrayImpl]> = iter.into_iter().collect();
         assert!(!arrays.is_empty());
         let cardinality = arrays[0].len();
         assert!(
@@ -86,8 +84,6 @@ impl DataChunk {
         self.arrays.iter().map(|a| a.get_estimated_size()).sum()
     }
 }
-
-pub type DataChunkRef = Arc<DataChunk>;
 
 /// Print the chunk as a pretty table.
 impl fmt::Display for DataChunk {

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use futures::TryStreamExt;
 use risinglight_proto::rowset::block_statistics::BlockStatisticsType;
 
-use crate::array::{ArrayBuilder, DataChunk, I32ArrayBuilder, Utf8ArrayBuilder};
+use crate::array::{ArrayBuilder, ArrayBuilderImpl, DataChunk, I32ArrayBuilder, Utf8ArrayBuilder};
 use crate::binder::{BindError, Binder};
 use crate::catalog::RootCatalogRef;
 use crate::executor::{ExecutorBuilder, ExecutorError};
@@ -79,13 +79,13 @@ impl Database {
                 }
             }
         }
-        let vecs = vec![
-            db_id_vec.finish().into(),
-            db_vec.finish().into(),
-            schema_id_vec.finish().into(),
-            schema_vec.finish().into(),
-            table_id_vec.finish().into(),
-            table_vec.finish().into(),
+        let vecs: Vec<ArrayBuilderImpl> = vec![
+            db_id_vec.into(),
+            db_vec.into(),
+            schema_id_vec.into(),
+            schema_vec.into(),
+            table_id_vec.into(),
+            table_vec.into(),
         ];
         Ok(vec![DataChunk::from_iter(vecs.into_iter())])
     }
@@ -127,8 +127,8 @@ impl Database {
                     stat_name.push(Some("DistinctValue"));
                     stat_value.push(Some(&format!("{:?}", row_count[1])));
                     Ok(vec![DataChunk::from_iter([
-                        stat_name.finish().into(),
-                        stat_value.finish().into(),
+                        ArrayBuilderImpl::from(stat_name),
+                        ArrayBuilderImpl::from(stat_value),
                     ])])
                 } else {
                     Err(Error::InternalError(

--- a/src/db.rs
+++ b/src/db.rs
@@ -8,7 +8,7 @@ use risinglight_proto::rowset::block_statistics::BlockStatisticsType;
 use crate::array::{ArrayBuilder, DataChunk, I32ArrayBuilder, Utf8ArrayBuilder};
 use crate::binder::{BindError, Binder};
 use crate::catalog::RootCatalogRef;
-use crate::executor::{ExecutorBuilder, ExecutorError, GlobalEnv};
+use crate::executor::{ExecutorBuilder, ExecutorError};
 use crate::logical_planner::{LogicalPlanError, LogicalPlaner};
 use crate::optimizer::logical_plan_rewriter::{InputRefResolver, PlanRewriter};
 use crate::optimizer::Optimizer;
@@ -31,10 +31,7 @@ impl Database {
         let storage = InMemoryStorage::new();
         let catalog = storage.catalog().clone();
         let storage = StorageImpl::InMemoryStorage(Arc::new(storage));
-        let env = Arc::new(GlobalEnv {
-            storage: storage.clone(),
-        });
-        let execution_manager = ExecutorBuilder::new(env);
+        let execution_manager = ExecutorBuilder::new(storage.clone());
         Database {
             catalog,
             executor_builder: execution_manager,
@@ -48,10 +45,7 @@ impl Database {
         storage.spawn_compactor().await;
         let catalog = storage.catalog().clone();
         let storage = StorageImpl::SecondaryStorage(storage);
-        let env = Arc::new(GlobalEnv {
-            storage: storage.clone(),
-        });
-        let execution_manager = ExecutorBuilder::new(env);
+        let execution_manager = ExecutorBuilder::new(storage.clone());
         Database {
             catalog,
             executor_builder: execution_manager,

--- a/src/executor/copy_from_file.rs
+++ b/src/executor/copy_from_file.rs
@@ -4,7 +4,6 @@ use std::fs::File;
 use std::io::BufReader;
 
 use indicatif::{ProgressBar, ProgressStyle};
-use itertools::Itertools;
 use tokio::sync::mpsc::UnboundedSender;
 
 use super::*;
@@ -43,10 +42,7 @@ impl CopyFromFileExecutor {
                 .collect_vec()
         };
         let flush_array = |array_builders: Vec<ArrayBuilderImpl>| -> DataChunk {
-            array_builders
-                .into_iter()
-                .map(|builder| builder.finish())
-                .collect()
+            array_builders.into_iter().collect()
         };
 
         let mut array_builders = create_array_builders(&self.plan);

--- a/src/executor/copy_from_file.rs
+++ b/src/executor/copy_from_file.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 use std::io::BufReader;
 
 use indicatif::{ProgressBar, ProgressStyle};
-use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::mpsc::Sender;
 
 use super::*;
 use crate::array::ArrayBuilderImpl;
@@ -16,16 +16,13 @@ pub struct CopyFromFileExecutor {
     pub plan: PhysicalCopyFromFile,
 }
 
-/// When the source file size is about the limit, we show a progress bar on the screen.
+/// When the source file size is above the limit, we show a progress bar on the screen.
 const IMPORT_PROGRESS_BAR_LIMIT: u64 = 1024 * 1024;
-
-/// We produce a batch everytime the [`DataChunk`] is larger than this size.
-const IMPORT_BATCH_SIZE: u64 = 16 * 1024 * 1024;
 
 impl CopyFromFileExecutor {
     #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
     pub async fn execute(self) {
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         let handle = tokio::task::spawn_blocking(|| self.read_file_blocking(tx));
         while let Some(chunk) = rx.recv().await {
             yield chunk;
@@ -33,20 +30,10 @@ impl CopyFromFileExecutor {
         handle.await.unwrap()?;
     }
 
-    fn read_file_blocking(self, tx: UnboundedSender<DataChunk>) -> Result<(), ExecutorError> {
-        let create_array_builders = |plan: &PhysicalCopyFromFile| {
-            plan.logical()
-                .column_types()
-                .iter()
-                .map(ArrayBuilderImpl::new)
-                .collect_vec()
-        };
-        let flush_array = |array_builders: Vec<ArrayBuilderImpl>| -> DataChunk {
-            array_builders.into_iter().collect()
-        };
-
-        let mut array_builders = create_array_builders(&self.plan);
-
+    /// Read records from file using blocking IO.
+    ///
+    /// The read data chunks will be sent through `tx`.
+    fn read_file_blocking(self, tx: Sender<DataChunk>) -> Result<(), ExecutorError> {
         let file = File::open(&self.plan.logical().path())?;
         let file_size = file.metadata()?.len();
         let mut buf_reader = BufReader::new(file);
@@ -79,25 +66,26 @@ impl CopyFromFileExecutor {
 
         let column_count = self.plan.logical().column_types().len();
         let mut iter = reader.records();
-        let mut round = 0;
-        let mut last_pos = 0;
-        loop {
-            round += 1;
-            if round % 1000 == 0 {
-                let current_pos = iter.reader().position().byte();
-                bar.set_position(current_pos);
-                // Produce a chunk of 16MB
-                if current_pos - last_pos > IMPORT_BATCH_SIZE {
-                    last_pos = current_pos;
-                    let chunk = flush_array(array_builders);
-                    array_builders = create_array_builders(&self.plan);
-                    if chunk.cardinality() > 0 {
-                        tx.send(chunk).unwrap();
+        let mut finished = false;
+        while !finished {
+            // create array builders
+            let mut array_builders = self
+                .plan
+                .logical()
+                .column_types()
+                .iter()
+                .map(|ty| ArrayBuilderImpl::with_capacity(PROCESSING_WINDOW_SIZE, ty))
+                .collect_vec();
+
+            // read records and push to array builder
+            for _ in 0..PROCESSING_WINDOW_SIZE {
+                let record = match iter.next() {
+                    Some(record) => record?,
+                    None => {
+                        finished = true;
+                        break;
                     }
-                }
-            }
-            if let Some(record) = iter.next() {
-                let record = record?;
+                };
                 if !(record.len() == column_count
                     || record.len() == column_count + 1 && record.get(column_count) == Some(""))
                 {
@@ -116,16 +104,17 @@ impl CopyFromFileExecutor {
                     }
                     builder.push_str(s)?;
                 }
-            } else {
-                break;
+            }
+            // update progress bar
+            bar.set_position(iter.reader().position().byte());
+
+            // send data chunk
+            let chunk: DataChunk = array_builders.into_iter().collect();
+            if chunk.cardinality() > 0 {
+                tx.blocking_send(chunk).unwrap();
             }
         }
         bar.finish();
-
-        let chunk = flush_array(array_builders);
-        if chunk.cardinality() > 0 {
-            tx.send(chunk).unwrap();
-        }
         Ok(())
     }
 }

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -1,5 +1,7 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
+//! Apply expressions on data chunks.
+
 use std::borrow::Borrow;
 
 use crate::array::*;

--- a/src/executor/hash_agg.rs
+++ b/src/executor/hash_agg.rs
@@ -69,7 +69,7 @@ impl HashAggExecutor {
     ) {
         // We use `iter_chunks::IterChunks` instead of `IterTools::Chunks` here, since
         // the latter doesn't implement Send.
-        let mut batches = IterChunks::chunks(state_entries.iter(), 1024);
+        let mut batches = IterChunks::chunks(state_entries.iter(), PROCESSING_WINDOW_SIZE);
         while let Some(batch) = batches.next() {
             let mut key_builders = group_keys
                 .iter()

--- a/src/executor/hash_agg.rs
+++ b/src/executor/hash_agg.rs
@@ -3,7 +3,6 @@
 use std::collections::HashMap;
 
 use iter_chunks::IterChunks;
-use itertools::Itertools;
 use smallvec::SmallVec;
 
 use super::*;
@@ -91,10 +90,7 @@ impl HashAggExecutor {
                 }
             }
             key_builders.append(&mut res_builders);
-            yield key_builders
-                .into_iter()
-                .map(|builder| builder.finish())
-                .collect::<DataChunk>()
+            yield key_builders.into_iter().collect()
         }
     }
 

--- a/src/executor/hash_join.rs
+++ b/src/executor/hash_join.rs
@@ -70,12 +70,7 @@ impl HashJoinExecutor {
                 }
             }
         }
-        Ok(Some(
-            chunk_builders
-                .into_iter()
-                .map(|builder| builder.finish())
-                .collect(),
-        ))
+        Ok(Some(chunk_builders.into_iter().collect()))
     }
 
     #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]

--- a/src/executor/insert.rs
+++ b/src/executor/insert.rs
@@ -2,8 +2,6 @@
 
 use std::sync::Arc;
 
-use itertools::Itertools;
-
 use super::*;
 use crate::array::{ArrayBuilderImpl, DataChunk};
 use crate::catalog::TableRefId;
@@ -82,7 +80,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::array::{ArrayImpl, DataChunk};
+    use crate::array::ArrayImpl;
     use crate::catalog::{ColumnCatalog, TableRefId};
     use crate::executor::CreateTableExecutor;
     use crate::optimizer::plan_nodes::PhysicalCreateTable;
@@ -102,7 +100,7 @@ mod tests {
                     ArrayImpl::Int32((100..104).collect()),
                 ]
                 .into_iter()
-                .collect::<DataChunk>();
+                .collect();
             }
             .boxed(),
         };

--- a/src/executor/limit.rs
+++ b/src/executor/limit.rs
@@ -65,7 +65,7 @@ mod tests {
             limit,
         };
         let actual = executor.execute().try_collect::<Vec<_>>().await.unwrap();
-        let outputs = outputs.iter().map(range_to_chunk).collect::<Vec<_>>();
+        let outputs = outputs.iter().map(range_to_chunk).collect_vec();
         assert_eq!(actual, outputs);
     }
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -97,6 +97,9 @@ pub enum ExecutorError {
     NotNullable,
 }
 
+/// The maximum chunk length produced by executor at a time.
+const PROCESSING_WINDOW_SIZE: usize = 1024;
+
 /// A type-erased executor object.
 ///
 /// Logically an executor is a stream of data chunks.

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 
 use futures::stream::{BoxStream, StreamExt};
 use futures_async_stream::try_stream;
+use itertools::Itertools;
 
 use crate::array::DataChunk;
 use crate::optimizer::plan_nodes::*;

--- a/src/executor/nested_loop_join.rs
+++ b/src/executor/nested_loop_join.rs
@@ -82,10 +82,7 @@ impl NestedLoopJoinExecutor {
                             builder.push(&left_row[idx]);
                         }
 
-                        let chunk: DataChunk = builders
-                            .into_iter()
-                            .map(|builder| builder.finish())
-                            .collect();
+                        let chunk = builders.into_iter().collect();
                         let arr_impl = join_cond.eval_array(&chunk)?;
                         let value = arr_impl.get(0);
                         match value {
@@ -161,12 +158,7 @@ impl NestedLoopJoinExecutor {
             }
             None => {}
         }
-        Ok(Some(
-            chunk_builders
-                .into_iter()
-                .map(|builder| builder.finish())
-                .collect(),
-        ))
+        Ok(Some(chunk_builders.into_iter().collect()))
     }
 
     #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]

--- a/src/executor/table_scan.rs
+++ b/src/executor/table_scan.rs
@@ -2,8 +2,6 @@
 
 use std::sync::Arc;
 
-use itertools::Itertools;
-
 use super::*;
 use crate::array::{ArrayBuilder, ArrayBuilderImpl, DataChunk, I64ArrayBuilder};
 use crate::binder::BoundExpr;
@@ -49,10 +47,7 @@ impl<S: Storage> TableScanExecutor<S> {
             builders.push(ArrayBuilderImpl::Int64(I64ArrayBuilder::new()));
         }
 
-        let chunk: DataChunk = builders
-            .into_iter()
-            .map(|builder| builder.finish())
-            .collect();
+        let chunk = builders.into_iter().collect();
 
         Ok(chunk)
     }

--- a/src/executor/values.rs
+++ b/src/executor/values.rs
@@ -16,19 +16,23 @@ pub struct ValuesExecutor {
 impl ValuesExecutor {
     #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
     pub async fn execute(self) {
-        let cardinality = self.values.len();
-        let mut builders = self
-            .column_types
-            .iter()
-            .map(|ty| ArrayBuilderImpl::with_capacity(cardinality, ty))
-            .collect_vec();
-        for row in &self.values {
-            for (expr, builder) in row.iter().zip(&mut builders) {
-                let value = expr.eval();
-                builder.push(&value);
+        for chunk in self.values.chunks(PROCESSING_WINDOW_SIZE) {
+            // Create array builders.
+            let mut builders = self
+                .column_types
+                .iter()
+                .map(|ty| ArrayBuilderImpl::with_capacity(chunk.len(), ty))
+                .collect_vec();
+            // Push value into the builder.
+            for row in chunk {
+                for (expr, builder) in row.iter().zip(&mut builders) {
+                    let value = expr.eval();
+                    builder.push(&value);
+                }
             }
+            // Finish build and yield chunk.
+            yield builders.into_iter().collect();
         }
-        yield builders.into_iter().collect();
     }
 }
 

--- a/src/executor/values.rs
+++ b/src/executor/values.rs
@@ -21,18 +21,14 @@ impl ValuesExecutor {
             .column_types
             .iter()
             .map(|ty| ArrayBuilderImpl::with_capacity(cardinality, ty))
-            .collect::<Vec<ArrayBuilderImpl>>();
+            .collect_vec();
         for row in &self.values {
             for (expr, builder) in row.iter().zip(&mut builders) {
                 let value = expr.eval();
                 builder.push(&value);
             }
         }
-        let chunk = builders
-            .into_iter()
-            .map(|builder| builder.finish())
-            .collect::<DataChunk>();
-        yield chunk;
+        yield builders.into_iter().collect();
     }
 }
 
@@ -53,9 +49,9 @@ mod tests {
                 .map(|row| {
                     row.iter()
                         .map(|&v| BoundExpr::Constant(DataValue::Int32(v)))
-                        .collect::<Vec<_>>()
+                        .collect_vec()
                 })
-                .collect::<Vec<_>>(),
+                .collect_vec(),
         };
         let output = executor.execute().next().await.unwrap().unwrap();
         let expected = [

--- a/src/storage/memory/iterator.rs
+++ b/src/storage/memory/iterator.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bitvec::prelude::BitVec;
 
-use crate::array::{ArrayImpl, DataChunk, DataChunkRef, I64Array};
+use crate::array::{ArrayImpl, DataChunk, I64Array};
 use crate::storage::{StorageColumnRef, StorageResult, TxnIterator};
 
 /// An iterator over all data in a transaction.
@@ -15,7 +15,7 @@ use crate::storage::{StorageColumnRef, StorageResult, TxnIterator};
 /// When the transaction end, accessing items inside iterator is UB.
 /// To achieve this, we must enable GAT.
 pub struct InMemoryTxnIterator {
-    chunks: Arc<Vec<DataChunkRef>>,
+    chunks: Arc<Vec<DataChunk>>,
     deleted_rows: Arc<HashSet<usize>>,
     col_idx: Vec<StorageColumnRef>,
     cnt: usize,
@@ -24,7 +24,7 @@ pub struct InMemoryTxnIterator {
 
 impl InMemoryTxnIterator {
     pub(super) fn new(
-        chunks: Arc<Vec<DataChunkRef>>,
+        chunks: Arc<Vec<DataChunk>>,
         deleted_rows: Arc<HashSet<usize>>,
         col_idx: &[StorageColumnRef],
     ) -> Self {

--- a/src/storage/memory/table.rs
+++ b/src/storage/memory/table.rs
@@ -7,7 +7,7 @@ use std::vec::Vec;
 use async_trait::async_trait;
 
 use super::*;
-use crate::array::{DataChunk, DataChunkRef};
+use crate::array::DataChunk;
 use crate::catalog::TableRefId;
 use crate::storage::Table;
 
@@ -21,7 +21,7 @@ pub struct InMemoryTable {
 }
 
 pub(super) struct InMemoryTableInner {
-    chunks: Vec<DataChunkRef>,
+    chunks: Vec<DataChunk>,
     deleted_rows: HashSet<usize>,
 }
 
@@ -36,7 +36,7 @@ impl InMemoryTableInner {
     }
 
     pub fn append(&mut self, chunk: DataChunk) -> Result<(), StorageError> {
-        self.chunks.push(Arc::new(chunk));
+        self.chunks.push(chunk);
         Ok(())
     }
 
@@ -45,7 +45,7 @@ impl InMemoryTableInner {
         Ok(())
     }
 
-    pub fn get_all_chunks(&self) -> Vec<DataChunkRef> {
+    pub fn get_all_chunks(&self) -> Vec<DataChunk> {
         self.chunks.clone()
     }
 

--- a/src/storage/memory/transaction.rs
+++ b/src/storage/memory/transaction.rs
@@ -8,9 +8,7 @@ use itertools::Itertools;
 
 use super::table::InMemoryTableInnerRef;
 use super::{InMemoryRowHandler, InMemoryTable, InMemoryTxnIterator};
-use crate::array::{
-    ArrayBuilderImpl, ArrayImplBuilderPickExt, ArrayImplSortExt, DataChunk, DataChunkRef,
-};
+use crate::array::{ArrayBuilderImpl, ArrayImplBuilderPickExt, ArrayImplSortExt, DataChunk};
 use crate::binder::BoundExpr;
 use crate::catalog::{find_sort_key_id, ColumnCatalog};
 use crate::storage::{StorageColumnRef, StorageResult, Transaction};
@@ -30,7 +28,7 @@ pub struct InMemoryTransaction {
 
     /// When transaction is started, reference to all data chunks will
     /// be cached in `snapshot` to provide snapshot isolation.
-    snapshot: Arc<Vec<DataChunkRef>>,
+    snapshot: Arc<Vec<DataChunk>>,
 
     /// Reference to inner table.
     table: InMemoryTableInnerRef,
@@ -59,9 +57,9 @@ impl InMemoryTransaction {
 
 /// If primary key is found in [`ColumnCatalog`], sort all in-memory data using that key.
 fn sort_datachunk_by_pk(
-    chunks: &Arc<Vec<Arc<DataChunk>>>,
+    chunks: &Arc<Vec<DataChunk>>,
     column_infos: &[ColumnCatalog],
-) -> Arc<Vec<Arc<DataChunk>>> {
+) -> Arc<Vec<DataChunk>> {
     if let Some(sort_key_id) = find_sort_key_id(column_infos) {
         if chunks.is_empty() {
             return chunks.clone();
@@ -92,7 +90,7 @@ fn sort_datachunk_by_pk(
                 builder.finish()
             })
             .collect::<DataChunk>();
-        Arc::new(vec![Arc::new(chunk)])
+        Arc::new(vec![chunk])
     } else {
         chunks.clone()
     }

--- a/src/storage/secondary/rowset/disk_rowset.rs
+++ b/src/storage/secondary/rowset/disk_rowset.rs
@@ -111,7 +111,7 @@ pub mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::array::I32Array;
+    use crate::array::ArrayImpl;
     use crate::storage::secondary::rowset::rowset_builder::RowsetBuilder;
     use crate::storage::secondary::ColumnBuilderOptions;
     use crate::types::{DataTypeExt, DataTypeKind};
@@ -156,21 +156,15 @@ pub mod tests {
         for _ in 0..100 {
             builder.append(
                 [
-                    I32Array::from_iter([1, 2, 3].iter().cycle().cloned().take(len).map(Some))
-                        .into(),
-                    I32Array::from_iter(
-                        [1, 3, 5, 7, 9].iter().cycle().cloned().take(len).map(Some),
-                    )
-                    .into(),
-                    I32Array::from_iter(
+                    ArrayImpl::Int32([1, 2, 3].into_iter().cycle().take(len).collect()),
+                    ArrayImpl::Int32([1, 3, 5, 7, 9].into_iter().cycle().take(len).collect()),
+                    ArrayImpl::Int32(
                         [2, 3, 3, 3, 3, 3, 3]
-                            .iter()
+                            .into_iter()
                             .cycle()
-                            .cloned()
                             .take(len)
-                            .map(Some),
-                    )
-                    .into(),
+                            .collect(),
+                    ),
                 ]
                 .into_iter()
                 .collect(),

--- a/src/storage/secondary/rowset/rowset_builder.rs
+++ b/src/storage/secondary/rowset/rowset_builder.rs
@@ -126,7 +126,7 @@ impl RowsetBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::I32Array;
+    use crate::array::ArrayImpl;
     use crate::types::{DataTypeExt, DataTypeKind};
 
     #[tokio::test]
@@ -146,10 +146,9 @@ mod tests {
 
         for _ in 0..1000 {
             builder.append(
-                [
-                    I32Array::from_iter([1, 2, 3].iter().cycle().cloned().take(1000).map(Some))
-                        .into(),
-                ]
+                [ArrayImpl::Int32(
+                    [1, 2, 3].into_iter().cycle().take(1000).collect(),
+                )]
                 .into_iter()
                 .collect(),
             )


### PR DESCRIPTION
This PR makes `CopyFromFile` and `Values` executors split chunks. (Part of #348)

