### PR TITLE
refactor(executor): poll concurrently with tokio::try_join! in join executors.

### DIFF
--- a/src/executor/nested_loop_join.rs
+++ b/src/executor/nested_loop_join.rs
@@ -23,8 +23,13 @@ impl NestedLoopJoinExecutor {
     #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
     pub async fn execute(self) {
         // collect all chunks from children
-        let left_chunks: Vec<DataChunk> = self.left_child.try_collect().await?;
-        let right_chunks: Vec<DataChunk> = self.right_child.try_collect().await?;
+        let (left_chunks, right_chunks) = async {
+            tokio::try_join!(
+                self.left_child.try_collect::<Vec<DataChunk>>(),
+                self.right_child.try_collect::<Vec<DataChunk>>(),
+            )
+        }
+        .await?;
 
         // helper functions
         let create_builders = || {


### PR DESCRIPTION
Instead of waiting until left side completes, the children executors can be driven concurrently to improve cpu utilization.

Experiments on my mac shows significant improvement on response time of queries with joins. 

`join`
```bash
hyperfine --warmup 3 './target/release/risinglight -f tests/sql/tpch/q1.sql'
Benchmark 1: ./target/release/risinglight -f tests/sql/tpch/q1.sql
  Time (mean ± σ):      3.901 s ±  0.054 s    [User: 5.423 s, System: 0.694 s]
  Range (min … max):    3.865 s …  4.040 s    10 runs

hyperfine --warmup 3 './target/release/risinglight -f tests/sql/tpch/q3.sql'
Benchmark 1: ./target/release/risinglight -f tests/sql/tpch/q3.sql
  Time (mean ± σ):      1.353 s ±  0.020 s    [User: 1.341 s, System: 0.448 s]
  Range (min … max):    1.329 s …  1.396 s    10 runs

hyperfine --warmup 3 './target/release/risinglight -f tests/sql/tpch/q5.sql'
Benchmark 1: ./target/release/risinglight -f tests/sql/tpch/q5.sql
  Time (mean ± σ):      3.453 s ±  0.138 s    [User: 3.331 s, System: 0.603 s]
  Range (min … max):    3.313 s …  3.706 s    10 runs

hyperfine --warmup 3 './target/release/risinglight -f tests/sql/tpch/q6.sql'
Benchmark 1: ./target/release/risinglight -f tests/sql/tpch/q6.sql
  Time (mean ± σ):      2.253 s ±  0.023 s    [User: 1.909 s, System: 0.385 s]
  Range (min … max):    2.225 s …  2.291 s    10 runs

hyperfine --warmup 3 './target/release/risinglight -f tests/sql/tpch/q10.sql'
Benchmark 1: ./target/release/risinglight -f tests/sql/tpch/q10.sql
  Time (mean ± σ):      2.005 s ±  0.078 s    [User: 2.015 s, System: 0.559 s]
  Range (min … max):    1.908 s …  2.170 s    10 runs
```

`sequential`
```bash
hyperfine --warmup 3 './target/release/risinglight -f tests/sql/tpch/q1.sql'
Benchmark 1: ./target/release/risinglight -f tests/sql/tpch/q1.sql
  Time (mean ± σ):      3.922 s ±  0.073 s    [User: 5.466 s, System: 0.683 s]
  Range (min … max):    3.826 s …  4.096 s    10 runs

hyperfine --warmup 3 './target/release/risinglight -f tests/sql/tpch/q3.sql'
Benchmark 1: ./target/release/risinglight -f tests/sql/tpch/q3.sql
  Time (mean ± σ):      1.744 s ±  0.028 s    [User: 1.376 s, System: 0.412 s]
  Range (min … max):    1.725 s …  1.815 s    10 runs

hyperfine --warmup 3 './target/release/risinglight -f tests/sql/tpch/q5.sql'
Benchmark 1: ./target/release/risinglight -f tests/sql/tpch/q5.sql
  Time (mean ± σ):      3.760 s ±  0.051 s    [User: 3.242 s, System: 0.528 s]
  Range (min … max):    3.702 s …  3.879 s    10 runs

hyperfine --warmup 3 './target/release/risinglight -f tests/sql/tpch/q6.sql'
Benchmark 1: ./target/release/risinglight -f tests/sql/tpch/q6.sql
  Time (mean ± σ):      2.536 s ±  0.530 s    [User: 2.064 s, System: 0.407 s]
  Range (min … max):    2.270 s …  4.029 s    10 runs

hyperfine --warmup 3 './target/release/risinglight -f tests/sql/tpch/q10.sql'
Benchmark 1: ./target/release/risinglight -f tests/sql/tpch/q10.sql
  Time (mean ± σ):      2.541 s ±  0.059 s    [User: 2.072 s, System: 0.517 s]
  Range (min … max):    2.476 s …  2.639 s    10 runs
```
