### PR TITLE
optimize(cli): optimize the execution time format and omit to print time on empty query

### DIFF
--- a/src/utils/time/duration.rs
+++ b/src/utils/time/duration.rs
@@ -1,0 +1,92 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::time::Duration;
+
+pub trait RoundingDuration {
+    /// Round duration to the nearest microseconds.
+    fn round_to_micros(self) -> Self;
+
+    /// Round duration to the nearest milliseconds.
+    fn round_to_millis(self) -> Self;
+
+    /// Round duration to the nearest seconds.
+    fn round_to_seconds(self) -> Self;
+}
+
+impl RoundingDuration for std::time::Duration {
+    fn round_to_micros(self) -> Self {
+        Duration::new(self.as_secs(), (self.subsec_nanos() + 500) / 1000 * 1000)
+    }
+
+    fn round_to_millis(self) -> Self {
+        Duration::new(
+            self.as_secs(),
+            (self.subsec_nanos() + 500_000) / 1_000_000 * 1_000_000,
+        )
+    }
+
+    fn round_to_seconds(self) -> Self {
+        Duration::new(
+            self.as_secs()
+                + if self.subsec_nanos() >= 500_000_000 {
+                    1
+                } else {
+                    0
+                },
+            0,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rounding_duration() {
+        assert_eq!(Duration::new(0, 1).round_to_micros(), Duration::new(0, 0));
+        assert_eq!(Duration::new(0, 499).round_to_micros(), Duration::new(0, 0));
+        assert_eq!(
+            Duration::new(0, 500).round_to_micros(),
+            Duration::new(0, 1_000)
+        );
+        assert_eq!(
+            Duration::new(0, 999).round_to_micros(),
+            Duration::new(0, 1_000)
+        );
+
+        assert_eq!(
+            Duration::from_micros(1).round_to_millis(),
+            Duration::from_micros(0)
+        );
+        assert_eq!(
+            Duration::from_micros(499).round_to_millis(),
+            Duration::from_micros(0)
+        );
+        assert_eq!(
+            Duration::from_micros(500).round_to_millis(),
+            Duration::from_micros(1_000)
+        );
+        assert_eq!(
+            Duration::from_micros(999).round_to_millis(),
+            Duration::from_micros(1_000)
+        );
+
+        assert_eq!(
+            Duration::from_millis(1).round_to_seconds(),
+            Duration::from_millis(0)
+        );
+        assert_eq!(
+            Duration::from_millis(499).round_to_seconds(),
+            Duration::from_millis(0)
+        );
+        assert_eq!(
+            Duration::from_millis(500).round_to_seconds(),
+            Duration::from_millis(1_000)
+        );
+        assert_eq!(
+            Duration::from_millis(999).round_to_seconds(),
+            Duration::from_millis(1_000)
+        );
+    }
+}

--- a/src/utils/time/mod.rs
+++ b/src/utils/time/mod.rs
@@ -1,4 +1,5 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
-pub mod sync;
-pub mod time;
+pub use duration::*;
+
+mod duration;


### PR DESCRIPTION
Signed-off-by: arkbriar <arkbriar@gmail.com>

close #510 

Optimize the time format to be similar to [pgcli](https://github.com/dbcli/pgcli), which prints the execution time in seconds with three precision numbers and also a human-readable duration in seconds when the duration is longer than 1 second.

Examples: 

1. Empty lines (no output)

```bash
> 
> 
> 
```

2. In 1s (only duration in seconds)

```bash
select count(*) from lineitem;
+---------+
| count   |
+---------+
| 6001215 |
+---------+
in 0.186s
```

3. Longer than 1s (with human-readable duration)

```bash
select
    l_returnflag,
    l_linestatus,
    sum(l_quantity) as sum_qty,
    sum(l_extendedprice) as sum_base_price,
    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
    avg(l_quantity) as avg_qty,
    avg(l_extendedprice) as avg_price,
    avg(l_discount) as avg_disc,
    count(*) as count_order
from
    lineitem
where
    l_shipdate <= date '1998-12-01' - interval '71' day
group by
    l_returnflag,
    l_linestatus
order by
    l_returnflag,
    l_linestatus;
+--------------+--------------+----------+-----------------+-------------------+---------------------+--------------------------------+--------------------------------+--------------------------------+-------------+
| l_returnflag | l_linestatus | sum_qty  | sum_base_price  | sum_disc_price    | sum_charge          | avg_qty                        | avg_price                      | avg_disc                       | count_order |
+--------------+--------------+----------+-----------------+-------------------+---------------------+--------------------------------+--------------------------------+--------------------------------+-------------+
| A            | F            | 37734107 | 56586554400.73  | 53758257134.8700  | 55909065222.827692  | 25.522005853257337031693758442 | 38273.129734621672202709109884 | 0.0499852958383976116221043995 | 1478493     |
| N            | F            | 991417   | 1487504710.38   | 1413082168.0541   | 1469649223.194375   | 25.516471920522983476604725382 | 38284.467760848303906933649045 | 0.0500934266742162969063674268 | 38854       |
| N            | O            | 75283683 | 112909876769.66 | 107265890064.7416 | 111560462484.162066 | 25.500840389078803497319290943 | 38245.960228243034695434326354 | 0.0499965957637073860749460403 | 2952204     |
| R            | F            | 37719753 | 56568041380.90  | 53741292684.6040  | 55889619119.831932  | 25.505793612690770655973817847 | 38250.85462609965717067761196  | 0.0500094058301270564687903602 | 1478870     |
+--------------+--------------+----------+-----------------+-------------------+---------------------+--------------------------------+--------------------------------+--------------------------------+-------------+
in 5.888s (6s)
```

4. Interrupted (no output)

```bash
> select
    l_returnflag,
    l_linestatus,
    sum(l_quantity) as sum_qty,
    sum(l_extendedprice) as sum_base_price,
    sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
    sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
    avg(l_quantity) as avg_qty,
    avg(l_extendedprice) as avg_price,
    avg(l_discount) as avg_disc,
    count(*) as count_order
from
    lineitem
where
    l_shipdate <= date '1998-12-01' - interval '71' day
group by
    l_returnflag,
    l_linestatus
order by
    l_returnflag,
    l_linestatus;
^CInterrupted
2022-02-21T11:57:20.018646Z  WARN risinglight::executor::table_scan: Abort!
```