### PR TITLE
executor: hash join support multi columns as hash key.

### DIFF
--- a/src/array/data_chunk.rs
+++ b/src/array/data_chunk.rs
@@ -182,6 +182,13 @@ impl RowRef<'_> {
         self.chunk.array_at(idx).get(self.row_idx)
     }
 
+    pub fn get_by_indexes(&self, indexes: &[usize]) -> Vec<DataValue> {
+        indexes
+            .iter()
+            .map(|i| self.chunk.array_at(*i).get(self.row_idx))
+            .collect()
+    }
+
     /// Get an iterator over the values of the row.
     pub fn values(&self) -> impl Iterator<Item = DataValue> + '_ {
         self.chunk.arrays().iter().map(|a| a.get(self.row_idx))

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -19,10 +19,11 @@ use futures_async_stream::try_stream;
 use itertools::Itertools;
 
 use crate::array::DataChunk;
+use crate::binder::BoundExpr;
 use crate::optimizer::plan_nodes::*;
 use crate::optimizer::PlanVisitor;
 use crate::storage::{StorageImpl, TracedStorageError};
-use crate::types::ConvertError;
+use crate::types::{ConvertError, DataValue};
 
 mod aggregation;
 mod copy_from_file;
@@ -274,14 +275,23 @@ impl PlanVisitor<BoxedExecutor> for ExecutorBuilder {
     fn visit_physical_hash_join(&mut self, plan: &PhysicalHashJoin) -> Option<BoxedExecutor> {
         let left_child = self.visit(plan.left()).unwrap();
         let right_child = self.visit(plan.right()).unwrap();
+
+        let left_col_num = plan.left().out_types().len();
+        let (left_column_indexes, right_column_indexes) = plan
+            .logical()
+            .predicate()
+            .eq_keys()
+            .iter()
+            .map(|(left, right)| (left.index, right.index - left_col_num))
+            .unzip();
         Some(
             HashJoinExecutor {
                 left_child,
                 right_child,
                 join_op: plan.logical().join_op(),
-                condition: plan.logical().predicate().to_on_clause(),
-                left_column_index: plan.left_column_index(),
-                right_column_index: plan.right_column_index(),
+                condition: BoundExpr::Constant(DataValue::Bool(true)),
+                left_column_indexes,
+                right_column_indexes,
                 left_types: plan.left().out_types(),
                 right_types: plan.right().out_types(),
             }

--- a/src/optimizer/logical_plan_rewriter/convert_physical.rs
+++ b/src/optimizer/logical_plan_rewriter/convert_physical.rs
@@ -52,7 +52,14 @@ impl PlanRewriter for PhysicalConverter {
                 || !predicate.other_conds().is_empty();
             if need_pull_filter {
                 return Arc::new(PhysicalFilter::new(LogicalFilter::new(
-                    predicate.to_on_clause(),
+                    merge_conjunctions(
+                        predicate
+                            .left_conds()
+                            .iter()
+                            .cloned()
+                            .chain(predicate.right_conds().iter().cloned())
+                            .chain(predicate.other_conds().iter().cloned()),
+                    ),
                     join,
                 )));
             } else {

--- a/src/optimizer/plan_nodes/join_predicate.rs
+++ b/src/optimizer/plan_nodes/join_predicate.rs
@@ -17,8 +17,9 @@ pub struct JoinPredicate {
     /// other conditions, linked with AND conjunction.
     other_conds: Vec<BoundExpr>,
 
-    /// the equal columns indexes(in the input schema) both sides, now all are normal equal(not
-    /// null-safe-equal),
+    /// the equal columns indexes(in the input schema) both sides,
+    /// the first is from the left table and the second is from the right table.
+    /// now all are normal equal(not null-safe-equal),
     eq_keys: Vec<(BoundInputRef, BoundInputRef)>,
 }
 #[allow(dead_code)]
@@ -40,7 +41,7 @@ impl JoinPredicate {
     /// `create` will analyze the on clause condition and construct a `JoinPredicate`.
     /// e.g.
     /// ```sql
-    ///   select a.v1, a.v2, b.v1, b.v2 from a,b on a.v1 = a.v2 and a.v1 = b.v1 and a.v2 > b.v2
+    ///   select a.v1, a.v2, b.v1, b.v2 from a join b on a.v1 = a.v2 and a.v1 = b.v1 and a.v2 > b.v2
     /// ```
     /// will call the `create` function with `left_colsnum` = 2 and `on_clause` is (supposed
     /// `input_ref` count start from 0)

--- a/src/optimizer/plan_nodes/physical_hash_join.rs
+++ b/src/optimizer/plan_nodes/physical_hash_join.rs
@@ -10,32 +10,16 @@ use super::*;
 #[derive(Clone, Debug, Serialize)]
 pub struct PhysicalHashJoin {
     logical: LogicalJoin,
-    left_column_index: usize,
-    right_column_index: usize,
 }
 
 impl PhysicalHashJoin {
-    pub fn new(logical: LogicalJoin, left_column_index: usize, right_column_index: usize) -> Self {
-        Self {
-            logical,
-            left_column_index,
-            right_column_index,
-        }
+    pub fn new(logical: LogicalJoin) -> Self {
+        Self { logical }
     }
 
     /// Get a reference to the physical hash join's logical.
     pub fn logical(&self) -> &LogicalJoin {
         &self.logical
-    }
-
-    /// Get a reference to the physical hash join's left column index.
-    pub fn left_column_index(&self) -> usize {
-        self.left_column_index
-    }
-
-    /// Get a reference to the physical hash join's right column index.
-    pub fn right_column_index(&self) -> usize {
-        self.right_column_index
     }
 }
 impl PlanTreeNodeBinary for PhysicalHashJoin {
@@ -48,11 +32,7 @@ impl PlanTreeNodeBinary for PhysicalHashJoin {
 
     #[must_use]
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
-        Self::new(
-            self.logical.clone_with_left_right(left, right),
-            self.left_column_index(),
-            self.right_column_index(),
-        )
+        Self::new(self.logical.clone_with_left_right(left, right))
     }
 }
 impl_plan_tree_node_for_binary!(PhysicalHashJoin);
@@ -68,10 +48,8 @@ impl fmt::Display for PhysicalHashJoin {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(
             f,
-            "PhysicalHashJoin: op {:?}, left_index {:?},  right_index {:?}, predicate: {} ",
+            "PhysicalHashJoin: op {:?}, predicate: {} ",
             self.logical().join_op(),
-            self.left_column_index,
-            self.right_column_index,
             self.logical().predicate()
         )
     }

--- a/tests/sql/join.slt
+++ b/tests/sql/join.slt
@@ -92,3 +92,35 @@ select v1, v2, v3, v4 from a full join b on v1 = v3;
 3 3 3 300
 2 2 NULL NULL
 NULL NULL 4 400
+
+statement ok
+drop table a;
+
+statement ok
+drop table b;
+
+statement ok
+create table a(v1 int, v2 int);
+
+statement ok
+create table b(v3 int, v4 int, v5 int);
+
+statement ok
+insert into a values (1, 1), (2, 2), (3, 3);
+
+statement ok
+insert into b values (1, 1, 1), (2, 2, 2), (3, 3, 4), (1, 1, 5);
+
+query IIIII
+select v1, v2, v3, v4, v5 from a join b on v1 = v3 and v2 = v4;
+----
+1   1   1   1   1
+2   2   2   2   2
+3   3   3   3   4
+1   1   1   1   5
+
+query IIIII
+select v1, v2, v3, v4, v5 from a join b on v1 = v3 and v2 = v4 and v1 < v5;
+----
+3   3   3   3   4
+1   1   1   1   5


### PR DESCRIPTION
closes https://github.com/risinglightdb/risinglight/issues/362

- `PhysicalHashJoin`'s `left/right_column_index` fields are deleted, only `logical` left. 
- `HashJoinExecutor`'s same fields are changed from `index` -> `indexes`. They are computed in `visit_physical_hash_join` now. (Previously in `rewrite_logical_join`)