### PR TITLE
cli: trim command's leading and trailing whitespace

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -163,7 +163,7 @@ impl Database {
 
     /// Run SQL queries and return the outputs.
     pub async fn run(&self, sql: &str) -> Result<Vec<DataChunk>, Error> {
-        if let Some(cmdline) = sql.strip_prefix('\\') {
+        if let Some(cmdline) = sql.trim().strip_prefix('\\') {
             return self.run_internal(cmdline).await;
         }
 


### PR DESCRIPTION
Previously:
![image](https://user-images.githubusercontent.com/37948597/153719333-56ecf1cf-8184-4a32-89a2-d1d371f8d4f4.png)