### PR TITLE
fix(executor): limit should exit early when offset and limit are both 0

### DIFF
--- a/src/executor/limit.rs
+++ b/src/executor/limit.rs
@@ -22,6 +22,9 @@ impl LimitExecutor {
             let batch = batch?;
             if dummy_chunk.is_none() {
                 dummy_chunk = Some(batch.slice(0..0));
+                if self.offset == 0 && self.limit == 0 {
+                    break;
+                }
             }
             let cardinality = batch.cardinality();
             let start = processed.max(self.offset) - processed;

--- a/tests/sql/limit.slt
+++ b/tests/sql/limit.slt
@@ -40,3 +40,11 @@ select v1 from t limit 0
 query I
 select v1 from t offset 5
 ----
+
+# test case for https://github.com/risinglightdb/risinglight/issues/264
+statement ok
+insert into t values (1, 1)
+
+query I
+select v1 from t limit 0
+----


### PR DESCRIPTION
Fix https://github.com/risinglightdb/risinglight/issues/264

The issue can be reproduced using memory engine like this: (Btw, the sqlogictest fails for both disk & memory engines)
```sql
> create table t(x int);insert into t values (0);insert into t values (0);
> select * from t limit 0;
```
The execution process is 
```
processed 0, cardinality 1, offsef 0, limit 0
processed 1, cardinality 1, offsef 0, limit 0 # boom
```

Because when `offset=limit=0`, `start=end=0`, and thus it will `continue`.
https://github.com/risinglightdb/risinglight/blob/fea5e0b3de264e3f2275d1ca6c04c2c97ef8d639/src/executor/limit.rs#L27-L32