### PR TITLE
chore: refine Makefile clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,10 @@ check: fmt_check clippy_check build test docs_check
 
 clean:
 	cargo clean
+	rm -rf $(TPCH_DBGEN_PATH)
 
 $(TPCH_DBGEN_PATH):
-	mkdir target || true
+	mkdir -p target
 	git clone https://github.com/electrum/tpch-dbgen.git $(TPCH_DBGEN_PATH)
 
 tpch: $(TPCH_DBGEN_PATH)


### PR DESCRIPTION
1. Use `mkdir -p {}` instead of `mkdir {} || true`. `mkdir` may failed due to other reasons, e.g. no disk space or permission error or `target` already exists with a file but not a directory.

2. also clean tpch dir in `make clean`

Signed-off-by: TennyZhuang <zty0826@gmail.com>