### PR TITLE
fix(storage): filter columns will be skipped incorrectly

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -115,7 +115,7 @@ pub trait Table: Sync + Send + Clone + 'static {
 }
 
 /// Reference to a column.
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum StorageColumnRef {
     /// A runtime column which contains necessary information to locate a row
     /// **only valid in the current transaction**.

--- a/src/storage/secondary/rowset/rowset_iterator.rs
+++ b/src/storage/secondary/rowset/rowset_iterator.rs
@@ -13,7 +13,7 @@ use crate::storage::secondary::DeleteVector;
 use crate::storage::{PackedVec, StorageChunk, StorageColumnRef, StorageResult};
 
 /// When `expected_size` is not specified, we should limit the maximum size of the chunk.
-const ROWSET_MAX_OUTPUT: usize = 65536;
+const ROWSET_MAX_OUTPUT: usize = 2048;
 
 /// Iterates on a `RowSet`
 pub struct RowSetIterator {

--- a/src/storage/secondary/rowset/rowset_iterator.rs
+++ b/src/storage/secondary/rowset/rowset_iterator.rs
@@ -226,7 +226,9 @@ impl RowSetIterator {
             // in filter conditions
             if filter_bitmap.not_any() {
                 for (id, _) in self.column_refs.iter().enumerate() {
-                    self.column_iterators[id].skip(filter_bitmap.len());
+                    if !filter_columns[id] {
+                        self.column_iterators[id].skip(filter_bitmap.len());
+                    }
                 }
                 return Ok((false, None));
             }
@@ -251,8 +253,12 @@ impl RowSetIterator {
                     .await?
                 {
                     if let Some(x) = common_chunk_range {
-                        if x != (row_id, array.len()) {
-                            panic!("unmatched rowid from column iterator");
+                        let current_data = (row_id, array.len());
+                        if x != current_data {
+                            panic!(
+                                "unmatched rowid from column iterator: {:?} of [{:?}], {:?} != {:?}",
+                                self.column_refs[id], self.column_refs, x, current_data
+                            );
                         }
                     }
                     common_chunk_range = Some((row_id, array.len()));


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

If `filter_map` is all false when filter condition gets evaluated, as we have already scanned filter columns, we should not skip them.