### PR TITLE
chore(storage): remove redundant get_current_row_id

### DIFF
--- a/src/storage/secondary/column/concrete_column_iterator.rs
+++ b/src/storage/secondary/column/concrete_column_iterator.rs
@@ -56,10 +56,6 @@ pub struct ConcreteColumnIterator<A: Array, F: BlockIteratorFactory<A>> {
 }
 
 impl<A: Array, F: BlockIteratorFactory<A>> ConcreteColumnIterator<A, F> {
-    #[cfg(test)]
-    pub fn get_current_row_id(&self) -> u32 {
-        self.current_row_id
-    }
 
     pub async fn new(column: Column, start_pos: u32, factory: F) -> StorageResult<Self> {
         let current_block_id = column

--- a/src/storage/secondary/column/concrete_column_iterator.rs
+++ b/src/storage/secondary/column/concrete_column_iterator.rs
@@ -56,7 +56,6 @@ pub struct ConcreteColumnIterator<A: Array, F: BlockIteratorFactory<A>> {
 }
 
 impl<A: Array, F: BlockIteratorFactory<A>> ConcreteColumnIterator<A, F> {
-
     pub async fn new(column: Column, start_pos: u32, factory: F) -> StorageResult<Self> {
         let current_block_id = column
             .index()

--- a/src/storage/secondary/column/primitive_column_factory.rs
+++ b/src/storage/secondary/column/primitive_column_factory.rs
@@ -220,7 +220,7 @@ mod tests {
         {
             recv_data.extend(data.to_vec());
             filter_bitmap =
-                filter_bitmap.split_off((scanner.get_current_row_id() - start_row_id) as usize);
+                filter_bitmap.split_off((scanner.fetch_current_row_id() - start_row_id) as usize);
         }
         recv_data
     }


### PR DESCRIPTION
Signed-off-by: asuka <312856403@qq.com>

Follow-up of #424 
For [the optimization](https://github.com/risinglightdb/risinglight/pull/424#discussion_r802473971), I think we already ensured `self.dvs` not to be empty at L137, right? cc @skyzh
https://github.com/risinglightdb/risinglight/blob/1a026b6ff74c57b27688c904094f145861931bf4/src/storage/secondary/rowset/rowset_iterator.rs?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L135-L153