### PR TITLE
feat: add initial support for blob type

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ fn main() {
     println!("cargo:rerun-if-changed=tests/sql");
     const PATTERN: &str = "tests/sql/**/[!_]*.slt"; // ignore files start with '_'
     const MEM_BLOCKLIST: &[&str] = &["statistics.slt"];
-    const DISK_BLOCKLIST: &[&str] = &[];
+    const DISK_BLOCKLIST: &[&str] = &["blob.slt"];
 
     let path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("testcase.rs");
     let mut fout = std::fs::File::create(path).expect("failed to create file");

--- a/src/array/data_chunk.rs
+++ b/src/array/data_chunk.rs
@@ -136,6 +136,7 @@ pub fn datachunk_to_sqllogictest_string(chunk: &DataChunk) -> String {
                 DataValue::Float64(v) => write!(output, "{}", v),
                 DataValue::String(s) if s.is_empty() => write!(output, "(empty)"),
                 DataValue::String(s) => write!(output, "{}", s),
+                DataValue::Blob(s) => write!(output, "{}", s),
                 DataValue::Decimal(v) => write!(output, "{}", v),
                 DataValue::Date(v) => write!(output, "{}", v),
                 DataValue::Interval(v) => write!(output, "{}", v),

--- a/src/array/data_chunk.rs
+++ b/src/array/data_chunk.rs
@@ -136,6 +136,7 @@ pub fn datachunk_to_sqllogictest_string(chunk: &DataChunk) -> String {
                 DataValue::Float64(v) => write!(output, "{}", v),
                 DataValue::String(s) if s.is_empty() => write!(output, "(empty)"),
                 DataValue::String(s) => write!(output, "{}", s),
+                DataValue::Blob(s) if s.is_empty() => write!(output, "(empty)"),
                 DataValue::Blob(s) => write!(output, "{}", s),
                 DataValue::Decimal(v) => write!(output, "{}", v),
                 DataValue::Date(v) => write!(output, "{}", v),

--- a/src/array/utf8_array.rs
+++ b/src/array/utf8_array.rs
@@ -1,28 +1,62 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::iter::FromIterator;
+use std::marker::PhantomData;
 
 use bitvec::vec::BitVec;
 use serde::{Deserialize, Serialize};
 
 use super::{Array, ArrayBuilder, ArrayEstimateExt, ArrayValidExt};
 
-/// A collection of Rust UTF8 `String`s.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Utf8Array {
+/// A collection of variable-length values.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+pub struct BytesArray<T: ValueRef + ?Sized> {
     offset: Vec<usize>,
     valid: BitVec,
     data: Vec<u8>,
+    _type: PhantomData<T>,
 }
 
-impl Array for Utf8Array {
-    type Item = str;
-    type Builder = Utf8ArrayBuilder;
+/// The borrowed type of a variable-length value.
+pub trait ValueRef: ToOwned + AsRef<[u8]> + Send + Sync + 'static {
+    fn from_bytes(s: &[u8]) -> &Self;
+}
 
-    fn get(&self, idx: usize) -> Option<&str> {
+impl ValueRef for str {
+    fn from_bytes(s: &[u8]) -> &Self {
+        unsafe { std::str::from_utf8_unchecked(s) }
+    }
+}
+impl ValueRef for [u8] {
+    fn from_bytes(s: &[u8]) -> &Self {
+        s
+    }
+}
+
+pub type Utf8Array = BytesArray<str>;
+pub type ByteArray = BytesArray<[u8]>;
+pub type Utf8ArrayBuilder = BytesArrayBuilder<str>;
+pub type ByteArrayBuilder = BytesArrayBuilder<[u8]>;
+
+impl<T: ValueRef + ?Sized> Clone for BytesArray<T> {
+    fn clone(&self) -> Self {
+        Self {
+            offset: self.offset.clone(),
+            valid: self.valid.clone(),
+            data: self.data.clone(),
+            _type: self._type.clone(),
+        }
+    }
+}
+
+impl<T: ValueRef + ?Sized> Array for BytesArray<T> {
+    type Item = T;
+    type Builder = BytesArrayBuilder<T>;
+
+    fn get(&self, idx: usize) -> Option<&T> {
         if self.valid[idx] {
             let data_slice = &self.data[self.offset[idx]..self.offset[idx + 1]];
-            Some(unsafe { std::str::from_utf8_unchecked(data_slice) })
+            Some(T::from_bytes(data_slice))
         } else {
             None
         }
@@ -33,27 +67,28 @@ impl Array for Utf8Array {
     }
 }
 
-impl ArrayValidExt for Utf8Array {
+impl<T: ValueRef + ?Sized> ArrayValidExt for BytesArray<T> {
     fn get_valid_bitmap(&self) -> &BitVec {
         &self.valid
     }
 }
 
-impl ArrayEstimateExt for Utf8Array {
+impl<T: ValueRef + ?Sized> ArrayEstimateExt for BytesArray<T> {
     fn get_estimated_size(&self) -> usize {
         self.data.len() + self.offset.len() + self.valid.len() / 8
     }
 }
 
-/// A builder that uses `&str` to build an [`Utf8Array`].
-pub struct Utf8ArrayBuilder {
+/// A builder that uses `&T` to build an [`BytesArray`].
+pub struct BytesArrayBuilder<T: ValueRef + ?Sized> {
     offset: Vec<usize>,
     valid: BitVec,
     data: Vec<u8>,
+    _type: PhantomData<T>,
 }
 
-impl ArrayBuilder for Utf8ArrayBuilder {
-    type Array = Utf8Array;
+impl<T: ValueRef + ?Sized> ArrayBuilder for BytesArrayBuilder<T> {
+    type Array = BytesArray<T>;
 
     fn with_capacity(capacity: usize) -> Self {
         let mut offset = Vec::with_capacity(capacity + 1);
@@ -62,18 +97,19 @@ impl ArrayBuilder for Utf8ArrayBuilder {
             offset,
             data: Vec::with_capacity(capacity),
             valid: BitVec::with_capacity(capacity),
+            _type: PhantomData,
         }
     }
 
-    fn push(&mut self, value: Option<&str>) {
+    fn push(&mut self, value: Option<&T>) {
         self.valid.push(value.is_some());
         if let Some(x) = value {
-            self.data.extend_from_slice(x.as_bytes());
+            self.data.extend_from_slice(x.as_ref());
         }
         self.offset.push(self.data.len());
     }
 
-    fn append(&mut self, other: &Utf8Array) {
+    fn append(&mut self, other: &BytesArray<T>) {
         self.valid.extend_from_bitslice(&other.valid);
         self.data.extend_from_slice(&other.data);
         let start = *self.offset.last().unwrap();
@@ -82,18 +118,19 @@ impl ArrayBuilder for Utf8ArrayBuilder {
         }
     }
 
-    fn finish(self) -> Utf8Array {
-        Utf8Array {
+    fn finish(self) -> BytesArray<T> {
+        BytesArray {
             valid: self.valid,
             data: self.data,
             offset: self.offset,
+            _type: PhantomData,
         }
     }
 }
 
-// Enable `collect()` an array from iterator of `Option<&str>` or `Option<String>`.
-impl<Str: AsRef<str>> FromIterator<Option<Str>> for Utf8Array {
-    fn from_iter<I: IntoIterator<Item = Option<Str>>>(iter: I) -> Self {
+// Enable `collect()` an array from iterator of `Option<&T>` or `Option<T::Owned>`.
+impl<O: AsRef<T>, T: ValueRef + ?Sized> FromIterator<Option<O>> for BytesArray<T> {
+    fn from_iter<I: IntoIterator<Item = Option<O>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let mut builder = <Self as Array>::Builder::with_capacity(iter.size_hint().0);
         for e in iter {

--- a/src/array/utf8_array.rs
+++ b/src/array/utf8_array.rs
@@ -7,6 +7,7 @@ use bitvec::vec::BitVec;
 use serde::{Deserialize, Serialize};
 
 use super::{Array, ArrayBuilder, ArrayEstimateExt, ArrayValidExt};
+use crate::types::BlobRef;
 
 /// A collection of variable-length values.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
@@ -27,16 +28,17 @@ impl ValueRef for str {
         unsafe { std::str::from_utf8_unchecked(s) }
     }
 }
-impl ValueRef for [u8] {
+
+impl ValueRef for BlobRef {
     fn from_bytes(s: &[u8]) -> &Self {
-        s
+        BlobRef::new(s)
     }
 }
 
 pub type Utf8Array = BytesArray<str>;
-pub type ByteArray = BytesArray<[u8]>;
+pub type BlobArray = BytesArray<BlobRef>;
 pub type Utf8ArrayBuilder = BytesArrayBuilder<str>;
-pub type ByteArrayBuilder = BytesArrayBuilder<[u8]>;
+pub type BlobArrayBuilder = BytesArrayBuilder<BlobRef>;
 
 impl<T: ValueRef + ?Sized> Clone for BytesArray<T> {
     fn clone(&self) -> Self {
@@ -44,7 +46,7 @@ impl<T: ValueRef + ?Sized> Clone for BytesArray<T> {
             offset: self.offset.clone(),
             valid: self.valid.clone(),
             data: self.data.clone(),
-            _type: self._type.clone(),
+            _type: PhantomData,
         }
     }
 }

--- a/src/binder/expression/mod.rs
+++ b/src/binder/expression/mod.rs
@@ -8,7 +8,7 @@ use sqlparser::ast::BinaryOperator;
 use super::*;
 use crate::catalog::ColumnRefId;
 use crate::parser::{DateTimeField, Expr, Function, UnaryOperator, Value};
-use crate::types::{DataType, DataTypeExt, DataTypeKind, DataValue, Date, Interval};
+use crate::types::{DataType, DataTypeExt, DataTypeKind, DataValue, Interval};
 
 mod agg_call;
 mod binary_op;
@@ -152,7 +152,7 @@ impl Binder {
     ) -> Result<BoundExpr, BindError> {
         match data_type {
             DataTypeKind::Date => {
-                let date = Date::from_str(value).map_err(|_| {
+                let date = value.parse().map_err(|_| {
                     BindError::CastError(DataValue::String(value.into()), DataTypeKind::Date)
                 })?;
                 Ok(BoundExpr::Constant(DataValue::Date(date)))

--- a/src/binder/expression/type_cast.rs
+++ b/src/binder/expression/type_cast.rs
@@ -16,9 +16,15 @@ impl Binder {
     pub fn bind_type_cast(
         &mut self,
         expr: &Expr,
-        ty: DataTypeKind,
+        mut ty: DataTypeKind,
     ) -> Result<BoundExpr, BindError> {
         let bound_expr = self.bind_expr(expr)?;
+        // workaround for 'BLOB'
+        if let DataTypeKind::Custom(name) = &ty {
+            if name.0.len() == 1 && name.0[0].value.to_lowercase() == "blob" {
+                ty = DataTypeKind::Blob(0);
+            }
+        }
         Ok(BoundExpr::TypeCast(BoundTypeCast {
             expr: (bound_expr.into()),
             ty,

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -7,7 +7,7 @@ use std::borrow::Borrow;
 use crate::array::*;
 use crate::binder::BoundExpr;
 use crate::parser::{BinaryOperator, UnaryOperator};
-use crate::types::{ConvertError, DataTypeExt, DataTypeKind, DataValue, Date};
+use crate::types::{Blob, ConvertError, DataTypeExt, DataTypeKind, DataValue, Date};
 
 impl BoundExpr {
     /// Evaluate the given expression as an array.
@@ -280,6 +280,9 @@ impl ArrayImpl {
                 })?),
                 Type::Date => Self::Date(try_unary_op(a, |s| {
                     Date::from_str(s).map_err(|e| ConvertError::ParseDate(s.to_string(), e))
+                })?),
+                Type::Bytea | Type::Blob(_) => Self::Blob(try_unary_op(a, |s| {
+                    Blob::from_str(s).map_err(|e| ConvertError::ParseBlob(s.to_string(), e))
                 })?),
                 _ => todo!("cast array"),
             },

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -309,6 +309,7 @@ impl ArrayImpl {
                 })?),
                 _ => todo!("cast array"),
             },
+            Self::Blob(_) => todo!("cast array"),
             Self::Decimal(a) => match data_type {
                 Type::Boolean => Self::Bool(unary_op(a, |&d| d != Decimal::from(0_i32))),
                 Type::Int(_) => Self::Int32(try_unary_op(a, |&d| {

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -7,54 +7,28 @@ use std::borrow::Borrow;
 use crate::array::*;
 use crate::binder::BoundExpr;
 use crate::parser::{BinaryOperator, UnaryOperator};
-use crate::types::{ConvertError, DataTypeKind, DataValue, Date};
+use crate::types::{ConvertError, DataTypeExt, DataTypeKind, DataValue, Date};
 
 impl BoundExpr {
-    /// Evaluate the given expression as a constant value.
-    ///
-    /// This method is used in the evaluation of `insert values` and optimizer
-    pub fn eval(&self) -> DataValue {
-        use DataValue::*;
-        match &self {
-            BoundExpr::Constant(v) => v.clone(),
-            BoundExpr::UnaryOp(v) => match (&v.op, v.expr.eval()) {
-                (UnaryOperator::Minus, Int32(i)) => Int32(-i),
-                (UnaryOperator::Minus, Float64(f)) => Float64(-f),
-                (UnaryOperator::Minus, Decimal(d)) => Decimal(-d),
-                _ => todo!("evaluate expression: {:?}", self),
-            },
-            BoundExpr::BinaryOp(v) => match (&v.op, v.left_expr.eval(), v.right_expr.eval()) {
-                (BinaryOperator::Plus, Int32(l), Int32(r)) => Int32(l + r),
-                (BinaryOperator::Plus, Float64(l), Float64(r)) => Float64(l + r),
-                (BinaryOperator::Minus, Int32(l), Int32(r)) => Int32(l - r),
-                (BinaryOperator::Minus, Float64(l), Float64(r)) => Float64(l - r),
-                (BinaryOperator::Multiply, Int32(l), Int32(r)) => Int32(l * r),
-                (BinaryOperator::Multiply, Float64(l), Float64(r)) => Float64(l * r),
-                (BinaryOperator::Divide, Int32(l), Int32(r)) => Int32(l / r),
-                (BinaryOperator::Divide, Float64(l), Float64(r)) => Float64(l / r),
-                _ => todo!("evaluate expression: {:?}", self),
-            },
-            _ => todo!("evaluate expression: {:?}", self),
-        }
-    }
-
     /// Evaluate the given expression as an array.
-    pub fn eval_array(&self, chunk: &DataChunk) -> Result<ArrayImpl, ConvertError> {
+    pub fn eval(&self, chunk: &DataChunk) -> Result<ArrayImpl, ConvertError> {
         match &self {
             BoundExpr::InputRef(input_ref) => Ok(chunk.array_at(input_ref.index).clone()),
             BoundExpr::BinaryOp(binary_op) => {
-                let left = binary_op.left_expr.eval_array(chunk)?;
-                let right = binary_op.right_expr.eval_array(chunk)?;
+                let left = binary_op.left_expr.eval(chunk)?;
+                let right = binary_op.right_expr.eval(chunk)?;
                 Ok(left.binary_op(&binary_op.op, &right))
             }
             BoundExpr::UnaryOp(op) => {
-                let array = op.expr.eval_array(chunk)?;
+                let array = op.expr.eval(chunk)?;
                 Ok(array.unary_op(&op.op))
             }
             BoundExpr::Constant(v) => {
                 let mut builder = ArrayBuilderImpl::with_capacity(
                     chunk.cardinality(),
-                    &self.return_type().unwrap(),
+                    &self
+                        .return_type()
+                        .unwrap_or_else(|| DataTypeKind::Int(None).nullable()),
                 );
                 // TODO: optimize this
                 for _ in 0..chunk.cardinality() {
@@ -63,21 +37,21 @@ impl BoundExpr {
                 Ok(builder.finish())
             }
             BoundExpr::TypeCast(cast) => {
-                let array = cast.expr.eval_array(chunk)?;
+                let array = cast.expr.eval(chunk)?;
                 if self.return_type() == cast.expr.return_type() {
                     return Ok(array);
                 }
                 array.try_cast(cast.ty.clone())
             }
             BoundExpr::IsNull(expr) => {
-                let array = expr.expr.eval_array(chunk)?;
+                let array = expr.expr.eval(chunk)?;
                 Ok(ArrayImpl::Bool(
                     (0..array.len())
                         .map(|i| array.get(i) == DataValue::Null)
                         .collect(),
                 ))
             }
-            BoundExpr::ExprWithAlias(expr_with_alias) => expr_with_alias.expr.eval_array(chunk),
+            BoundExpr::ExprWithAlias(expr_with_alias) => expr_with_alias.expr.eval(chunk),
             _ => panic!("{:?} should not be evaluated in `eval_array`", self),
         }
     }

--- a/src/executor/filter.rs
+++ b/src/executor/filter.rs
@@ -16,7 +16,7 @@ impl FilterExecutor {
         #[for_await]
         for batch in self.child {
             let batch = batch?;
-            let vis = match self.expr.eval_array(&batch)? {
+            let vis = match self.expr.eval(&batch)? {
                 ArrayImpl::Bool(a) => a,
                 _ => panic!("filters can only accept bool array"),
             };

--- a/src/executor/hash_agg.rs
+++ b/src/executor/hash_agg.rs
@@ -29,13 +29,11 @@ impl HashAggExecutor {
         group_keys: &[BoundExpr],
     ) -> Result<(), ExecutorError> {
         // Eval group keys and arguments
-        let group_cols: SmallVec<[ArrayImpl; 16]> = group_keys
-            .iter()
-            .map(|e| e.eval_array(&chunk))
-            .try_collect()?;
+        let group_cols: SmallVec<[ArrayImpl; 16]> =
+            group_keys.iter().map(|e| e.eval(&chunk)).try_collect()?;
         let arrays: SmallVec<[ArrayImpl; 16]> = agg_calls
             .iter()
-            .map(|agg| agg.args[0].eval_array(&chunk))
+            .map(|agg| agg.args[0].eval(&chunk))
             .try_collect()?;
 
         // Update states

--- a/src/executor/nested_loop_join.rs
+++ b/src/executor/nested_loop_join.rs
@@ -50,7 +50,7 @@ impl NestedLoopJoinExecutor {
         let cross_chunk = builders.into_iter().collect();
 
         // evaluate filter bitmap
-        let filter = match self.condition.eval_array(&cross_chunk)? {
+        let filter = match self.condition.eval(&cross_chunk)? {
             ArrayImpl::Bool(a) => a,
             _ => panic!("unsupported value from join condition"),
         };

--- a/src/executor/projection.rs
+++ b/src/executor/projection.rs
@@ -16,12 +16,12 @@ impl ProjectionExecutor {
         #[for_await]
         for batch in self.child {
             let batch = batch?;
-            let chunk = self
+            let chunk: Vec<_> = self
                 .project_expressions
                 .iter()
                 .map(|expr| expr.eval(&batch))
-                .collect::<Result<DataChunk, _>>()?;
-            yield chunk;
+                .try_collect()?;
+            yield chunk.into_iter().collect();
         }
     }
 }

--- a/src/executor/projection.rs
+++ b/src/executor/projection.rs
@@ -19,7 +19,7 @@ impl ProjectionExecutor {
             let chunk = self
                 .project_expressions
                 .iter()
-                .map(|expr| expr.eval_array(&batch))
+                .map(|expr| expr.eval(&batch))
                 .collect::<Result<DataChunk, _>>()?;
             yield chunk;
         }

--- a/src/executor/simple_agg.rs
+++ b/src/executor/simple_agg.rs
@@ -23,7 +23,7 @@ impl SimpleAggExecutor {
         // TODO: support aggregations with multiple arguments
         let exprs: SmallVec<[ArrayImpl; 16]> = agg_calls
             .iter()
-            .map(|agg| agg.args[0].eval_array(&chunk))
+            .map(|agg| agg.args[0].eval(&chunk))
             .try_collect()?;
 
         for (state, expr) in states.iter_mut().zip_eq(exprs) {

--- a/src/executor/values.rs
+++ b/src/executor/values.rs
@@ -24,10 +24,11 @@ impl ValuesExecutor {
                 .map(|ty| ArrayBuilderImpl::with_capacity(chunk.len(), ty))
                 .collect_vec();
             // Push value into the builder.
+            let dummy = DataChunk::single(0);
             for row in chunk {
                 for (expr, builder) in row.iter().zip_eq(&mut builders) {
-                    let value = expr.eval();
-                    builder.push(&value);
+                    let value = expr.eval(&dummy)?;
+                    builder.push(&value.get(0));
                 }
             }
             // Finish build and yield chunk.

--- a/src/optimizer/logical_plan_rewriter/constant_folding.rs
+++ b/src/optimizer/logical_plan_rewriter/constant_folding.rs
@@ -37,8 +37,12 @@ impl ExprRewriter for ConstantFoldingRule {
             TypeCast(cast) => {
                 self.rewrite_expr(&mut *cast.expr);
                 if let Constant(v) = &*cast.expr {
-                    let res = ArrayImpl::from(v).try_cast(cast.ty.clone()).unwrap().get(0);
-                    *expr = Constant(res);
+                    if let Ok(array) = ArrayImpl::from(v).try_cast(cast.ty.clone()) {
+                        let res = array.get(0);
+                        *expr = Constant(res);
+                    }
+                    // ignore if cast failed
+                    // TODO: raise an error
                 }
             }
             AggCall(agg_call) => {

--- a/src/types/blob.rs
+++ b/src/types/blob.rs
@@ -1,0 +1,149 @@
+use std::borrow::Borrow;
+use std::fmt;
+use std::ops::Deref;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Binary large object.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
+pub struct Blob(Vec<u8>);
+
+impl From<&[u8]> for Blob {
+    fn from(bytes: &[u8]) -> Self {
+        Blob(bytes.into())
+    }
+}
+
+impl From<Vec<u8>> for Blob {
+    fn from(vec: Vec<u8>) -> Self {
+        Blob(vec)
+    }
+}
+
+impl Borrow<BlobRef> for Blob {
+    fn borrow(&self) -> &BlobRef {
+        &*self
+    }
+}
+
+impl AsRef<BlobRef> for Blob {
+    fn as_ref(&self) -> &BlobRef {
+        &*self
+    }
+}
+
+impl Deref for Blob {
+    type Target = BlobRef;
+
+    fn deref(&self) -> &Self::Target {
+        BlobRef::new(&self.0)
+    }
+}
+
+/// An error which can be returned when parsing a blob.
+#[derive(thiserror::Error, Debug, Clone, PartialEq)]
+#[error("parse blob error")]
+pub enum ParseBlobError {
+    Int(#[from] std::num::ParseIntError),
+    Length,
+}
+
+impl FromStr for Blob {
+    type Err = ParseBlobError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(mut s) = s.strip_prefix("\\x") {
+            let mut v = Vec::with_capacity(s.len() / 2);
+            while !s.is_empty() {
+                if s.len() < 2 {
+                    return Err(ParseBlobError::Length);
+                }
+                v.push(u8::from_str_radix(&s[..2], 16)?);
+                s = &s[2..];
+            }
+            Ok(Blob(v))
+        } else {
+            Ok(Blob(s.as_bytes().into()))
+        }
+    }
+}
+
+impl fmt::Debug for Blob {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.as_ref())
+    }
+}
+
+impl fmt::Display for Blob {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
+/// A slice of a blob.
+#[repr(transparent)]
+#[derive(PartialEq, PartialOrd)]
+pub struct BlobRef([u8]);
+
+impl BlobRef {
+    pub fn new(bytes: &[u8]) -> &Self {
+        // SAFETY: `&BlobRef` and `&[u8]` have the same layout.
+        unsafe { std::mem::transmute(bytes) }
+    }
+}
+
+impl ToOwned for BlobRef {
+    type Owned = Blob;
+
+    fn to_owned(&self) -> Self::Owned {
+        self.as_ref().into()
+    }
+}
+
+impl AsRef<[u8]> for BlobRef {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl Deref for BlobRef {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Debug for BlobRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "'\\x{self}'")
+    }
+}
+
+impl fmt::Display for BlobRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for b in &self.0 {
+            write!(f, "{b:02X}")?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_blob() {
+        assert_eq!("\\xAA".parse::<Blob>(), Ok(Blob::from([170].as_slice())));
+        assert_eq!("AB".parse::<Blob>(), Ok(Blob::from(b"AB".as_slice())));
+    }
+
+    #[test]
+    fn blob_to_string() {
+        let b = Blob::from([170].as_slice());
+        assert_eq!(b.to_string(), "AA");
+        assert_eq!(format!("{b:?}"), "'\\xAA'");
+    }
+}

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt::{Display, Formatter};
+use std::str::FromStr;
 
 use chrono::{Datelike, NaiveDate};
 use serde::Serialize;
@@ -20,15 +21,18 @@ impl Date {
         Date(inner)
     }
 
-    /// Convert string to date
-    pub fn from_str(s: &str) -> chrono::ParseResult<Date> {
-        NaiveDate::parse_from_str(s, "%Y-%m-%d")
-            .map(|ret| Date(ret.num_days_from_ce() - UNIX_EPOCH_DAYS))
-    }
-
     /// Get the inner value of date type
     pub fn get_inner(&self) -> i32 {
         self.0
+    }
+}
+
+impl FromStr for Date {
+    type Err = chrono::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        NaiveDate::parse_from_str(s, "%Y-%m-%d")
+            .map(|ret| Date(ret.num_days_from_ce() - UNIX_EPOCH_DAYS))
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -36,20 +36,17 @@ pub enum PhysicalDataTypeKind {
 
 impl From<DataTypeKind> for PhysicalDataTypeKind {
     fn from(kind: DataTypeKind) -> Self {
+        use DataTypeKind::*;
         match kind {
-            DataTypeKind::Char(_) | DataTypeKind::Varchar(_) | DataTypeKind::String => {
-                PhysicalDataTypeKind::String
-            }
-            DataTypeKind::Binary(_) | DataTypeKind::Varbinary(_) | DataTypeKind::Blob(_) => {
-                PhysicalDataTypeKind::Blob
-            }
-            DataTypeKind::Float(_) | DataTypeKind::Double => PhysicalDataTypeKind::Float64,
-            DataTypeKind::Int(_) => PhysicalDataTypeKind::Int32,
-            DataTypeKind::BigInt(_) => PhysicalDataTypeKind::Int64,
-            DataTypeKind::Boolean => PhysicalDataTypeKind::Bool,
-            DataTypeKind::Decimal(_, _) => PhysicalDataTypeKind::Decimal,
-            DataTypeKind::Date => PhysicalDataTypeKind::Date,
-            DataTypeKind::Interval => PhysicalDataTypeKind::Interval,
+            Char(_) | Varchar(_) | String => Self::String,
+            Bytea | Binary(_) | Varbinary(_) | Blob(_) => Self::Blob,
+            Float(_) | Double => Self::Float64,
+            Int(_) => Self::Int32,
+            BigInt(_) => Self::Int64,
+            Boolean => Self::Bool,
+            Decimal(_, _) => Self::Decimal,
+            Date => Self::Date,
+            Interval => Self::Interval,
             _ => todo!("physical type for {:?} is not supported", kind),
         }
     }

--- a/tests/sql/blob.slt
+++ b/tests/sql/blob.slt
@@ -1,0 +1,106 @@
+# Copyright 2018-2022 Stichting DuckDB Foundation
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# name: test/sql/types/blob/test_blob.test
+# description: BLOB tests
+# group: [blob]
+
+# statement ok
+# PRAGMA enable_verification
+
+statement ok
+CREATE TABLE blobs (b BYTEA);
+
+# Insert valid hex strings
+statement ok
+INSERT INTO blobs VALUES('\xaa\xff\xaa'), ('\xAA\xFF\xAA\xAA\xFF\xAA'), ('\xAA\xFF\xAA\xAA\xFF\xAA\xAA\xFF\xAA')
+
+query T
+SELECT * FROM blobs
+----
+\xAA\xFF\xAA
+\xAA\xFF\xAA\xAA\xFF\xAA
+\xAA\xFF\xAA\xAA\xFF\xAA\xAA\xFF\xAA
+
+# Insert valid hex strings, lower case
+statement ok
+DELETE FROM blobs WHERE true
+
+statement ok
+INSERT INTO blobs VALUES('\xaa\xff\xaa'), ('\xaa\xff\xaa\xaa\xff\xaa'), ('\xaa\xff\xaa\xaa\xff\xaa\xaa\xff\xaa')
+
+query T
+SELECT * FROM blobs
+----
+\xAA\xFF\xAA
+\xAA\xFF\xAA\xAA\xFF\xAA
+\xAA\xFF\xAA\xAA\xFF\xAA\xAA\xFF\xAA
+
+# Insert valid hex strings with number and letters
+statement ok
+DELETE FROM blobs WHERE true
+
+statement ok
+INSERT INTO blobs VALUES('\xaa1199'), ('\xaa1199aa1199'), ('\xaa1199aa1199aa1199')
+
+query T
+SELECT * FROM blobs
+----
+\xAA1199
+\xAA1199aa1199
+\xAA1199aa1199aa1199
+
+# Insert invalid hex strings (invalid hex chars: G, H, I)
+statement error
+INSERT INTO blobs VALUES('\xGA\xFF\xAA')
+
+# Insert invalid hex strings (odd # of chars)
+statement error
+INSERT INTO blobs VALUES('\xA')
+
+statement error
+INSERT INTO blobs VALUES('\xAA\xA')
+
+statement error
+INSERT INTO blobs VALUES('blablabla\x')
+
+# BLOB with “non-printable” octets
+statement error
+SELECT 'abc �'::BYTEA;
+
+# BLOB null and empty values
+query T
+SELECT ''::BLOB
+----
+(empty)
+
+# FIXME: support 'NULL::BLOB'
+
+# query T
+# SELECT NULL::BLOB
+# ----
+# NULL
+
+# statement ok
+# CREATE TABLE blob_empty (b BYTEA);
+
+# statement ok
+# INSERT INTO blob_empty VALUES(''), (''::BLOB)
+
+# statement ok
+# INSERT INTO blob_empty VALUES(NULL), (NULL::BLOB)
+
+# query T
+# SELECT * FROM blob_empty
+# ----
+# (empty)
+# (empty)
+# NULL
+# NULL
+
+# convert non-ascii string to blob using cat
+statement error
+select 'ü'::blob;


### PR DESCRIPTION
This PR adds initial support for blob type.

We borrowed a test script from DuckDB and managed to pass most of the tests on memory storage.
The failed case is `SELECT NULL::BLOB`, which needs further fixes in our binder.

This PR also proposes another approach to support unsized types in array without using GAT (related discussion #381).
In short, we can define unsized types over a slice, like `std::path::Path`. They have the same memory layout as `[u8]` but can parse the underlying data in their own way. For more details, you can see `BlobRef` in the code.

TODO: support blob type on disk storage.