### PR TITLE
fix(planner): row handler not included when count(*) is used as subexpression

### DIFF
--- a/src/binder/expression/mod.rs
+++ b/src/binder/expression/mod.rs
@@ -92,6 +92,40 @@ impl BoundExpr {
         self.get_filter_column_inner(&mut filter_column);
         filter_column
     }
+
+    pub fn contains_column_ref(&self) -> bool {
+        match self {
+            BoundExpr::Constant(_) => false,
+            BoundExpr::ColumnRef(_) => true,
+            BoundExpr::InputRef(_) => false,
+            BoundExpr::BinaryOp(e) => {
+                e.left_expr.contains_column_ref() || e.right_expr.contains_column_ref()
+            }
+            BoundExpr::UnaryOp(e) => e.expr.contains_column_ref(),
+            BoundExpr::TypeCast(e) => e.expr.contains_column_ref(),
+            BoundExpr::AggCall(e) => e.args.iter().any(|e| e.contains_column_ref()),
+            BoundExpr::IsNull(e) => e.expr.contains_column_ref(),
+            BoundExpr::ExprWithAlias(e) => e.expr.contains_column_ref(),
+            BoundExpr::Alias(_) => true,
+        }
+    }
+
+    pub fn contains_row_count(&self) -> bool {
+        match self {
+            BoundExpr::Constant(_) => false,
+            BoundExpr::ColumnRef(_) => false,
+            BoundExpr::InputRef(_) => false,
+            BoundExpr::BinaryOp(e) => {
+                e.left_expr.contains_row_count() || e.right_expr.contains_row_count()
+            }
+            BoundExpr::UnaryOp(e) => e.expr.contains_row_count(),
+            BoundExpr::TypeCast(e) => e.expr.contains_row_count(),
+            BoundExpr::AggCall(e) => e.kind == AggKind::RowCount,
+            BoundExpr::IsNull(e) => e.expr.contains_row_count(),
+            BoundExpr::ExprWithAlias(e) => e.expr.contains_row_count(),
+            BoundExpr::Alias(_) => false,
+        }
+    }
 }
 
 impl std::fmt::Debug for BoundExpr {

--- a/src/logical_planner/select.rs
+++ b/src/logical_planner/select.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 
 use super::*;
 use crate::binder::{
-    AggKind, BoundAggCall, BoundExpr, BoundInputRef, BoundOrderBy, BoundSelect, BoundTableRef,
+    BoundAggCall, BoundExpr, BoundInputRef, BoundOrderBy, BoundSelect, BoundTableRef,
 };
 use crate::optimizer::plan_nodes::{
     Dummy, LogicalAggregate, LogicalFilter, LogicalJoin, LogicalLimit, LogicalOrder,
@@ -36,20 +36,10 @@ impl LogicalPlaner {
             }
             if let BoundTableRef::JoinTableRef { join_tables, .. } = table_ref {
                 if join_tables.is_empty() {
-                    stmt.select_list.iter().for_each(|expr| match expr {
-                        BoundExpr::AggCall(expr) => {
-                            if expr.kind == AggKind::RowCount {
-                                with_row_handler = true;
-                            }
+                    stmt.select_list.iter().for_each(|expr| {
+                        if expr.contains_row_count() && !expr.contains_column_ref() {
+                            with_row_handler = true;
                         }
-                        BoundExpr::ExprWithAlias(expr) => {
-                            if let BoundExpr::AggCall(expr) = &*expr.expr {
-                                if expr.kind == AggKind::RowCount {
-                                    with_row_handler = true;
-                                }
-                            }
-                        }
-                        _ => {}
                     });
                 }
             }

--- a/tests/sql/count.slt
+++ b/tests/sql/count.slt
@@ -10,6 +10,26 @@ select count(*) from t
 8
 
 query I
+select count(*)+1 from t;
+----
+9
+
+query I
+select 2*count(*) from t;
+----
+16
+
+query I
+select -count(*) from t;
+----
+-8
+
+query I
+select count(*)+min(v) from t;
+----
+9
+
+query I
 select count(*) as 'total' from t where v > 5
 ----
 3


### PR DESCRIPTION
fix https://github.com/risinglightdb/risinglight/issues/501


```sql
> explain select count(*) from t;
PhysicalProjection: exprs [InputRef #0]
  PhysicalSimpleAgg: 1 agg calls
    PhysicalTableScan: table #10, columns [], with_row_handler: true, is_sorted: false, expr: None

> explain select 1 from t;
PhysicalProjection: exprs [Int32(1) (const)]
  PhysicalTableScan: table #10, columns [], with_row_handler: false, is_sorted: false, expr: None

> explain select count(*)+1 from t;
PhysicalProjection: exprs [Plus(InputRef #0, Int32(1) (const))]
  PhysicalSimpleAgg: 1 agg calls
    PhysicalTableScan: table #10, columns [], with_row_handler: true, is_sorted: false, expr: None

> explain select -count(*) from t;
PhysicalProjection: exprs [BoundUnaryOp { op: Minus, expr: InputRef #0, return_type: Some(Int(None)) }]
  PhysicalSimpleAgg: 1 agg calls
    PhysicalTableScan: table #10, columns [], with_row_handler: true, is_sorted: false, expr: None

```