### PR TITLE
chore(storage): use tokio OwnedMutexGuard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "parking_lot"] }
+
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_tokio"] }
 env_logger = "0.9"

--- a/src/storage/secondary/mod.rs
+++ b/src/storage/secondary/mod.rs
@@ -43,6 +43,7 @@ mod row_handler;
 mod table;
 mod transaction;
 mod txn_iterator;
+
 // internal modules and structures
 mod block;
 mod checksum;
@@ -58,10 +59,11 @@ mod merge_iterator;
 mod rowset;
 mod statistics;
 mod storage;
-#[cfg(test)]
-mod tests;
 mod transaction_manager;
 mod version_manager;
+
+#[cfg(test)]
+mod tests;
 
 /// Secondary storage of RisingLight.
 pub struct SecondaryStorage {

--- a/src/storage/secondary/table.rs
+++ b/src/storage/secondary/table.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::Arc;
 
 use moka::future::Cache;
+use tokio::sync::OwnedMutexGuard;
 
 use super::*;
 use crate::catalog::TableRefId;
@@ -99,7 +100,7 @@ impl SecondaryTable {
         self.table_ref_id.table_id
     }
 
-    pub async fn lock_for_deletion(&self) -> TransactionLock {
+    pub async fn lock_for_deletion(&self) -> OwnedMutexGuard<()> {
         self.txn_mgr.lock_for_deletion(self.table_id()).await
     }
 }

--- a/src/storage/secondary/transaction.rs
+++ b/src/storage/secondary/transaction.rs
@@ -7,13 +7,14 @@ use futures::Future;
 use itertools::Itertools;
 use risinglight_proto::rowset::block_statistics::BlockStatisticsType;
 use risinglight_proto::rowset::DeleteRecord;
+use tokio::sync::OwnedMutexGuard;
 use tracing::{info, warn};
 
 use super::version_manager::{Snapshot, VersionManager};
 use super::{
     AddDVEntry, AddRowSetEntry, ColumnBuilderOptions, ColumnSeekPosition, ConcatIterator,
     DeleteVector, DiskRowset, EpochOp, MergeIterator, RowSetIterator, SecondaryMemRowsetImpl,
-    SecondaryRowHandler, SecondaryTable, SecondaryTableTxnIterator, TransactionLock,
+    SecondaryRowHandler, SecondaryTable, SecondaryTableTxnIterator,
 };
 use crate::array::DataChunk;
 use crate::binder::BoundExpr;
@@ -50,7 +51,7 @@ pub struct SecondaryTransaction {
     /// The rowsets produced in the txn.
     to_be_committed_rowsets: Vec<DiskRowset>,
 
-    delete_lock: Option<TransactionLock>,
+    delete_lock: Option<OwnedMutexGuard<()>>,
 
     read_only: bool,
 

--- a/src/storage/secondary/transaction_manager.rs
+++ b/src/storage/secondary/transaction_manager.rs
@@ -1,9 +1,10 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
-use async_channel::{unbounded, Receiver, Sender};
 use parking_lot::Mutex as PLMutex;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 
 /// Secondary's Transaction Manager.
 ///
@@ -17,60 +18,40 @@ use parking_lot::Mutex as PLMutex;
 #[derive(Default)]
 pub struct TransactionManager {
     /// A single big lock for each table
-    ///
-    /// To make things easy, we use a pair of channel to mock a Mutex. All async Mutex requires
-    /// some kind of lifetime in their guards, which make the code hard to implement. An item
-    /// in channel represents its availability.
-    #[allow(clippy::type_complexity)]
-    lock_map: PLMutex<HashMap<u32, (Sender<()>, Receiver<()>)>>,
-}
-
-pub struct TransactionLock {
-    tx: Sender<()>,
-}
-
-impl Drop for TransactionLock {
-    fn drop(&mut self) {
-        self.tx.try_send(()).unwrap();
-    }
+    lock_map: PLMutex<HashMap<u32, Arc<Mutex<()>>>>,
 }
 
 impl TransactionManager {
-    fn get_lock_for_table(&self, table: u32) -> (Sender<()>, Receiver<()>) {
+    fn get_lock_for_table(&self, table: u32) -> Arc<Mutex<()>> {
         let mut lock_map = self.lock_map.lock();
         lock_map
             .entry(table)
-            .or_insert_with(|| {
-                let (tx, rx) = unbounded();
-                // only one member can get the lock, so we send one `()` message.
-                tx.try_send(()).unwrap();
-                (tx, rx)
-            })
+            .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone()
     }
 
     /// Get a lock for compaction, return immediately
-    pub fn try_lock_for_compaction(&self, table: u32) -> Option<TransactionLock> {
-        let (tx, rx) = self.get_lock_for_table(table);
-        match rx.try_recv() {
-            Ok(()) => Some(TransactionLock { tx }),
-            Err(_) => None,
+    pub fn try_lock_for_compaction(&self, table: u32) -> Option<OwnedMutexGuard<()>> {
+        let mutex = self.get_lock_for_table(table);
+        if let Ok(guard) = mutex.try_lock_owned() {
+            Some(guard)
+        } else {
+            None
         }
     }
 
-    async fn lock(&self, table: u32) -> TransactionLock {
-        let (tx, rx) = self.get_lock_for_table(table);
-        rx.recv().await.unwrap();
-        TransactionLock { tx }
+    async fn lock(&self, table: u32) -> OwnedMutexGuard<()> {
+        let mutex = self.get_lock_for_table(table);
+        mutex.lock_owned().await
     }
 
     /// Get a lock for compaction
-    pub async fn lock_for_compaction(&self, table: u32) -> TransactionLock {
+    pub async fn lock_for_compaction(&self, table: u32) -> OwnedMutexGuard<()> {
         self.lock(table).await
     }
 
     /// Get a lock for deletion
-    pub async fn lock_for_deletion(&self, table: u32) -> TransactionLock {
+    pub async fn lock_for_deletion(&self, table: u32) -> OwnedMutexGuard<()> {
         self.lock(table).await
     }
 }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

It turned out that tokio already has an `OwnedMutexGuard`... Before realizing tokio already provides such functionality, I wasted ~1hr implementing a self-referential struct and wrapping MutexGuard with a Arc by myself 🤣