### PR TITLE
fix(array): support no columns table

### DIFF
--- a/src/array/data_chunk.rs
+++ b/src/array/data_chunk.rs
@@ -18,8 +18,10 @@ pub struct DataChunk {
 impl FromIterator<ArrayImpl> for DataChunk {
     fn from_iter<I: IntoIterator<Item = ArrayImpl>>(iter: I) -> Self {
         let arrays: Arc<[ArrayImpl]> = iter.into_iter().collect();
-        assert!(!arrays.is_empty());
-        let cardinality = arrays[0].len();
+        let cardinality = match arrays.first() {
+            Some(array) => array.len(),
+            None => 0,
+        };
         assert!(
             arrays.iter().map(|a| a.len()).all(|l| l == cardinality),
             "all arrays must have the same length"
@@ -46,7 +48,10 @@ impl DataChunk {
 
     /// Return the number of rows in the chunk.
     pub fn cardinality(&self) -> usize {
-        self.arrays[0].len()
+        match self.arrays.first() {
+            Some(first) => first.len(),
+            None => 0,
+        }
     }
 
     /// Get reference to a row.

--- a/src/array/data_chunk.rs
+++ b/src/array/data_chunk.rs
@@ -18,10 +18,7 @@ pub struct DataChunk {
 impl FromIterator<ArrayImpl> for DataChunk {
     fn from_iter<I: IntoIterator<Item = ArrayImpl>>(iter: I) -> Self {
         let arrays: Arc<[ArrayImpl]> = iter.into_iter().collect();
-        let cardinality = match arrays.first() {
-            Some(array) => array.len(),
-            None => 0,
-        };
+        let cardinality = arrays.first().map(ArrayImpl::len).unwrap_or(0);
         assert!(
             arrays.iter().map(|a| a.len()).all(|l| l == cardinality),
             "all arrays must have the same length"
@@ -48,10 +45,7 @@ impl DataChunk {
 
     /// Return the number of rows in the chunk.
     pub fn cardinality(&self) -> usize {
-        match self.arrays.first() {
-            Some(first) => first.len(),
-            None => 0,
-        }
+        self.arrays.first().map(ArrayImpl::len).unwrap_or(0)
     }
 
     /// Get reference to a row.

--- a/tests/sql/issue-398.slt
+++ b/tests/sql/issue-398.slt
@@ -1,0 +1,10 @@
+statement ok
+create table t
+
+query I
+select * from t
+----
+
+
+statement ok
+drop table t


### PR DESCRIPTION
Try to close https://github.com/risinglightdb/risinglight/issues/398

This table creation syntax is not standard and weird but supported by PostgreSQL. like this:

```
postgres@127:db1> create table t();
CREATE TABLE
Time: 0.006s

postgres@127:db1> select * from t;
SELECT 0
Time: 0.002s
```

After investigation, I found sqlparser-rs also supported this syntax, see https://github.com/sqlparser-rs/sqlparser-rs/pull/94. so RisingLight could parse successfully.

I think RisingLight should support the query `no columns table` instead of throwing exception on table creation.

So I just fixed the code that caused panic to avoid process termination.


Signed-off-by: Fedomn <fedomn.ma@gmail.com>