### PR TITLE
fix(optimizer): manually import all plan nodes

### DIFF
--- a/src/optimizer/plan_nodes/dummy.rs
+++ b/src/optimizer/plan_nodes/dummy.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 
 /// A dummy plan.

--- a/src/optimizer/plan_nodes/logical_aggregate.rs
+++ b/src/optimizer/plan_nodes/logical_aggregate.rs
@@ -1,7 +1,8 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
 
 use super::*;
 use crate::binder::{BoundAggCall, BoundExpr};

--- a/src/optimizer/plan_nodes/logical_copy_from_file.rs
+++ b/src/optimizer/plan_nodes/logical_copy_from_file.rs
@@ -1,8 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
 use std::path::PathBuf;
+
+use serde::Serialize;
 
 use super::*;
 use crate::binder::statement::copy::FileFormat;

--- a/src/optimizer/plan_nodes/logical_copy_to_file.rs
+++ b/src/optimizer/plan_nodes/logical_copy_to_file.rs
@@ -2,7 +2,8 @@
 
 use std::fmt;
 use std::path::PathBuf;
-use serde::{Serialize};
+
+use serde::Serialize;
 
 use super::*;
 use crate::binder::statement::copy::FileFormat;

--- a/src/optimizer/plan_nodes/logical_create_table.rs
+++ b/src/optimizer/plan_nodes/logical_create_table.rs
@@ -1,8 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
 use itertools::Itertools;
+use serde::Serialize;
 
 use super::*;
 use crate::catalog::ColumnCatalog;

--- a/src/optimizer/plan_nodes/logical_delete.rs
+++ b/src/optimizer/plan_nodes/logical_delete.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 use crate::catalog::TableRefId;
 

--- a/src/optimizer/plan_nodes/logical_drop.rs
+++ b/src/optimizer/plan_nodes/logical_drop.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 use crate::binder::statement::drop::Object;
 

--- a/src/optimizer/plan_nodes/logical_explain.rs
+++ b/src/optimizer/plan_nodes/logical_explain.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 
 /// The logical plan of `EXPLAIN`.

--- a/src/optimizer/plan_nodes/logical_filter.rs
+++ b/src/optimizer/plan_nodes/logical_filter.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 use crate::binder::BoundExpr;
 use crate::optimizer::logical_plan_rewriter::ExprRewriter;

--- a/src/optimizer/plan_nodes/logical_insert.rs
+++ b/src/optimizer/plan_nodes/logical_insert.rs
@@ -1,8 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
 use itertools::Itertools;
+use serde::Serialize;
 
 use super::*;
 use crate::catalog::TableRefId;

--- a/src/optimizer/plan_nodes/logical_join.rs
+++ b/src/optimizer/plan_nodes/logical_join.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 use crate::binder::BoundJoinOperator;
 use crate::optimizer::logical_plan_rewriter::ExprRewriter;

--- a/src/optimizer/plan_nodes/logical_limit.rs
+++ b/src/optimizer/plan_nodes/logical_limit.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 
 /// The logical plan of limit operation.

--- a/src/optimizer/plan_nodes/logical_order.rs
+++ b/src/optimizer/plan_nodes/logical_order.rs
@@ -1,7 +1,8 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
 
 use super::*;
 use crate::binder::BoundOrderBy;

--- a/src/optimizer/plan_nodes/logical_projection.rs
+++ b/src/optimizer/plan_nodes/logical_projection.rs
@@ -1,7 +1,8 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
 
 use super::*;
 use crate::binder::BoundExpr;

--- a/src/optimizer/plan_nodes/logical_table_scan.rs
+++ b/src/optimizer/plan_nodes/logical_table_scan.rs
@@ -1,8 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
 use itertools::Itertools;
+use serde::Serialize;
 
 use super::*;
 use crate::catalog::{ColumnDesc, TableRefId};

--- a/src/optimizer/plan_nodes/logical_values.rs
+++ b/src/optimizer/plan_nodes/logical_values.rs
@@ -1,7 +1,8 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
 
 use super::*;
 use crate::binder::BoundExpr;

--- a/src/optimizer/plan_nodes/mod.rs
+++ b/src/optimizer/plan_nodes/mod.rs
@@ -11,11 +11,81 @@ use paste::paste;
 
 use crate::binder::BoundExpr;
 use crate::types::DataType;
-#[macro_use]
+
 mod plan_tree_node;
 pub use plan_tree_node::*;
 mod join_predicate;
 pub use join_predicate::*;
+
+// Import and use all plan nodes
+
+mod dummy;
+mod logical_aggregate;
+mod logical_copy_from_file;
+mod logical_copy_to_file;
+mod logical_create_table;
+mod logical_delete;
+mod logical_drop;
+mod logical_explain;
+mod logical_filter;
+mod logical_insert;
+mod logical_join;
+mod logical_limit;
+mod logical_order;
+mod logical_projection;
+mod logical_table_scan;
+mod logical_values;
+mod physical_copy_from_file;
+mod physical_copy_to_file;
+mod physical_create_table;
+mod physical_delete;
+mod physical_drop;
+mod physical_explain;
+mod physical_filter;
+mod physical_hash_agg;
+mod physical_hash_join;
+mod physical_insert;
+mod physical_limit;
+mod physical_nested_loop_join;
+mod physical_order;
+mod physical_projection;
+mod physical_simple_agg;
+mod physical_table_scan;
+mod physical_values;
+
+pub use dummy::*;
+pub use logical_aggregate::*;
+pub use logical_copy_from_file::*;
+pub use logical_copy_to_file::*;
+pub use logical_create_table::*;
+pub use logical_delete::*;
+pub use logical_drop::*;
+pub use logical_explain::*;
+pub use logical_filter::*;
+pub use logical_insert::*;
+pub use logical_join::*;
+pub use logical_limit::*;
+pub use logical_order::*;
+pub use logical_projection::*;
+pub use logical_table_scan::*;
+pub use logical_values::*;
+pub use physical_copy_from_file::*;
+pub use physical_copy_to_file::*;
+pub use physical_create_table::*;
+pub use physical_delete::*;
+pub use physical_drop::*;
+pub use physical_explain::*;
+pub use physical_filter::*;
+pub use physical_hash_agg::*;
+pub use physical_hash_join::*;
+pub use physical_insert::*;
+pub use physical_limit::*;
+pub use physical_nested_loop_join::*;
+pub use physical_order::*;
+pub use physical_projection::*;
+pub use physical_simple_agg::*;
+pub use physical_table_scan::*;
+pub use physical_values::*;
 
 /// The common trait over all plan nodes.
 pub trait PlanNode:
@@ -94,17 +164,6 @@ macro_rules! for_all_plan_nodes {
         }
     };
 }
-
-/// Define module for each node.
-macro_rules! def_mod_and_use {
-    ([], $($node_name:ty),*) => {
-        $(paste! {
-            mod [<$node_name:snake>];
-            pub use [<$node_name:snake>]::*;
-        })*
-    }
-}
-for_all_plan_nodes! { def_mod_and_use }
 
 pub trait WithPlanNodeType {
     fn node_type(&self) -> PlanNodeType;

--- a/src/optimizer/plan_nodes/physical_copy_from_file.rs
+++ b/src/optimizer/plan_nodes/physical_copy_from_file.rs
@@ -1,11 +1,10 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
 
 use super::*;
-
-
 
 /// The physical plan of `COPY FROM`.
 #[derive(Debug, Clone, Serialize)]

--- a/src/optimizer/plan_nodes/physical_copy_to_file.rs
+++ b/src/optimizer/plan_nodes/physical_copy_to_file.rs
@@ -1,11 +1,10 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
 
 use super::*;
-
-
 
 /// The physical plan of `COPY TO`.
 #[derive(Debug, Clone, Serialize)]

--- a/src/optimizer/plan_nodes/physical_create_table.rs
+++ b/src/optimizer/plan_nodes/physical_create_table.rs
@@ -1,12 +1,11 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
 use itertools::Itertools;
+use serde::Serialize;
 
 use super::*;
-
-
 
 /// The physical plan of `CREATE TABLE`.
 #[derive(Debug, Clone, Serialize)]

--- a/src/optimizer/plan_nodes/physical_delete.rs
+++ b/src/optimizer/plan_nodes/physical_delete.rs
@@ -1,9 +1,10 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
-use super::*;
 
+use serde::Serialize;
+
+use super::*;
 
 /// The physical plan of `DELETE`.
 #[derive(Debug, Clone, Serialize)]

--- a/src/optimizer/plan_nodes/physical_drop.rs
+++ b/src/optimizer/plan_nodes/physical_drop.rs
@@ -1,9 +1,10 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
-use super::*;
 
+use serde::Serialize;
+
+use super::*;
 
 /// The physical plan of `DROP`.
 #[derive(Debug, Clone, Serialize)]

--- a/src/optimizer/plan_nodes/physical_explain.rs
+++ b/src/optimizer/plan_nodes/physical_explain.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 
 /// The physical plan of `EXPLAIN`.

--- a/src/optimizer/plan_nodes/physical_filter.rs
+++ b/src/optimizer/plan_nodes/physical_filter.rs
@@ -1,9 +1,10 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
-use super::*;
 
+use serde::Serialize;
+
+use super::*;
 
 /// The physical plan of filter operation.
 #[derive(Debug, Clone, Serialize)]

--- a/src/optimizer/plan_nodes/physical_hash_agg.rs
+++ b/src/optimizer/plan_nodes/physical_hash_agg.rs
@@ -1,9 +1,10 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
-use super::*;
 
+use serde::Serialize;
+
+use super::*;
 
 /// The physical plan of hash aggregation.
 #[derive(Debug, Clone, Serialize)]

--- a/src/optimizer/plan_nodes/physical_insert.rs
+++ b/src/optimizer/plan_nodes/physical_insert.rs
@@ -1,12 +1,11 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
 use itertools::Itertools;
+use serde::Serialize;
 
 use super::*;
-
-
 
 /// The physical plan of `INSERT`.
 #[derive(Debug, Clone, Serialize)]

--- a/src/optimizer/plan_nodes/physical_limit.rs
+++ b/src/optimizer/plan_nodes/physical_limit.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 
 /// The physical plan of limit operation.

--- a/src/optimizer/plan_nodes/physical_order.rs
+++ b/src/optimizer/plan_nodes/physical_order.rs
@@ -1,9 +1,10 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
-use super::*;
 
+use serde::Serialize;
+
+use super::*;
 
 /// The physical plan of order.
 #[derive(Debug, Clone, Serialize)]

--- a/src/optimizer/plan_nodes/physical_projection.rs
+++ b/src/optimizer/plan_nodes/physical_projection.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 
 /// The physical plan of project operation.

--- a/src/optimizer/plan_nodes/physical_simple_agg.rs
+++ b/src/optimizer/plan_nodes/physical_simple_agg.rs
@@ -1,7 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
+use serde::Serialize;
+
 use super::*;
 use crate::binder::BoundAggCall;
 

--- a/src/optimizer/plan_nodes/physical_table_scan.rs
+++ b/src/optimizer/plan_nodes/physical_table_scan.rs
@@ -1,8 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
+
 use itertools::Itertools;
+use serde::Serialize;
 
 use super::*;
 

--- a/src/optimizer/plan_nodes/physical_values.rs
+++ b/src/optimizer/plan_nodes/physical_values.rs
@@ -1,9 +1,10 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
-use serde::{Serialize};
-use super::*;
 
+use serde::Serialize;
+
+use super::*;
 use crate::types::DataType;
 
 /// The physical plan of `VALUES`.

--- a/src/optimizer/plan_nodes/plan_tree_node.rs
+++ b/src/optimizer/plan_nodes/plan_tree_node.rs
@@ -42,7 +42,6 @@ pub trait PlanTreeNodeBinary {
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self;
 }
 
-#[macro_export]
 macro_rules! impl_plan_tree_node_for_leaf {
     ($leaf_node_type:ident) => {
         impl crate::optimizer::plan_nodes::PlanTreeNode for $leaf_node_type {
@@ -62,7 +61,8 @@ macro_rules! impl_plan_tree_node_for_leaf {
     };
 }
 
-#[macro_export]
+pub(crate) use impl_plan_tree_node_for_leaf;
+
 macro_rules! impl_plan_tree_node_for_unary {
     ($unary_node_type:ident) => {
         impl crate::optimizer::plan_nodes::PlanTreeNode for $unary_node_type {
@@ -82,7 +82,8 @@ macro_rules! impl_plan_tree_node_for_unary {
     };
 }
 
-#[macro_export]
+pub(crate) use impl_plan_tree_node_for_unary;
+
 macro_rules! impl_plan_tree_node_for_binary {
     ($binary_node_type:ident) => {
         impl crate::optimizer::plan_nodes::PlanTreeNode for $binary_node_type {
@@ -101,3 +102,5 @@ macro_rules! impl_plan_tree_node_for_binary {
         }
     };
 }
+
+pub(crate) use impl_plan_tree_node_for_binary;


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

It seems that if we import modules in macro, cargo fmt will fail to format some parts... As we can see, now `use serde::{Serialize};` is correctly formatted.

fix https://github.com/risinglightdb/risinglight/issues/370