### PR TITLE
refactor(table): remove async_trait for Table trait

### DIFF
--- a/src/storage/memory/table.rs
+++ b/src/storage/memory/table.rs
@@ -67,11 +67,11 @@ impl InMemoryTable {
 impl Table for InMemoryTable {
     type TransactionType = InMemoryTransaction;
     type ReadResultFuture<'a> =
-        impl Future<Output = StorageResult<Self::TransactionType>> + Sync + Send + 'a;
+        impl Future<Output = StorageResult<Self::TransactionType>> + Send + 'a;
     type WriteResultFuture<'a> =
-        impl Future<Output = StorageResult<Self::TransactionType>> + Sync + Send + 'a;
+        impl Future<Output = StorageResult<Self::TransactionType>> + Send + 'a;
     type UpdateResultFuture<'a> =
-        impl Future<Output = StorageResult<Self::TransactionType>> + Sync + Send + 'a;
+        impl Future<Output = StorageResult<Self::TransactionType>> + Send + 'a;
 
     fn columns(&self) -> StorageResult<Arc<[ColumnCatalog]>> {
         Ok(self.columns.clone())

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -90,19 +90,16 @@ pub trait Table: Sync + Send + Clone + 'static {
     type TransactionType: Transaction;
 
     type WriteResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>>
-        + Sync
         + Send
         + 'a
     where
         Self: 'a;
     type ReadResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>>
-        + Sync
         + Send
         + 'a
     where
         Self: 'a;
     type UpdateResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>>
-        + Sync
         + Send
         + 'a
     where

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -85,22 +85,40 @@ pub trait Storage: Sync + Send + 'static {
 
 /// A table in the storage engine. [`Table`] is by default a reference to a table,
 /// so you could clone it and manipulate in different threads as you like.
-#[async_trait]
 pub trait Table: Sync + Send + Clone + 'static {
     /// Type of the transaction.
     type TransactionType: Transaction;
+
+    type WriteResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>>
+        + Sync
+        + Send
+        + 'a
+    where
+        Self: 'a;
+    type ReadResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>>
+        + Sync
+        + Send
+        + 'a
+    where
+        Self: 'a;
+    type UpdateResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>>
+        + Sync
+        + Send
+        + 'a
+    where
+        Self: 'a;
 
     /// Get schema of the current table
     fn columns(&self) -> StorageResult<Arc<[ColumnCatalog]>>;
 
     /// Begin a read-write-only txn
-    async fn write(&self) -> StorageResult<Self::TransactionType>;
+    fn write(&self) -> Self::WriteResultFuture<'_>;
 
     /// Begin a read-only txn
-    async fn read(&self) -> StorageResult<Self::TransactionType>;
+    fn read(&self) -> Self::ReadResultFuture<'_>;
 
     /// Begin a txn that might delete or update rows
-    async fn update(&self) -> StorageResult<Self::TransactionType>;
+    fn update(&self) -> Self::UpdateResultFuture<'_>;
 
     /// Get table id
     fn table_id(&self) -> TableRefId;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -89,19 +89,13 @@ pub trait Table: Sync + Send + Clone + 'static {
     /// Type of the transaction.
     type TransactionType: Transaction;
 
-    type WriteResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>>
-        + Send
-        + 'a
+    type WriteResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>> + Send + 'a
     where
         Self: 'a;
-    type ReadResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>>
-        + Send
-        + 'a
+    type ReadResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>> + Send + 'a
     where
         Self: 'a;
-    type UpdateResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>>
-        + Send
-        + 'a
+    type UpdateResultFuture<'a>: Future<Output = StorageResult<Self::TransactionType>> + Send + 'a
     where
         Self: 'a;
 


### PR DESCRIPTION
part of https://github.com/risinglightdb/risinglight/issues/389

Issue Number: close https://github.com/risinglightdb/risinglight/issues/393

Signed-off-by: tabVersion tabvision@bupt.icu

--- 

one question: 

Since `ReadResultFuture`, `WriteResultFuture` and `UpdateResultFuture` share type `Future<Output = StorageResult<Self::TransactionType>>`, why rust requires implementing them separately. 
