### PR TITLE
fix(storage): skip flush in rowset builder if it's empty, allow empty `finish` of column builders.

### DIFF
--- a/src/storage/secondary/column/char_column_builder.rs
+++ b/src/storage/secondary/column/char_column_builder.rs
@@ -46,6 +46,10 @@ impl CharColumnBuilder {
     }
 
     fn finish_builder(&mut self) {
+        if self.current_builder.is_none() {
+            return;
+        }
+
         let (block_type, stats, mut block_data) = match self.current_builder.take().unwrap() {
             CharBlockBuilderImpl::PlainFixedChar(builder) => (
                 BlockType::PlainFixedChar,

--- a/src/storage/secondary/column/primitive_column_builder.rs
+++ b/src/storage/secondary/column/primitive_column_builder.rs
@@ -55,6 +55,10 @@ impl<T: PrimitiveFixedWidthEncode> PrimitiveColumnBuilder<T> {
     }
 
     fn finish_builder(&mut self) {
+        if self.current_builder.is_none() {
+            return;
+        }
+
         let (block_type, stats, mut block_data) = match self.current_builder.take().unwrap() {
             BlockBuilderImpl::Plain(builder) => {
                 (BlockType::Plain, builder.get_statistics(), builder.finish())

--- a/src/storage/secondary/rowset/rowset_builder.rs
+++ b/src/storage/secondary/rowset/rowset_builder.rs
@@ -99,6 +99,11 @@ impl RowsetBuilder {
     }
 
     pub async fn finish_and_flush(self) -> StorageResult<()> {
+        // Skip flush when empty.
+        if self.row_cnt == 0 {
+            return Ok(());
+        }
+
         for (column_info, builder) in self.columns.iter().zip(self.builders) {
             let (index, data) = builder.finish();
 


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

As mentioned in #489 , the panic is caused by invoking `finish_and_flush` on an empty rowset builder, then finishes an empty column builder. Thanks @skyzh for pointing out my problem.

This PR fixes these problems by allowing finishing empty column builder and skip the `finish_and_flush` of rowset builder entirely if empty.