### PR TITLE
chore(storage): fix error display

### DIFF
--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -61,13 +61,20 @@ impl From<prost::DecodeError> for TracedStorageError {
 }
 
 /// [`StorageResult`] with backtrace.
-#[derive(Error, Debug)]
-#[error("{source}")]
+#[derive(Error)]
+#[error("{source:?}\n{backtrace:#}")]
 pub struct TracedStorageError {
     #[from]
     source: StorageError,
     backtrace: Backtrace,
 }
+
+impl std::fmt::Debug for TracedStorageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
 impl TracedStorageError {
     pub fn duplicated(ty: &'static str, item: impl ToString) -> Self {
         StorageError::Duplicated(ty, item.to_string()).into()


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

Previously:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: TracedStorageError { source: JsonDecode(Error("missing field `name`", line: 1, column: 233)), backtrace: Backtrace [{ fn: "std::backtrace_rs::backtrace::libunwind::trace", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/../../backtrace/src/backtrace/libunwind.rs", line: 93 }, { fn: "std::backtrace_rs::backtrace::trace_unsynchronized", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/../../backtrace/src/backtrace/mod.rs", line: 66 }, { fn: "std::backtrace::Backtrace::create", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/backtrace.rs", line: 328 }, { fn: "<risinglight::storage::error::TracedStorageError as core::convert::From<risinglight::storage::error::StorageError>>::from", file: "./src/storage/error.rs", line: 64 }, { fn: "<T as core::convert::Into<U>>::into", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/convert/mod.rs", line: 542 }, { fn: "<risinglight::storage::error::TracedStorageError as core::convert::From<serde_json::error::Error>>::from", file: "./src/storage/error.rs", line: 45 }, { fn: "<core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/result.rs", line: 2052 }, { fn: "risinglight::storage::secondary::manifest::Manifest::replay::{{closure}}", file: "./src/storage/secondary/manifest.rs", line: 107 }, { fn: "<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs", line: 84 }, { fn: "risinglight::storage::secondary::storage::<impl risinglight::storage::secondary::SecondaryStorage>::bootstrap::{{closure}}", file: "./src/storage/secondary/storage.rs", line: 39 }, { fn: "<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs", line: 84 }, { fn: "risinglight::storage::secondary::SecondaryStorage::open::{{closure}}", file: "./src/storage/secondary/mod.rs", line: 105 }, { fn: "<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs", line: 84 }, { fn: "risinglight::db::Database::new_on_disk::{{closure}}", file: "./src/db.rs", line: 46 }, { fn: "<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs", line: 84 }, { fn: "risinglight::main::{{closure}}", file: "./src/main.rs", line: 167 }, { fn: "<core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs", line: 84 }, { fn: "tokio::park::thread::CachedParkThread::block_on::{{closure}}", file: "/Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/park/thread.rs", line: 263 }, { fn: "tokio::coop::with_budget::{{closure}}", file: "/Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs", line: 102 }, { fn: "std::thread::local::LocalKey<T>::try_with", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/thread/local.rs", line: 413 }, { fn: "std::thread::local::LocalKey<T>::with", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/thread/local.rs", line: 389 }, { fn: "tokio::coop::with_budget", file: "/Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs", line: 95 }, { fn: "tokio::coop::budget", file: "/Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs", line: 72 }, { fn: "tokio::park::thread::CachedParkThread::block_on", file: "/Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/park/thread.rs", line: 263 }, { fn: "tokio::runtime::enter::Enter::block_on", file: "/Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/enter.rs", line: 151 }, { fn: "tokio::runtime::thread_pool::ThreadPool::block_on", file: "/Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/thread_pool/mod.rs", line: 73 }, { fn: "tokio::runtime::Runtime::block_on", file: "/Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/mod.rs", line: 477 }, { fn: "risinglight::main", file: "./src/main.rs", line: 183 }, { fn: "core::ops::function::FnOnce::call_once", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/ops/function.rs", line: 227 }, { fn: "std::sys_common::backtrace::__rust_begin_short_backtrace", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/sys_common/backtrace.rs", line: 123 }, { fn: "std::rt::lang_start::{{closure}}", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/rt.rs", line: 145 }, { fn: "core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/ops/function.rs", line: 259 }, { fn: "std::panicking::try::do_call", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panicking.rs", line: 485 }, { fn: "std::panicking::try", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panicking.rs", line: 449 }, { fn: "std::panic::catch_unwind", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panic.rs", line: 136 }, { fn: "std::rt::lang_start_internal::{{closure}}", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/rt.rs", line: 128 }, { fn: "std::panicking::try::do_call", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panicking.rs", line: 485 }, { fn: "std::panicking::try", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panicking.rs", line: 449 }, { fn: "std::panic::catch_unwind", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panic.rs", line: 136 }, { fn: "std::rt::lang_start_internal", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/rt.rs", line: 128 }, { fn: "std::rt::lang_start", file: "/rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/rt.rs", line: 144 }, { fn: <unknown>, file: "/Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tracing-0.1.30/src/lib.rs", line: 1080 }] }', /Users/skyzh/Work/risinglight/src/db.rs:46:70
stack backtrace:
   0: rust_begin_unwind
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panicking.rs:577:5
   1: core::panicking::panic_fmt
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/panicking.rs:110:14
   2: core::result::unwrap_failed
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/result.rs:1737:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/result.rs:1065:23
   4: risinglight::db::Database::new_on_disk::{{closure}}
             at ./src/db.rs:46:32
   5: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs:84:19
   6: risinglight::main::{{closure}}
             at ./src/main.rs:167:74
   7: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs:84:19
   8: tokio::park::thread::CachedParkThread::block_on::{{closure}}
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/park/thread.rs:263:54
   9: tokio::coop::with_budget::{{closure}}
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs:102:9
  10: std::thread::local::LocalKey<T>::try_with
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/thread/local.rs:413:16
  11: std::thread::local::LocalKey<T>::with
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/thread/local.rs:389:9
  12: tokio::coop::with_budget
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs:95:5
  13: tokio::coop::budget
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs:72:5
  14: tokio::park::thread::CachedParkThread::block_on
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/park/thread.rs:263:31
  15: tokio::runtime::enter::Enter::block_on
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/enter.rs:151:13
  16: tokio::runtime::thread_pool::ThreadPool::block_on
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/thread_pool/mod.rs:73:9
  17: tokio::runtime::Runtime::block_on
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/mod.rs:477:43
  18: risinglight::main
             at ./src/main.rs:183:5
  19: core::ops::function::FnOnce::call_once
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

The new error panic display:

```
2022-02-09T06:04:41.456180Z  INFO risinglight: using Secondary engine
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: JSON decode error: missing field `name` at line 1 column 233
   0:        0x10133edf4 - std::backtrace_rs::backtrace::libunwind::trace::h75afce407256d21e
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:        0x10133edf4 - std::backtrace_rs::backtrace::trace_unsynchronized::hd483c835ae494ddd
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:        0x10133edf4 - std::backtrace::Backtrace::create::h186e1484498a30aa
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/backtrace.rs:328:13
   3:        0x100b68a60 - <risinglight::storage::error::TracedStorageError as core::convert::From<risinglight::storage::error::StorageError>>::from::h5498b140722c0f77
                               at /Users/skyzh/Work/risinglight/src/storage/error.rs:64:10
   4:        0x100996274 - <T as core::convert::Into<U>>::into::h8a050e7c2ce5413d
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/convert/mod.rs:542:9
   5:        0x100854db0 - <risinglight::storage::error::TracedStorageError as core::convert::From<serde_json::error::Error>>::from::h37382afcb0df6d67
                               at /Users/skyzh/Work/risinglight/src/storage/error.rs:45:9
   6:        0x1007f7c8c - <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual::h39c2045d787ad298
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/result.rs:2052:27
   7:        0x10082e00c - risinglight::storage::secondary::manifest::Manifest::replay::{{closure}}::hb905b8110fd62bf5
                               at /Users/skyzh/Work/risinglight/src/storage/secondary/manifest.rs:107:25
   8:        0x1007a5684 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::hf618271618f2f080
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs:84:19
   9:        0x10079bcfc - risinglight::storage::secondary::storage::<impl risinglight::storage::secondary::SecondaryStorage>::bootstrap::{{closure}}::h2b250e96deb01473
                               at /Users/skyzh/Work/risinglight/src/storage/secondary/storage.rs:39:45
  10:        0x1007a4e10 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::ha90e4497f4cb913f
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs:84:19
  11:        0x1007ef630 - risinglight::storage::secondary::SecondaryStorage::open::{{closure}}::h7ed03b36eac5f94f
                               at /Users/skyzh/Work/risinglight/src/storage/secondary/mod.rs:105:33
  12:        0x1007a3c40 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h2dd5a775d32ace97
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs:84:19
  13:        0x1008595a4 - risinglight::db::Database::new_on_disk::{{closure}}::h053a3833b5a26e33
                               at /Users/skyzh/Work/risinglight/src/db.rs:46:63
  14:        0x1007a3f38 - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h3fbcd6960de8165d
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs:84:19
  15:        0x10082b378 - risinglight::main::{{closure}}::hc3304f165a38380f
                               at /Users/skyzh/Work/risinglight/src/main.rs:167:74
  16:        0x1007a392c - <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll::h23f325c619a65716
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs:84:19
  17:        0x100794934 - tokio::park::thread::CachedParkThread::block_on::{{closure}}::h15233b339e19e746
                               at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/park/thread.rs:263:54
  18:        0x100858980 - tokio::coop::with_budget::{{closure}}::h2547b0f0a259d214
                               at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs:102:9
  19:        0x1007ea2c8 - std::thread::local::LocalKey<T>::try_with::hbb60a8e034609e82
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/thread/local.rs:413:16
  20:        0x1007e9a94 - std::thread::local::LocalKey<T>::with::hbd26222c3b2bbccf
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/thread/local.rs:389:9
  21:        0x100794444 - tokio::coop::with_budget::hbdd50263b98be488
                               at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs:95:5
  22:        0x100794444 - tokio::coop::budget::he42fc7661fc4cd11
                               at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs:72:5
  23:        0x100794444 - tokio::park::thread::CachedParkThread::block_on::h9dbe3880f49f6474
                               at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/park/thread.rs:263:31
  24:        0x10077deb0 - tokio::runtime::enter::Enter::block_on::h50459d0d8196ff09
                               at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/enter.rs:151:13
  25:        0x1007846a4 - tokio::runtime::thread_pool::ThreadPool::block_on::h67c04b8cafebc04c
                               at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/thread_pool/mod.rs:73:9
  26:        0x1007f24d4 - tokio::runtime::Runtime::block_on::h3e8e8bdb0c27e630
                               at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/mod.rs:477:43
  27:        0x10079f9b8 - risinglight::main::h0e69f814d945c1bc
                               at /Users/skyzh/Work/risinglight/src/main.rs:183:5
  28:        0x10083d9e0 - core::ops::function::FnOnce::call_once::h261dd876c22b422c
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/ops/function.rs:227:5
  29:        0x100797b7c - std::sys_common::backtrace::__rust_begin_short_backtrace::h6e437a7ef40f62fb
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/sys_common/backtrace.rs:123:18
  30:        0x100863b54 - std::rt::lang_start::{{closure}}::hac9d73917c32ea23
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/rt.rs:145:18
  31:        0x10134b504 - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::h03f6e88ad71e0bb9
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/ops/function.rs:259:13
  32:        0x10134b504 - std::panicking::try::do_call::hbb6497bfb0f1d83c
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panicking.rs:485:40
  33:        0x10134b504 - std::panicking::try::he8cc61a8ecf567b0
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panicking.rs:449:19
  34:        0x10134b504 - std::panic::catch_unwind::hce889bca62d3bee8
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panic.rs:136:14
  35:        0x10134b504 - std::rt::lang_start_internal::{{closure}}::h68d531ff06a323d2
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/rt.rs:128:48
  36:        0x10134b504 - std::panicking::try::do_call::hb7443bb6a27ae2a2
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panicking.rs:485:40
  37:        0x10134b504 - std::panicking::try::hc259e8400fa41c0e
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panicking.rs:449:19
  38:        0x10134b504 - std::panic::catch_unwind::h5f3c43f43b77bee8
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panic.rs:136:14
  39:        0x10134b504 - std::rt::lang_start_internal::h435b67d8b598b56f
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/rt.rs:128:20
  40:        0x100863b20 - std::rt::lang_start::h71cb49046f79903a
                               at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/rt.rs:144:17
  41:        0x10079fa70 - <unknown>
                               at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tracing-0.1.30/src/lib.rs:1080:10
', /Users/skyzh/Work/risinglight/src/db.rs:46:70
stack backtrace:
   0: rust_begin_unwind
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/panicking.rs:577:5
   1: core::panicking::panic_fmt
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/panicking.rs:110:14
   2: core::result::unwrap_failed
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/result.rs:1737:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/result.rs:1065:23
   4: risinglight::db::Database::new_on_disk::{{closure}}
             at ./src/db.rs:46:32
   5: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs:84:19
   6: risinglight::main::{{closure}}
             at ./src/main.rs:167:74
   7: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/future/mod.rs:84:19
   8: tokio::park::thread::CachedParkThread::block_on::{{closure}}
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/park/thread.rs:263:54
   9: tokio::coop::with_budget::{{closure}}
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs:102:9
  10: std::thread::local::LocalKey<T>::try_with
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/thread/local.rs:413:16
  11: std::thread::local::LocalKey<T>::with
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/std/src/thread/local.rs:389:9
  12: tokio::coop::with_budget
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs:95:5
  13: tokio::coop::budget
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/coop.rs:72:5
  14: tokio::park::thread::CachedParkThread::block_on
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/park/thread.rs:263:31
  15: tokio::runtime::enter::Enter::block_on
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/enter.rs:151:13
  16: tokio::runtime::thread_pool::ThreadPool::block_on
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/thread_pool/mod.rs:73:9
  17: tokio::runtime::Runtime::block_on
             at /Users/skyzh/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/tokio-1.16.1/src/runtime/mod.rs:477:43
  18: risinglight::main
             at ./src/main.rs:183:5
  19: core::ops::function::FnOnce::call_once
             at /rustc/5e57faa78aa7661c6000204591558f6665f11abc/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```