### PR TITLE
feat(join): refactor and support outer join for hash join

### DIFF
--- a/src/executor/hash_agg.rs
+++ b/src/executor/hash_agg.rs
@@ -52,7 +52,7 @@ impl HashAggExecutor {
             }
             // since we just checked existence, the key must exist so we `unwrap` directly
             let states = state_entries.get_mut(&group_key).unwrap();
-            for (array, state) in arrays.iter().zip(states.iter_mut()) {
+            for (array, state) in arrays.iter().zip_eq(states.iter_mut()) {
                 // TODO: support aggregations with multiple arguments
                 state.update_single(&array.get(row_idx))?;
             }
@@ -81,11 +81,11 @@ impl HashAggExecutor {
                 .collect::<Vec<ArrayBuilderImpl>>();
             for (key, val) in batch {
                 // Push group key
-                for (k, builder) in key.iter().zip(key_builders.iter_mut()) {
+                for (k, builder) in key.iter().zip_eq(key_builders.iter_mut()) {
                     builder.push(k);
                 }
                 // Push aggregate result
-                for (state, builder) in val.iter().zip(res_builders.iter_mut()) {
+                for (state, builder) in val.iter().zip_eq(res_builders.iter_mut()) {
                     builder.push(&state.output());
                 }
             }

--- a/src/executor/hash_join.rs
+++ b/src/executor/hash_join.rs
@@ -3,8 +3,10 @@
 use std::collections::HashMap;
 use std::vec::Vec;
 
+use futures::TryStreamExt;
+
 use super::*;
-use crate::array::{ArrayBuilderImpl, DataChunk};
+use crate::array::{ArrayBuilderImpl, DataChunk, RowRef};
 use crate::binder::{BoundExpr, BoundJoinOperator};
 use crate::types::{DataType, DataValue};
 
@@ -21,81 +23,41 @@ pub struct HashJoinExecutor {
 
 // TODO : support other types of join: left/right/full join
 impl HashJoinExecutor {
-    fn execute_hash_join(
-        left_chunks: Vec<DataChunk>,
-        right_chunks: Vec<DataChunk>,
-        left_column_index: usize,
-        right_column_index: usize,
-        data_types: Vec<DataType>,
-    ) -> Result<Option<DataChunk>, ExecutorError> {
-        // Build hash table
-
-        let mut hash_map: HashMap<DataValue, Vec<Vec<DataValue>>> = HashMap::new();
-        for left_chunk in &left_chunks {
-            for left_row_idx in 0..left_chunk.cardinality() {
-                let row = left_chunk.get_row_by_idx(left_row_idx);
-                let hash_data_value = &row[left_column_index];
-
-                hash_map
-                    .entry(hash_data_value.clone())
-                    .or_insert_with(Vec::new);
-                let val = hash_map.get_mut(hash_data_value).unwrap();
-                val.push(row);
-            }
-        }
-        let mut chunk_builders: Vec<ArrayBuilderImpl> = vec![];
-        for ty in &data_types {
-            chunk_builders.push(ArrayBuilderImpl::new(ty));
-        }
-        // Probe
-        for right_chunk in &right_chunks {
-            for right_row_idx in 0..right_chunk.cardinality() {
-                let right_row = right_chunk.get_row_by_idx(right_row_idx);
-                let hash_data_value = &right_row[right_column_index];
-
-                if !hash_map.contains_key(hash_data_value) {
-                    continue;
-                }
-                let rows = hash_map.get(hash_data_value).unwrap();
-                for left_row in rows.iter() {
-                    if left_row[left_column_index] == right_row[right_column_index] {
-                        for (idx, builder) in chunk_builders.iter_mut().enumerate() {
-                            if idx < left_row.len() {
-                                builder.push(&left_row[idx]);
-                            } else {
-                                builder.push(&right_row[idx - left_row.len()]);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        Ok(Some(chunk_builders.into_iter().collect()))
-    }
-
     #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
     pub async fn execute(self) {
-        let mut left_chunks: Vec<DataChunk> = vec![];
-        let mut right_chunks: Vec<DataChunk> = vec![];
-        #[for_await]
-        for batch in self.left_child {
-            left_chunks.push(batch?);
+        // collect all chunks from children
+        let left_chunks: Vec<DataChunk> = self.left_child.try_collect().await?;
+        let right_chunks: Vec<DataChunk> = self.right_child.try_collect().await?;
+
+        // helper functions
+        let left_rows = || left_chunks.iter().flat_map(|chunk| chunk.rows());
+        let right_rows = || right_chunks.iter().flat_map(|chunk| chunk.rows());
+
+        // build
+        let mut hash_map: HashMap<DataValue, Vec<RowRef<'_>>> = HashMap::new();
+        for left_row in left_rows() {
+            let hash_value = left_row.get(self.left_column_index);
+            hash_map
+                .entry(hash_value)
+                .or_insert_with(Vec::new)
+                .push(left_row);
         }
 
-        #[for_await]
-        for batch in self.right_child {
-            right_chunks.push(batch?);
+        // probe
+        let mut builders = self
+            .data_types
+            .iter()
+            .map(|ty| ArrayBuilderImpl::with_capacity(PROCESSING_WINDOW_SIZE, ty))
+            .collect_vec();
+        for right_row in right_rows() {
+            let hash_value = right_row.get(self.right_column_index);
+            for left_row in hash_map.get(&hash_value).unwrap_or(&vec![]) {
+                let values = left_row.values().chain(right_row.values());
+                for (builder, v) in builders.iter_mut().zip(values) {
+                    builder.push(&v);
+                }
+            }
         }
-
-        let chunk = Self::execute_hash_join(
-            left_chunks,
-            right_chunks,
-            self.left_column_index,
-            self.right_column_index,
-            self.data_types,
-        )?;
-        if let Some(chunk) = chunk {
-            yield chunk;
-        }
+        yield builders.into_iter().collect();
     }
 }

--- a/src/executor/hash_join.rs
+++ b/src/executor/hash_join.rs
@@ -53,7 +53,7 @@ impl HashJoinExecutor {
             let hash_value = right_row.get(self.right_column_index);
             for left_row in hash_map.get(&hash_value).unwrap_or(&vec![]) {
                 let values = left_row.values().chain(right_row.values());
-                for (builder, v) in builders.iter_mut().zip(values) {
+                for (builder, v) in builders.iter_mut().zip_eq(values) {
                     builder.push(&v);
                 }
             }
@@ -75,7 +75,7 @@ impl HashJoinExecutor {
                 // append row: (left, NULL)
                 let values =
                     (left_row.values()).chain(self.right_types.iter().map(|_| DataValue::Null));
-                for (builder, v) in builders.iter_mut().zip(values) {
+                for (builder, v) in builders.iter_mut().zip_eq(values) {
                     builder.push(&v);
                 }
             }
@@ -94,7 +94,7 @@ impl HashJoinExecutor {
                 // append row: (NULL, right)
                 let values =
                     (self.left_types.iter().map(|_| DataValue::Null)).chain(right_row.values());
-                for (builder, v) in builders.iter_mut().zip(values) {
+                for (builder, v) in builders.iter_mut().zip_eq(values) {
                     builder.push(&v);
                 }
             }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -183,9 +183,7 @@ impl PlanVisitor<BoxedExecutor> for ExecutorBuilder {
         &mut self,
         plan: &PhysicalNestedLoopJoin,
     ) -> Option<BoxedExecutor> {
-        let left_types = plan.left().out_types();
         let left_child = self.visit(plan.left()).unwrap();
-        let right_types = plan.right().out_types();
         let right_child = self.visit(plan.right()).unwrap();
         Some(
             NestedLoopJoinExecutor {
@@ -193,8 +191,8 @@ impl PlanVisitor<BoxedExecutor> for ExecutorBuilder {
                 right_child,
                 join_op: plan.logical().join_op(),
                 condition: plan.logical().condition().clone(),
-                left_types,
-                right_types,
+                left_types: plan.left().out_types(),
+                right_types: plan.right().out_types(),
             }
             .execute(),
         )
@@ -284,7 +282,8 @@ impl PlanVisitor<BoxedExecutor> for ExecutorBuilder {
                 condition: plan.logical().condition().clone(),
                 left_column_index: plan.left_column_index(),
                 right_column_index: plan.right_column_index(),
-                data_types: plan.out_types(),
+                left_types: plan.left().out_types(),
+                right_types: plan.right().out_types(),
             }
             .execute(),
         )

--- a/src/executor/nested_loop_join.rs
+++ b/src/executor/nested_loop_join.rs
@@ -42,7 +42,7 @@ impl NestedLoopJoinExecutor {
         for left_row in left_rows() {
             for right_row in right_rows() {
                 let values = left_row.values().chain(right_row.values());
-                for (builder, v) in builders.iter_mut().zip(values) {
+                for (builder, v) in builders.iter_mut().zip_eq(values) {
                     builder.push(&v);
                 }
             }
@@ -75,7 +75,7 @@ impl NestedLoopJoinExecutor {
                 // append row: (left, NULL)
                 let values =
                     (left_row.values()).chain(self.right_types.iter().map(|_| DataValue::Null));
-                for (builder, v) in builders.iter_mut().zip(values) {
+                for (builder, v) in builders.iter_mut().zip_eq(values) {
                     builder.push(&v);
                 }
             }
@@ -101,7 +101,7 @@ impl NestedLoopJoinExecutor {
                 // append row: (NULL, right)
                 let values =
                     (self.left_types.iter().map(|_| DataValue::Null)).chain(right_row.values());
-                for (builder, v) in builders.iter_mut().zip(values) {
+                for (builder, v) in builders.iter_mut().zip_eq(values) {
                     builder.push(&v);
                 }
             }

--- a/src/executor/simple_agg.rs
+++ b/src/executor/simple_agg.rs
@@ -26,7 +26,7 @@ impl SimpleAggExecutor {
             .map(|agg| agg.args[0].eval_array(&chunk))
             .try_collect()?;
 
-        for (state, expr) in states.iter_mut().zip(exprs) {
+        for (state, expr) in states.iter_mut().zip_eq(exprs) {
             state.update(&expr)?;
         }
 

--- a/src/executor/values.rs
+++ b/src/executor/values.rs
@@ -25,7 +25,7 @@ impl ValuesExecutor {
                 .collect_vec();
             // Push value into the builder.
             for row in chunk {
-                for (expr, builder) in row.iter().zip(&mut builders) {
+                for (expr, builder) in row.iter().zip_eq(&mut builders) {
                     let value = expr.eval();
                     builder.push(&value);
                 }

--- a/src/storage/secondary/rowset/mem_rowset.rs
+++ b/src/storage/secondary/rowset/mem_rowset.rs
@@ -58,7 +58,7 @@ impl MemTable for BTreeMapMemTable {
         for row_idx in 0..columns.cardinality() {
             self.multi_btree_map.insert(
                 ComparableDataValue(columns.array_at(self.primary_key_idx).get(row_idx)),
-                columns.get_row_by_idx(row_idx),
+                columns.row(row_idx).values().collect(),
             );
         }
         Ok(())


### PR DESCRIPTION
This PR refactors `NestedLoopJoin` and `HashJoin` executors, and adds outer join support to hash join.