### PR TITLE
feat(optimizer): add exchange plan

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -344,4 +344,9 @@ impl PlanVisitor<BoxedExecutor> for ExecutorBuilder {
             .execute(),
         )
     }
+
+    fn visit_physical_exchange(&mut self, plan: &PhysicalExchange) -> Option<BoxedExecutor> {
+        // Exchange is currently a no-op, will add a ExchangeExecutor later.
+        Some(self.visit(plan.child()).unwrap())
+    }
 }

--- a/src/optimizer/logical_plan_rewriter/convert_physical.rs
+++ b/src/optimizer/logical_plan_rewriter/convert_physical.rs
@@ -128,4 +128,8 @@ impl PlanRewriter for PhysicalConverter {
             Arc::new(PhysicalHashAgg::new(logical))
         }
     }
+
+    fn rewrite_logical_exchange(&mut self, logical: &LogicalExchange) -> PlanRef {
+        Arc::new(PhysicalExchange::new(self.rewrite(logical.child())))
+    }
 }

--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -36,7 +36,8 @@ impl Optimizer {
         plan = arith_expr_simplification_rule.rewrite(plan);
         plan = bool_expr_simplification_rule.rewrite(plan);
         plan = constant_moving_rule.rewrite(plan);
-        let mut rules: Vec<Box<(dyn rules::Rule + 'static)>> = vec![Box::new(FilterJoinRule {})];
+        let mut rules: Vec<Box<(dyn rules::Rule + 'static)>> =
+            vec![Box::new(FilterJoinRule {}), Box::new(ExchangeRule)];
         if self.enable_filter_scan {
             rules.push(Box::new(FilterScanRule {}));
         }

--- a/src/optimizer/plan_nodes/logical_exchange.rs
+++ b/src/optimizer/plan_nodes/logical_exchange.rs
@@ -1,0 +1,40 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::fmt;
+use serde::{Serialize};
+use super::*;
+
+/// The logical plan of exchange.
+#[derive(Debug, Clone, Serialize)]
+pub struct LogicalExchange {
+    plan: PlanRef,
+}
+
+impl LogicalExchange {
+    pub fn new(plan: PlanRef) -> Self {
+        Self { plan }
+    }
+
+    /// Get a reference to the logical explain's plan.
+    pub fn plan(&self) -> &dyn PlanNode {
+        self.plan.as_ref()
+    }
+}
+impl PlanTreeNodeUnary for LogicalExchange {
+    fn child(&self) -> PlanRef {
+        self.plan.clone()
+    }
+    #[must_use]
+    fn clone_with_child(&self, child: PlanRef) -> Self {
+        Self::new(child)
+    }
+}
+impl_plan_tree_node_for_unary!(LogicalExchange);
+
+impl PlanNode for LogicalExchange {}
+
+impl fmt::Display for LogicalExchange {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "Exchange:")
+    }
+}

--- a/src/optimizer/plan_nodes/logical_table_scan.rs
+++ b/src/optimizer/plan_nodes/logical_table_scan.rs
@@ -1,8 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
 use itertools::Itertools;
+use serde::Serialize;
 
 use super::*;
 use crate::catalog::{ColumnDesc, TableRefId};
@@ -16,6 +17,7 @@ pub struct LogicalTableScan {
     with_row_handler: bool,
     is_sorted: bool,
     expr: Option<BoundExpr>,
+    exchanged: bool,
 }
 
 impl LogicalTableScan {
@@ -34,6 +36,7 @@ impl LogicalTableScan {
             with_row_handler,
             is_sorted,
             expr,
+            exchanged: false,
         }
     }
 
@@ -65,6 +68,17 @@ impl LogicalTableScan {
     /// Get a reference to the logical table scan's expr.
     pub fn expr(&self) -> Option<&BoundExpr> {
         self.expr.as_ref()
+    }
+
+    /// Check if the plan node is already being exchanged
+    pub fn exchanged(&self) -> bool {
+        self.exchanged
+    }
+
+    #[must_use]
+    pub fn exchange(mut self) -> Self {
+        self.exchanged = true;
+        self
     }
 }
 impl PlanTreeNodeLeaf for LogicalTableScan {}

--- a/src/optimizer/plan_nodes/mod.rs
+++ b/src/optimizer/plan_nodes/mod.rs
@@ -74,6 +74,7 @@ macro_rules! for_all_plan_nodes {
             LogicalDelete,
             LogicalCopyFromFile,
             LogicalCopyToFile,
+            LogicalExchange,
             PhysicalTableScan,
             PhysicalInsert,
             PhysicalValues,
@@ -90,7 +91,8 @@ macro_rules! for_all_plan_nodes {
             PhysicalLimit,
             PhysicalDelete,
             PhysicalCopyFromFile,
-            PhysicalCopyToFile
+            PhysicalCopyToFile,
+            PhysicalExchange
         }
     };
 }

--- a/src/optimizer/plan_nodes/physical_exchange.rs
+++ b/src/optimizer/plan_nodes/physical_exchange.rs
@@ -1,0 +1,36 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::fmt;
+
+use serde::Serialize;
+
+use super::*;
+
+/// The physical plan of exchange.
+#[derive(Debug, Clone, Serialize)]
+pub struct PhysicalExchange {
+    child: PlanRef,
+}
+
+impl PhysicalExchange {
+    pub fn new(child: PlanRef) -> Self {
+        Self { child }
+    }
+}
+
+impl PlanTreeNodeUnary for PhysicalExchange {
+    fn child(&self) -> PlanRef {
+        self.child.clone()
+    }
+    #[must_use]
+    fn clone_with_child(&self, child: PlanRef) -> Self {
+        Self { child }
+    }
+}
+impl_plan_tree_node_for_unary!(PhysicalExchange);
+impl PlanNode for PhysicalExchange {}
+impl fmt::Display for PhysicalExchange {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "PhysicalExchange:")
+    }
+}

--- a/src/optimizer/rules/exchange_rule.rs
+++ b/src/optimizer/rules/exchange_rule.rs
@@ -1,0 +1,21 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use super::*;
+use crate::optimizer::plan_nodes::LogicalExchange;
+
+pub struct ExchangeRule;
+
+impl Rule for ExchangeRule {
+    fn apply(&self, plan: PlanRef) -> Result<PlanRef, ()> {
+        let table_scan = plan.as_logical_table_scan()?;
+        if !table_scan.exchanged() {
+            Ok(Arc::new(LogicalExchange::new(Arc::new(
+                table_scan.clone().exchange(),
+            ))))
+        } else {
+            Err(())
+        }
+    }
+}

--- a/src/optimizer/rules/mod.rs
+++ b/src/optimizer/rules/mod.rs
@@ -2,8 +2,11 @@
 
 use super::plan_nodes::PlanRef;
 
+mod exchange_rule;
 mod filter_join_rule;
 mod filter_scan_rule;
+
+pub use exchange_rule::*;
 pub use filter_join_rule::*;
 pub use filter_scan_rule::*;
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

part of https://github.com/risinglightdb/risinglight/issues/366

As the optimizer will visit children recursively, we have to set a `exchanged` flag on `LogicalTableScan`, so that it won't be exchanged further.

Not sure if this is the correct way to do this. Any way to stop iteration (or finish the rule)?