### PR TITLE
feat(optimizer): column pruning framework

### DIFF
--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -1,5 +1,7 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
+use bit_set::BitSet;
+
 use crate::binder::*;
 
 mod expr_utils;
@@ -42,6 +44,8 @@ impl Optimizer {
         }
         let hep_optimizer = HeuristicOptimizer { rules };
         plan = hep_optimizer.optimize(plan);
+        let out_types_num = plan.out_types().len();
+        plan = plan.prune_col(BitSet::from_iter((0..out_types_num).into_iter()));
         let mut phy_converter = PhysicalConverter;
         phy_converter.rewrite(plan)
     }

--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -45,7 +45,7 @@ impl Optimizer {
         let hep_optimizer = HeuristicOptimizer { rules };
         plan = hep_optimizer.optimize(plan);
         let out_types_num = plan.out_types().len();
-        plan = plan.prune_col(BitSet::from_iter((0..out_types_num).into_iter()));
+        plan = plan.prune_col(BitSet::from_iter(0..out_types_num));
         let mut phy_converter = PhysicalConverter;
         phy_converter.rewrite(plan)
     }

--- a/src/optimizer/plan_nodes/logical_explain.rs
+++ b/src/optimizer/plan_nodes/logical_explain.rs
@@ -33,7 +33,16 @@ impl PlanTreeNodeUnary for LogicalExplain {
 }
 impl_plan_tree_node_for_unary!(LogicalExplain);
 
-impl PlanNode for LogicalExplain {}
+impl PlanNode for LogicalExplain {
+    fn prune_col(&self, _required_cols: BitSet) -> PlanRef {
+        let out_types_num = self.plan.out_types().len();
+        self.clone_with_child(
+            self.plan
+                .prune_col(BitSet::from_iter((0..out_types_num).into_iter())),
+        )
+        .into_plan_ref()
+    }
+}
 
 impl fmt::Display for LogicalExplain {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/optimizer/plan_nodes/logical_explain.rs
+++ b/src/optimizer/plan_nodes/logical_explain.rs
@@ -36,11 +36,8 @@ impl_plan_tree_node_for_unary!(LogicalExplain);
 impl PlanNode for LogicalExplain {
     fn prune_col(&self, _required_cols: BitSet) -> PlanRef {
         let out_types_num = self.plan.out_types().len();
-        self.clone_with_child(
-            self.plan
-                .prune_col(BitSet::from_iter((0..out_types_num).into_iter())),
-        )
-        .into_plan_ref()
+        self.clone_with_child(self.plan.prune_col(BitSet::from_iter(0..out_types_num)))
+            .into_plan_ref()
     }
 }
 

--- a/src/optimizer/plan_nodes/mod.rs
+++ b/src/optimizer/plan_nodes/mod.rs
@@ -112,6 +112,15 @@ pub trait PlanNode:
     /// logical plan node will use it, though all plan node impl it.
     fn prune_col(&self, required_cols: BitSet) -> PlanRef {
         let input_types = self.out_types();
+        let mut need_prune = false;
+        for i in 0..input_types.len() {
+            if !required_cols.contains(i) {
+                need_prune = true;
+            }
+        }
+        if !need_prune {
+            return self.clone_as_plan_ref();
+        }
         let exprs = required_cols
             .iter()
             .map(|index| {

--- a/src/optimizer/plan_nodes/mod.rs
+++ b/src/optimizer/plan_nodes/mod.rs
@@ -5,11 +5,12 @@
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
+use bit_set::BitSet;
 use downcast_rs::{impl_downcast, Downcast};
 use erased_serde::serialize_trait_object;
 use paste::paste;
 
-use crate::binder::BoundExpr;
+use crate::binder::{BoundExpr, BoundInputRef};
 use crate::types::DataType;
 
 mod plan_tree_node;
@@ -87,12 +88,40 @@ pub use physical_simple_agg::*;
 pub use physical_table_scan::*;
 pub use physical_values::*;
 
+/// The upcast trait for `PlanNode`.
+pub trait IntoPlanRef {
+    fn into_plan_ref(self) -> PlanRef;
+    fn clone_as_plan_ref(&self) -> PlanRef;
+}
 /// The common trait over all plan nodes.
 pub trait PlanNode:
-    WithPlanNodeType + PlanTreeNode + Debug + Display + Downcast + erased_serde::Serialize + Send + Sync
+    WithPlanNodeType
+    + IntoPlanRef
+    + PlanTreeNode
+    + Debug
+    + Display
+    + Downcast
+    + erased_serde::Serialize
+    + Send
+    + Sync
 {
     fn out_types(&self) -> Vec<DataType> {
         vec![]
+    }
+    /// transform the plan node to only output the required columns ordered by index number, only
+    /// logical plan node will use it, though all plan node impl it.
+    fn prune_col(&self, required_cols: BitSet) -> PlanRef {
+        let input_types = self.out_types();
+        let exprs = required_cols
+            .iter()
+            .map(|index| {
+                BoundExpr::InputRef(BoundInputRef {
+                    index,
+                    return_type: input_types[index].clone(),
+                })
+            })
+            .collect();
+        LogicalProjection::new(exprs, self.clone_as_plan_ref()).into_plan_ref()
     }
 }
 impl_downcast!(PlanNode);
@@ -200,3 +229,18 @@ macro_rules! impl_downcast_utility {
     }
 }
 for_all_plan_nodes! { impl_downcast_utility }
+
+/// impl `IntoPlanRef` for each node.
+macro_rules! impl_into_plan_ref {
+    ([], $($node_name:ident),*) => {
+            $(impl IntoPlanRef for $node_name {
+                fn into_plan_ref(self) -> PlanRef {
+                    std::sync::Arc::new(self)
+                }
+                fn clone_as_plan_ref(&self) -> PlanRef{
+                    self.clone().into_plan_ref()
+                }
+            })*
+    }
+}
+for_all_plan_nodes! {impl_into_plan_ref }


### PR DESCRIPTION
add `prune_col` method on `PlanNode`, every logical node should implement `fn prune_col(&self, required_cols: BitSet) -> PlanRef`, which will optimize itself and output only the required columns. Now there is a default implementation which is insert a `LogialProjection` on the top of the Node.

ref https://github.com/risinglightdb/risinglight/issues/388