### PR TITLE
feat(optimizer): join predicate 

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -192,7 +192,7 @@ impl PlanVisitor<BoxedExecutor> for ExecutorBuilder {
                 left_child,
                 right_child,
                 join_op: plan.logical().join_op(),
-                condition: plan.logical().condition().clone(),
+                condition: plan.logical().predicate().to_on_clause(),
                 left_types,
                 right_types,
             }
@@ -281,7 +281,7 @@ impl PlanVisitor<BoxedExecutor> for ExecutorBuilder {
                 left_child,
                 right_child,
                 join_op: plan.logical().join_op(),
-                condition: plan.logical().condition().clone(),
+                condition: plan.logical().predicate().to_on_clause(),
                 left_column_index: plan.left_column_index(),
                 right_column_index: plan.right_column_index(),
                 data_types: plan.out_types(),

--- a/src/executor/nested_loop_join.rs
+++ b/src/executor/nested_loop_join.rs
@@ -92,11 +92,13 @@ impl NestedLoopJoinExecutor {
             let right_row_num = right_rows().count();
             for (mut i, right_row) in right_rows().enumerate() {
                 // skip if the right row matches any left rows
+                let mut matched = false;
                 for _ in 0..left_row_num {
-                    if matches!(filter.get(i), Some(true)) {
-                        continue;
-                    }
+                    matched |= matches!(filter.get(i), Some(true));
                     i += right_row_num;
+                }
+                if matched {
+                    continue;
                 }
                 // append row: (NULL, right)
                 let values =

--- a/src/logical_planner/select.rs
+++ b/src/logical_planner/select.rs
@@ -116,7 +116,7 @@ impl LogicalPlaner {
                 for join_table in join_tables.iter() {
                     let table_plan =
                         self.plan_table_ref(&join_table.table_ref, with_row_handler, is_sorted)?;
-                    plan = Arc::new(LogicalJoin::new(
+                    plan = Arc::new(LogicalJoin::create(
                         plan,
                         table_plan,
                         join_table.join_op,

--- a/src/optimizer/expr_utils.rs
+++ b/src/optimizer/expr_utils.rs
@@ -32,7 +32,7 @@ pub fn merge_conjunctions<I>(iter: I) -> BoundExpr
 where
     I: Iterator<Item = BoundExpr>,
 {
-    let mut ret = BoundExpr::Constant(DataValue::Bool(false));
+    let mut ret = BoundExpr::Constant(DataValue::Bool(true));
     for expr in iter {
         ret = BoundExpr::BinaryOp(BoundBinaryOp {
             op: And,

--- a/src/optimizer/expr_utils.rs
+++ b/src/optimizer/expr_utils.rs
@@ -23,11 +23,6 @@ pub fn conjunctions(expr: BoundExpr) -> Vec<BoundExpr> {
     rets
 }
 
-#[allow(dead_code)]
-pub fn to_cnf(expr: BoundExpr) -> Vec<BoundExpr> {
-    // FIXME：TODO it is just convering to conjunctions now
-    conjunctions(expr)
-}
 pub fn merge_conjunctions<I>(iter: I) -> BoundExpr
 where
     I: Iterator<Item = BoundExpr>,
@@ -44,7 +39,6 @@ where
     ret
 }
 
-#[allow(dead_code)]
 pub fn input_col_refs(expr: &BoundExpr) -> BitSet {
     let mut set = BitSet::default();
     input_col_refs_inner(expr, &mut set);

--- a/src/optimizer/expr_utils.rs
+++ b/src/optimizer/expr_utils.rs
@@ -2,6 +2,7 @@
 
 use bit_set::BitSet;
 
+use super::logical_plan_rewriter::{BoolExprSimplificationRule, ExprRewriter};
 use crate::binder::BoundBinaryOp;
 use crate::optimizer::BoundExpr;
 use crate::optimizer::BoundExpr::BinaryOp;
@@ -36,6 +37,8 @@ where
             return_type: Some(DataTypeKind::Boolean.nullable()),
         })
     }
+    let rewriter = BoolExprSimplificationRule {};
+    rewriter.rewrite_expr(&mut ret);
     ret
 }
 

--- a/src/optimizer/logical_plan_rewriter/convert_physical.rs
+++ b/src/optimizer/logical_plan_rewriter/convert_physical.rs
@@ -3,8 +3,6 @@
 use super::super::plan_nodes::*;
 use super::*;
 use crate::binder::BoundJoinOperator;
-use crate::optimizer::BoundExpr::{BinaryOp, InputRef};
-use crate::parser::BinaryOperator;
 use crate::types::DataValue;
 /// Convert all logical plan nodes to physical.
 pub struct PhysicalConverter;

--- a/src/optimizer/logical_plan_rewriter/convert_physical.rs
+++ b/src/optimizer/logical_plan_rewriter/convert_physical.rs
@@ -40,7 +40,7 @@ impl PlanRewriter for PhysicalConverter {
             // the conditions as a filter operator. And this transformation is only correct for
             // inner join
             let on_clause = predicate.to_on_clause();
-
+            let left_col_num = left.out_types().len();
             let (left_column_index, right_column_index) = predicate.eq_keys()[0].clone();
             let join = Arc::new(PhysicalHashJoin::new(
                 LogicalJoin::create(
@@ -50,7 +50,7 @@ impl PlanRewriter for PhysicalConverter {
                     BoundExpr::Constant(DataValue::Bool(true)),
                 ),
                 left_column_index.index,
-                right_column_index.index,
+                right_column_index.index - left_col_num,
             ));
             return Arc::new(PhysicalFilter::new(LogicalFilter::new(on_clause, join)));
         }

--- a/src/optimizer/plan_nodes/join_predicate.rs
+++ b/src/optimizer/plan_nodes/join_predicate.rs
@@ -5,7 +5,7 @@ use crate::optimizer::expr_utils::{conjunctions, input_col_refs, merge_conjuncti
 use crate::optimizer::logical_plan_rewriter::ExprRewriter;
 use crate::optimizer::BoundExpr::InputRef;
 use crate::parser::BinaryOperator;
-use crate::types::{DataTypeExt, DataTypeKind};
+use crate::types::{DataTypeExt, DataTypeKind, DataValue};
 
 #[derive(Debug, Clone, Serialize)]
 /// the join predicate used in optimizer
@@ -60,6 +60,11 @@ impl JoinPredicate {
         let mut eq_keys = vec![];
 
         for cond in conds {
+            if let BoundExpr::Constant(DataValue::Bool(f)) = cond {
+                if f {
+                    continue;
+                }
+            }
             let cols = input_col_refs(&cond);
             let from_left = cols
                 .iter()

--- a/src/optimizer/plan_nodes/join_predicate.rs
+++ b/src/optimizer/plan_nodes/join_predicate.rs
@@ -163,9 +163,6 @@ impl JoinPredicate {
     ) -> Self {
         let mut new_cond = self.to_on_clause();
         rewriter.rewrite_expr(&mut new_cond);
-        dbg!(new_cond.clone());
-        dbg!(left_cols_num);
-
         Self::create(left_cols_num, new_cond)
     }
 }

--- a/src/optimizer/plan_nodes/join_predicate.rs
+++ b/src/optimizer/plan_nodes/join_predicate.rs
@@ -65,7 +65,7 @@ impl JoinPredicate {
                 .unwrap_or(false);
             let from_right = cols
                 .iter()
-                .min()
+                .max()
                 .map(|mx| mx >= left_cols_num)
                 .unwrap_or(false);
             match (from_left, from_right) {
@@ -160,6 +160,9 @@ impl JoinPredicate {
     ) -> Self {
         let mut new_cond = self.to_on_clause();
         rewriter.rewrite_expr(&mut new_cond);
+        dbg!(new_cond.clone());
+        dbg!(left_cols_num);
+
         Self::create(left_cols_num, new_cond)
     }
 }

--- a/src/optimizer/plan_nodes/join_predicate.rs
+++ b/src/optimizer/plan_nodes/join_predicate.rs
@@ -1,23 +1,38 @@
 use crate::binder::BoundExpr;
 use crate::optimizer::expr_utils::{conjunctions, input_col_refs};
+use crate::optimizer::BoundExpr::InputRef;
+use crate::parser::BinaryOperator;
 
 #[derive(Debug, Clone)]
 /// the join predicate used in optimizer
 pub struct JoinPredicate {
+    /// the conditions that all columns in the left side,
+    left_conds: Vec<BoundExpr>,
+    /// the conditions that all columns in the right side,
+    right_conds: Vec<BoundExpr>,
     /// other conditions, linked with AND conjunction.
-    /// 1. the non equal conditons
-    /// 2. the conditions in the same side,
     other_conds: Vec<BoundExpr>,
+
     /// the equal columns indexes(in the input schema) both sides, now all are normal equal(not
     /// null-safe-equal),
-    keys: Vec<(usize, usize)>,
+    eq_keys: Vec<(usize, usize)>,
 }
 #[allow(dead_code)]
 impl JoinPredicate {
-    /// the new method for `JoinPredicate` without any analysis, check or rewrite.
-    pub fn new(other_conds: Vec<BoundExpr>, keys: Vec<(usize, usize)>) -> Self {
-        JoinPredicate { other_conds, keys }
+    pub fn new(
+        other_conds: Vec<BoundExpr>,
+        left_conds: Vec<BoundExpr>,
+        right_conds: Vec<BoundExpr>,
+        eq_keys: Vec<(usize, usize)>,
+    ) -> Self {
+        Self {
+            left_conds,
+            right_conds,
+            other_conds,
+            eq_keys,
+        }
     }
+
     /// `create` will analyze the on clause condition and construct a `JoinPredicate`.
     /// e.g.
     /// ```sql
@@ -31,37 +46,78 @@ impl JoinPredicate {
     /// And the `create funcitons` should return `JoinPredicate`
     /// ```sql
     ///   other_conds = Vec[input_ref(1) = input_ref(1), input_ref(1) > input_ref(3)],
-    ///   keys= Vec[(1,1)]
+    ///   eq_keys= Vec[(1,1)]
     /// ```
     pub fn create(left_cols_num: usize, on_clause: BoundExpr) -> Self {
         let conds = conjunctions(on_clause);
+        let mut other_conds = vec![];
+        let mut left_conds = vec![];
+        let mut right_conds = vec![];
+        let mut eq_keys = vec![];
+
         for cond in conds {
             let cols = input_col_refs(&cond);
+            let from_left = cols
+                .iter()
+                .min()
+                .map(|mx| mx < left_cols_num)
+                .unwrap_or(false);
+            let from_right = cols
+                .iter()
+                .min()
+                .map(|mx| mx >= left_cols_num)
+                .unwrap_or(false);
+            match (from_left, from_right) {
+                (true, true) => {
+                    // TODO: refactor with if_chain
+                    let is_other = true;
+                    if let BoundExpr::BinaryOp(op) = &cond {
+                        match (&op.op, &*op.left_expr, &*op.right_expr) {
+                            // TODO: if the eq condition's input is another expression, we should
+                            // insert project as the join's input plan node
+                            (BinaryOperator::Eq, InputRef(x), InputRef(y)) => {
+                                let l = x.index.min(y.index);
+                                let r = x.index.max(y.index);
+                                eq_keys.push((l, r));
+                            }
+                            _ => {}
+                        }
+                    }
+                    if is_other {
+                        other_conds.push(cond)
+                    }
+                }
+                (true, false) => left_conds.push(cond),
+                (false, true) => right_conds.push(cond),
+                (false, false) => other_conds.push(cond),
+            }
         }
-        todo!()
+        Self::new(other_conds, left_conds, right_conds, eq_keys)
     }
 
-    /// check if the `JoinPredicate` only include equal conditions, because now our hash join and
-    /// stream join executor just support join predicate only with equi-conditions
-    pub fn is_equal_cond(&self) -> bool {
-        self.other_conds.is_empty()
-    }
-    pub fn equal_keys(&self) -> Vec<(usize, usize)> {
-        self.keys.clone()
-    }
-    pub fn left_keys(&self) -> Vec<usize> {
-        self.keys.iter().map(|(left, _)| *left).collect()
-    }
-    pub fn right_keys(&self) -> Vec<usize> {
-        self.keys.iter().map(|(_, right)| *right).collect()
-    }
-
-    /// Get a reference to the join predicate's other conds.
-    pub fn other_conds(&self) -> &[BoundExprImpl] {
+    /// Get a reference to the join predicate's non eq conds.
+    pub fn other_conds(&self) -> &[BoundExpr] {
         self.other_conds.as_ref()
     }
-    // TODO: our backend not support some equal columns and sonm NonEqual condition
-    //   fn has_equal_cond(&self) ->bool{
-    //     todo!()
-    //   }
+
+    /// Get a reference to the join predicate's left conds.
+    pub fn left_conds(&self) -> &[BoundExpr] {
+        self.left_conds.as_ref()
+    }
+
+    /// Get a reference to the join predicate's right conds.
+    pub fn right_conds(&self) -> &[BoundExpr] {
+        self.right_conds.as_ref()
+    }
+
+    /// Get a reference to the join predicate's eq keys.
+    pub fn eq_keys(&self) -> &[(usize, usize)] {
+        self.eq_keys.as_ref()
+    }
+    pub fn left_eq_keys(&self) -> Vec<usize> {
+        self.eq_keys.iter().map(|(left, _)| *left).collect()
+    }
+    pub fn right_eq_keys(&self) -> Vec<usize> {
+        self.eq_keys.iter().map(|(_, right)| *right).collect()
+    }
 }

--- a/src/optimizer/plan_nodes/join_predicate.rs
+++ b/src/optimizer/plan_nodes/join_predicate.rs
@@ -38,8 +38,8 @@ impl JoinPredicate {
     /// ```sql
     ///   select a.v1, a.v2, b.v1, b.v2 from a,b on a.v1 = a.v2 and a.v1 = b.v1 and a.v2 > b.v2
     /// ```
-    /// will call the `create` function with left_colsnum = 2 and on_clause is (supposed input_ref
-    /// count start from 0)
+    /// will call the `create` function with `left_colsnum` = 2 and `on_clause` is (supposed
+    /// `input_ref` count start from 0)
     /// ```sql
     /// input_ref(0) = input_ref(1) and input_ref(0) = input_ref(2) and input_ref(1) > input_ref(3)
     /// ```
@@ -70,17 +70,17 @@ impl JoinPredicate {
             match (from_left, from_right) {
                 (true, true) => {
                     // TODO: refactor with if_chain
-                    let is_other = true;
+                    let mut is_other = true;
                     if let BoundExpr::BinaryOp(op) = &cond {
-                        match (&op.op, &*op.left_expr, &*op.right_expr) {
-                            // TODO: if the eq condition's input is another expression, we should
-                            // insert project as the join's input plan node
-                            (BinaryOperator::Eq, InputRef(x), InputRef(y)) => {
-                                let l = x.index.min(y.index);
-                                let r = x.index.max(y.index);
-                                eq_keys.push((l, r));
-                            }
-                            _ => {}
+                        // TODO: if the eq condition's input is another expression, we should
+                        // insert project as the join's input plan node
+                        if let (BinaryOperator::Eq, InputRef(x), InputRef(y)) =
+                            (&op.op, &*op.left_expr, &*op.right_expr)
+                        {
+                            let l = x.index.min(y.index);
+                            let r = x.index.max(y.index);
+                            eq_keys.push((l, r));
+                            is_other = false;
                         }
                     }
                     if is_other {

--- a/src/optimizer/plan_nodes/join_predicate.rs
+++ b/src/optimizer/plan_nodes/join_predicate.rs
@@ -1,0 +1,67 @@
+use crate::binder::BoundExpr;
+use crate::optimizer::expr_utils::{conjunctions, input_col_refs};
+
+#[derive(Debug, Clone)]
+/// the join predicate used in optimizer
+pub struct JoinPredicate {
+    /// other conditions, linked with AND conjunction.
+    /// 1. the non equal conditons
+    /// 2. the conditions in the same side,
+    other_conds: Vec<BoundExpr>,
+    /// the equal columns indexes(in the input schema) both sides, now all are normal equal(not
+    /// null-safe-equal),
+    keys: Vec<(usize, usize)>,
+}
+#[allow(dead_code)]
+impl JoinPredicate {
+    /// the new method for `JoinPredicate` without any analysis, check or rewrite.
+    pub fn new(other_conds: Vec<BoundExpr>, keys: Vec<(usize, usize)>) -> Self {
+        JoinPredicate { other_conds, keys }
+    }
+    /// `create` will analyze the on clause condition and construct a `JoinPredicate`.
+    /// e.g.
+    /// ```sql
+    ///   select a.v1, a.v2, b.v1, b.v2 from a,b on a.v1 = a.v2 and a.v1 = b.v1 and a.v2 > b.v2
+    /// ```
+    /// will call the `create` function with left_colsnum = 2 and on_clause is (supposed input_ref
+    /// count start from 0)
+    /// ```sql
+    /// input_ref(0) = input_ref(1) and input_ref(0) = input_ref(2) and input_ref(1) > input_ref(3)
+    /// ```
+    /// And the `create funcitons` should return `JoinPredicate`
+    /// ```sql
+    ///   other_conds = Vec[input_ref(1) = input_ref(1), input_ref(1) > input_ref(3)],
+    ///   keys= Vec[(1,1)]
+    /// ```
+    pub fn create(left_cols_num: usize, on_clause: BoundExpr) -> Self {
+        let conds = conjunctions(on_clause);
+        for cond in conds {
+            let cols = input_col_refs(&cond);
+        }
+        todo!()
+    }
+
+    /// check if the `JoinPredicate` only include equal conditions, because now our hash join and
+    /// stream join executor just support join predicate only with equi-conditions
+    pub fn is_equal_cond(&self) -> bool {
+        self.other_conds.is_empty()
+    }
+    pub fn equal_keys(&self) -> Vec<(usize, usize)> {
+        self.keys.clone()
+    }
+    pub fn left_keys(&self) -> Vec<usize> {
+        self.keys.iter().map(|(left, _)| *left).collect()
+    }
+    pub fn right_keys(&self) -> Vec<usize> {
+        self.keys.iter().map(|(_, right)| *right).collect()
+    }
+
+    /// Get a reference to the join predicate's other conds.
+    pub fn other_conds(&self) -> &[BoundExprImpl] {
+        self.other_conds.as_ref()
+    }
+    // TODO: our backend not support some equal columns and sonm NonEqual condition
+    //   fn has_equal_cond(&self) ->bool{
+    //     todo!()
+    //   }
+}

--- a/src/optimizer/plan_nodes/join_predicate.rs
+++ b/src/optimizer/plan_nodes/join_predicate.rs
@@ -166,3 +166,8 @@ impl JoinPredicate {
         Self::create(left_cols_num, new_cond)
     }
 }
+impl std::fmt::Display for JoinPredicate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.to_on_clause())
+    }
+}

--- a/src/optimizer/plan_nodes/join_predicate.rs
+++ b/src/optimizer/plan_nodes/join_predicate.rs
@@ -1,10 +1,13 @@
+use serde::Serialize;
+
 use crate::binder::{BoundBinaryOp, BoundExpr, BoundInputRef};
 use crate::optimizer::expr_utils::{conjunctions, input_col_refs, merge_conjunctions};
 use crate::optimizer::logical_plan_rewriter::ExprRewriter;
 use crate::optimizer::BoundExpr::InputRef;
 use crate::parser::BinaryOperator;
 use crate::types::{DataTypeExt, DataTypeKind};
-#[derive(Debug, Clone)]
+
+#[derive(Debug, Clone, Serialize)]
 /// the join predicate used in optimizer
 pub struct JoinPredicate {
     /// the conditions that all columns in the left side,

--- a/src/optimizer/plan_nodes/mod.rs
+++ b/src/optimizer/plan_nodes/mod.rs
@@ -13,6 +13,8 @@ use crate::types::DataType;
 #[macro_use]
 mod plan_tree_node;
 pub use plan_tree_node::*;
+mod join_predicate;
+pub use join_predicate::*;
 
 /// The common trait over all plan nodes.
 pub trait PlanNode:

--- a/src/optimizer/plan_nodes/physical_hash_join.rs
+++ b/src/optimizer/plan_nodes/physical_hash_join.rs
@@ -66,9 +66,9 @@ impl fmt::Display for PhysicalHashJoin {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(
             f,
-            "PhysicalHashJoin: op {:?}, condition: {:?}",
+            "PhysicalHashJoin: op {:?}, predicate: {:?}",
             self.logical().join_op(),
-            self.logical().condition()
+            self.logical().predicate()
         )
     }
 }

--- a/src/optimizer/plan_nodes/physical_hash_join.rs
+++ b/src/optimizer/plan_nodes/physical_hash_join.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 
 /// The phyiscal plan of join.
@@ -66,8 +68,10 @@ impl fmt::Display for PhysicalHashJoin {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(
             f,
-            "PhysicalHashJoin: op {:?}, predicate: {:?}",
+            "PhysicalHashJoin: op {:?}, left_index {:?},  right_index {:?}, predicate: {} ",
             self.logical().join_op(),
+            self.left_column_index,
+            self.right_column_index,
             self.logical().predicate()
         )
     }

--- a/src/optimizer/plan_nodes/physical_nested_loop_join.rs
+++ b/src/optimizer/plan_nodes/physical_nested_loop_join.rs
@@ -46,9 +46,9 @@ impl fmt::Display for PhysicalNestedLoopJoin {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(
             f,
-            "PhysicalNestedLoopJoin: op {:?}, condition: {:?}",
+            "PhysicalNestedLoopJoin: op {:?}, predicate: {:?}",
             self.logical().join_op(),
-            self.logical().condition()
+            self.logical().predicate()
         )
     }
 }

--- a/src/optimizer/plan_nodes/physical_nested_loop_join.rs
+++ b/src/optimizer/plan_nodes/physical_nested_loop_join.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 
 /// The phyiscal plan of join.
@@ -46,7 +48,7 @@ impl fmt::Display for PhysicalNestedLoopJoin {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(
             f,
-            "PhysicalNestedLoopJoin: op {:?}, predicate: {:?}",
+            "PhysicalNestedLoopJoin: op {:?}, predicate: {}",
             self.logical().join_op(),
             self.logical().predicate()
         )

--- a/src/optimizer/rules/filter_join_rule.rs
+++ b/src/optimizer/rules/filter_join_rule.rs
@@ -60,10 +60,6 @@ impl Rule for FilterJoinRule {
                     .chain(inner_join_predicate.other_conds().iter().cloned()),
             ),
         ));
-        // FIXME:
-        // Currently HashJoinExecutor ignores the condition,
-        // so for correctness we have to keep filter operator.
-        let new_filter = Arc::new(LogicalFilter::new(filter.expr().clone(), new_join));
-        Ok(new_filter)
+        Ok(new_join)
     }
 }

--- a/src/optimizer/rules/filter_join_rule.rs
+++ b/src/optimizer/rules/filter_join_rule.rs
@@ -3,9 +3,10 @@
 use std::sync::Arc;
 
 use super::*;
-use crate::binder::BoundExpr;
+use crate::binder::{BoundExpr, BoundJoinOperator};
+use crate::optimizer::expr_utils::merge_conjunctions;
 use crate::optimizer::plan_nodes::{
-    LogicalFilter, LogicalJoin, PlanTreeNodeBinary, PlanTreeNodeUnary,
+    JoinPredicate, LogicalFilter, LogicalJoin, PlanTreeNodeBinary, PlanTreeNodeUnary,
 };
 use crate::optimizer::BoundBinaryOp;
 use crate::parser::BinaryOperator::And;
@@ -18,42 +19,51 @@ impl Rule for FilterJoinRule {
         let filter = plan.as_logical_filter()?;
         let child = filter.child();
         let join = child.as_logical_join()?;
-        let join_cond = BoundExpr::BinaryOp(BoundBinaryOp {
+        if join.join_op() != BoundJoinOperator::Inner {
+            return Err(());
+        }
+        let filter_cond = filter.expr().clone();
+        let join_on_clause = join.predicate().to_on_clause();
+        let new_inner_join_cond = BoundExpr::BinaryOp(BoundBinaryOp {
             op: And,
-            left_expr: Box::new(join.condition().clone()),
-            right_expr: Box::new(filter.expr().clone()),
+            left_expr: Box::new(filter_cond),
+            right_expr: Box::new(join_on_clause),
             return_type: Some(DataTypeKind::Boolean.nullable()),
         });
-        let new_join = Arc::new(LogicalJoin::new(
-            join.left().clone(),
-            join.right().clone(),
+        let inner_join_predicate =
+            JoinPredicate::create(join.left().out_types().len(), new_inner_join_cond);
+        let left = if inner_join_predicate.left_conds().is_empty() {
+            join.left()
+        } else {
+            Arc::new(LogicalFilter::new(
+                merge_conjunctions(inner_join_predicate.left_conds().iter().cloned()),
+                join.left(),
+            ))
+        };
+        let right = if inner_join_predicate.right_conds().is_empty() {
+            join.right()
+        } else {
+            Arc::new(LogicalFilter::new(
+                merge_conjunctions(inner_join_predicate.right_conds().iter().cloned()),
+                join.right(),
+            ))
+        };
+
+        let new_join = Arc::new(LogicalJoin::create(
+            left,
+            right,
             join.join_op(),
-            join_cond,
+            merge_conjunctions(
+                inner_join_predicate
+                    .eq_conds()
+                    .into_iter()
+                    .chain(inner_join_predicate.other_conds().iter().cloned()),
+            ),
         ));
         // FIXME:
         // Currently HashJoinExecutor ignores the condition,
         // so for correctness we have to keep filter operator.
         let new_filter = Arc::new(LogicalFilter::new(filter.expr().clone(), new_join));
         Ok(new_filter)
-
-        // TODO: we need schema of operator to push condition to each side.
-        // let filter_conds = to_cnf(filter.expr.clone());
-        // let join_cond = match join.join_op {
-        //     Inner(On(op)) => op.clone(),
-        //     _ => unreachable!(),
-        // };
-        // let join_conds = to_cnf(join_cond);
-        // let left_filter_expr = vec![];
-        // let right_filter_expr = vec![];
-        // let join_filter_expr = vec![];
-
-        // for cond in filter_conds.into_iter().chain(join_conds.into_iter()) {
-        //     let input_refs = input_col_refs(&cond);
-        //     let in_left = false;
-        //     let in_right = false;
-        //     for index in input_refs.iter() {
-        //         if(index <=)
-        //     }
-        // }
     }
 }


### PR DESCRIPTION
 - refactor join predicate 
 - fix hash join determine 
 - inner join predicate push down 
 - fix a bug in `NestedLoopJoinExecutor`

And after that, our TPC-H Q3 is optimal with HashJoin
```
+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| PhysicalLimit: offset: 0, limit: 10                                                                                                                       |
|   PhysicalOrder: [InputRef #1 (desc), InputRef #2 (asc)]                                                                                                  |
|     PhysicalProjection: exprs [InputRef #0, InputRef #3 (alias to revenue), InputRef #1, InputRef #2]                                                     |
|       PhysicalHashAgg: 1 agg calls                                                                                                                        |
|         PhysicalHashJoin: op Inner, left_index 3,  right_index 0, predicate: Bool(true) (const)                                                           |
|           PhysicalHashJoin: op Inner, left_index 1,  right_index 0, predicate: Bool(true) (const)                                                         |
|             PhysicalTableScan: table #5, columns [6, 0], with_row_handler: false, is_sorted: false, expr: Eq(InputRef #0, String("BUILDING") (const))     |
|             PhysicalTableScan: table #6, columns [1, 0, 4, 7], with_row_handler: false, is_sorted: false, expr: Lt(InputRef #2, Date(Date(9204)) (const)) |
|           PhysicalTableScan: table #7, columns [0, 10, 5, 6], with_row_handler: false, is_sorted: false, expr: Gt(InputRef #1, Date(Date(9204)) (const))  |
|                                                                                                                                                           |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
```