### PR TITLE
feat: support TPC-H Q5 & Q10

### DIFF
--- a/src/binder/expression/mod.rs
+++ b/src/binder/expression/mod.rs
@@ -208,10 +208,13 @@ impl From<&Value> for DataValue {
                 ..
             } => match leading_field {
                 Some(DateTimeField::Day) => {
-                    Self::Interval(Interval::new(0, value.parse().unwrap()))
+                    Self::Interval(Interval::from_days(value.parse().unwrap()))
+                }
+                Some(DateTimeField::Month) => {
+                    Self::Interval(Interval::from_months(value.parse().unwrap()))
                 }
                 Some(DateTimeField::Year) => {
-                    Self::Interval(Interval::new(value.parse().unwrap(), 0))
+                    Self::Interval(Interval::from_years(value.parse().unwrap()))
                 }
                 _ => todo!("Support interval with leading field: {:?}", leading_field),
             },

--- a/src/storage/secondary/encode.rs
+++ b/src/storage/secondary/encode.rs
@@ -97,18 +97,18 @@ impl PrimitiveFixedWidthEncode for Date {
 
 impl PrimitiveFixedWidthEncode for Interval {
     const WIDTH: usize = std::mem::size_of::<i32>() + std::mem::size_of::<i32>();
-    const DEAFULT_VALUE: &'static Self = &Interval::new(0, 0);
+    const DEAFULT_VALUE: &'static Self = &Interval::from_days(0);
 
     type ArrayType = IntervalArray;
 
     fn encode(&self, buffer: &mut impl BufMut) {
-        buffer.put_i32(self.get_years());
-        buffer.put_i32(self.get_days());
+        buffer.put_i32(self.num_months());
+        buffer.put_i32(self.days());
     }
 
     fn decode(buffer: &mut impl Buf) -> Self {
-        let years = buffer.get_i32();
+        let months = buffer.get_i32();
         let days = buffer.get_i32();
-        Interval::new(years, days)
+        Interval::from_md(months, days)
     }
 }

--- a/src/types/interval.rs
+++ b/src/types/interval.rs
@@ -1,31 +1,73 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt::{Display, Formatter};
+use std::ops::Neg;
 
 use serde::Serialize;
+
 /// Interval type
 #[derive(PartialOrd, PartialEq, Debug, Copy, Clone, Default, Hash, Serialize)]
 pub struct Interval {
-    years: i32,
+    months: i32,
     days: i32,
 }
 
 impl Interval {
-    pub const fn new(years: i32, days: i32) -> Self {
-        Interval { years, days }
+    pub const fn from_days(days: i32) -> Self {
+        Interval { months: 0, days }
     }
 
-    pub fn get_years(&self) -> i32 {
-        self.years
+    pub const fn from_months(months: i32) -> Self {
+        Interval { months, days: 0 }
     }
 
-    pub fn get_days(&self) -> i32 {
+    pub const fn from_years(years: i32) -> Self {
+        Interval {
+            months: years * 12,
+            days: 0,
+        }
+    }
+
+    pub const fn from_md(months: i32, days: i32) -> Self {
+        Interval { months, days }
+    }
+
+    pub const fn years(&self) -> i32 {
+        self.months / 12
+    }
+
+    pub const fn months(&self) -> i32 {
+        self.months % 12
+    }
+
+    pub const fn days(&self) -> i32 {
         self.days
+    }
+
+    pub const fn num_months(&self) -> i32 {
+        self.months
+    }
+}
+
+impl Neg for Interval {
+    type Output = Interval;
+
+    fn neg(self) -> Self::Output {
+        Interval {
+            months: -self.months,
+            days: -self.days,
+        }
     }
 }
 
 impl Display for Interval {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} years {} days", self.years, self.days)
+        write!(
+            f,
+            "{} years {} months {} days",
+            self.years(),
+            self.months(),
+            self.days()
+        )
     }
 }

--- a/tests/sql/tpch/q10.slt
+++ b/tests/sql/tpch/q10.slt
@@ -1,0 +1,54 @@
+query ITRRTTTT
+select
+        c_custkey,
+        c_name,
+        sum(l_extendedprice * (1 - l_discount)) as revenue,
+        c_acctbal,
+        n_name,
+        c_address,
+        c_phone,
+        c_comment
+from
+        customer,
+        orders,
+        lineitem,
+        nation
+where
+        c_custkey = o_custkey
+        and l_orderkey = o_orderkey
+        and o_orderdate >= date '1993-10-01'
+        and o_orderdate < date '1993-10-01' + interval '3' month
+        and l_returnflag = 'R'
+        and c_nationkey = n_nationkey
+group by
+        c_custkey,
+        c_name,
+        c_acctbal,
+        c_phone,
+        n_name,
+        c_address,
+        c_comment
+order by
+        revenue desc
+limit 20;
+----
+121       Customer#000000121 282635.1719 6428.32   PERU       tv nCR2YKupGN73mQudO                     27-411-990-2959 uriously stealthy ideas. carefully final courts use carefully                     
+124       Customer#000000124 222182.5188 1842.49   CHINA      aTbyVAW5tCd,v09O                         28-183-750-7809 le fluffily even dependencies. quietly s                                          
+106       Customer#000000106 190241.3334 3288.42   ARGENTINA  xGCOEAUjUNG                              11-751-989-4627 lose slyly. ironic accounts along the evenly regular theodolites wake about the special, final gifts.
+16        Customer#000000016 161422.0461 4681.03   IRAN       cYiaeMLZSMAOQ2 d0W,                      20-781-609-3107 kly silent courts. thinly regular theodolites sleep fluffily after                
+44        Customer#000000044 149364.5652 7315.94   MOZAMBIQUE Oi,dOSPwDu4jo4x,,P85E0dmhZGvNtBwi        26-190-260-5375 r requests around the unusual, bold a                                             
+71        Customer#000000071 129481.0245 -611.19   GERMANY    TlGalgdXWBmMV,6agLyWYDyIz9MKzcY8gl,w6t1B 17-710-812-5403 g courts across the regular, final pinto beans are blithely pending ac            
+89        Customer#000000089 121663.1243 1530.76   KENYA      dtR, y9JQWUO6FoJExyp8whOU                24-394-451-5404 counts are slyly beyond the slyly final accounts. quickly final ideas wake. r     
+112       Customer#000000112 111137.7141 2953.35   ROMANIA    RcfgG3bO7QeCnfjqJT1                      29-233-262-8382 rmanently unusual multipliers. blithely ruthless deposits are furiously along the
+62        Customer#000000062 106368.0153 595.61    GERMANY    upJK2Dnw13,                              17-361-978-7059 kly special dolphins. pinto beans are slyly. quickly regular accounts are furiously a
+146       Customer#000000146 103265.9888 3328.68   CANADA     GdxkdXG9u7iyI1,,y5tq4ZyrcEy              13-835-723-3223 ffily regular dinos are slyly unusual requests. slyly specia                      
+19        Customer#000000019 99306.0127  8914.71   CHINA      uc,3bHIx84H,wdrmLOjVsiqXCq2tr            28-396-526-5053  nag. furiously careful packages are slyly at the accounts. furiously regular in
+145       Customer#000000145 99256.9018  9748.93   JORDAN     kQjHmt2kcec cy3hfMh969u                  23-562-444-8454 ests? express, express instructions use. blithely fina                            
+103       Customer#000000103 97311.7724  2757.45   INDONESIA  8KIsQX4LJ7QMsj6DrtFtXu0nUEdV,8a          19-216-107-2107 furiously pending notornis boost slyly around the blithely ironic ideas? final, even instructions cajole fl
+136       Customer#000000136 95855.3980  -842.39   GERMANY    QoLsJ0v5C1IQbh,DS1                       17-501-210-4726 ackages sleep ironic, final courts. even requests above the blithely bold requests g
+53        Customer#000000053 92568.9124  4113.64   MOROCCO    HnaxHzTfFTZs8MuCpJyTbZ47Cm4wFOOgib       25-168-852-5363 ar accounts are. even foxes are blithely. fluffily pending deposits boost         
+49        Customer#000000049 90965.7262  4573.94   IRAN       cNgAeX7Fqrdf7HQN9EwjUa4nxT,68L FKAxzl    20-908-631-4424 nusual foxes! fluffily pending packages maintain to the regular                   
+37        Customer#000000037 88065.7458  -917.75   INDIA      7EV4Pwh,3SboctTWt                        18-385-235-7162 ilent packages are carefully among the deposits. furiousl                         
+82        Customer#000000082 86998.9644  9468.34   CHINA      zhG3EZbap4c992Gj3bK,3Ne,Xn               28-159-442-5305 s wake. bravely regular accounts are furiously. regula                            
+125       Customer#000000125 84808.0680  -234.12   ROMANIA    ,wSZXdVR xxIIfm9s8ITyLl3kgjT6UC07GY0Y    29-261-996-3120 x-ray finally after the packages? regular requests c                              
+59        Customer#000000059 84655.5711  3458.60   ARGENTINA  zLOCP0wh92OtBihgspOGl4                   11-355-584-3112 ously final packages haggle blithely after the express deposits. furiou           

--- a/tests/sql/tpch/q5.slt
+++ b/tests/sql/tpch/q5.slt
@@ -1,0 +1,28 @@
+query TR
+select
+        n_name,
+        sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+        customer,
+        orders,
+        lineitem,
+        supplier,
+        nation,
+        region
+where
+        c_custkey = o_custkey
+        and l_orderkey = o_orderkey
+        and l_suppkey = s_suppkey
+        and c_nationkey = s_nationkey
+        and s_nationkey = n_nationkey
+        and n_regionkey = r_regionkey
+        and r_name = 'AFRICA'
+        and o_orderdate >= date '1994-01-01'
+        and o_orderdate < date '1994-01-01' + interval '1' year
+group by
+        n_name
+order by
+        revenue desc;
+----
+MOROCCO  220457.0142
+ETHIOPIA 115183.8546

--- a/tests/sql/tpch/tpch.slt
+++ b/tests/sql/tpch/tpch.slt
@@ -2,5 +2,6 @@ include create.slt
 include insert.slt
 include q1.slt
 include q3.slt
+include q5.slt
 include q6.slt
 include drop.slt

--- a/tests/sql/tpch/tpch.slt
+++ b/tests/sql/tpch/tpch.slt
@@ -4,4 +4,5 @@ include q1.slt
 include q3.slt
 include q5.slt
 include q6.slt
+include q10.slt
 include drop.slt

--- a/tests/sqllogictest.rs
+++ b/tests/sqllogictest.rs
@@ -35,7 +35,10 @@ fn test_mem(name: &str) {
         db: Database::new_in_memory(),
     });
     tester.enable_testdir();
-    tester.run_file(Path::new("tests/sql").join(name)).unwrap();
+    tester
+        .run_file(Path::new("tests/sql").join(name))
+        .map_err(|e| panic!("{}", e))
+        .unwrap();
 }
 
 #[test_case("basic_test.slt")]
@@ -67,7 +70,10 @@ fn test_disk(name: &str) {
     ));
     let mut tester = sqllogictest::Runner::new(DatabaseWrapper { rt, db });
     tester.enable_testdir();
-    tester.run_file(Path::new("tests/sql").join(name)).unwrap();
+    tester
+        .run_file(Path::new("tests/sql").join(name))
+        .map_err(|e| panic!("{}", e))
+        .unwrap();
 }
 
 fn init_logger() {


### PR DESCRIPTION
This PR adds TPC-H Q5 and fixes `date + interval (month)` to pass TPC-H Q10.