### PR TITLE
refactor: introduce visitor for expr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 /tpch-dbgen
 /.vscode
+.gdb_history

--- a/src/binder/expr_visitor.rs
+++ b/src/binder/expr_visitor.rs
@@ -1,0 +1,130 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use super::expression::*;
+use crate::types::DataValue;
+
+pub trait ExprVisitor {
+    fn visit_expr(&mut self, expr: &BoundExpr) {
+        match expr {
+            BoundExpr::Constant(v) => self.visit_constant(v),
+            BoundExpr::ColumnRef(expr) => self.visit_column_ref(expr),
+            BoundExpr::InputRef(expr) => self.visit_input_ref(expr),
+            BoundExpr::BinaryOp(expr) => self.visit_binary_op(expr),
+            BoundExpr::UnaryOp(expr) => self.visit_unary_op(expr),
+            BoundExpr::TypeCast(expr) => self.visit_type_cast(expr),
+            BoundExpr::AggCall(expr) => self.visit_agg_call(expr),
+            BoundExpr::IsNull(expr) => self.visit_is_null(expr),
+            BoundExpr::ExprWithAlias(expr) => self.visit_expr_with_alias(expr),
+            BoundExpr::Alias(expr) => self.visit_alias(expr),
+        }
+    }
+
+    fn visit_constant(&mut self, _: &DataValue) {}
+
+    fn visit_column_ref(&mut self, _: &BoundColumnRef) {}
+
+    fn visit_input_ref(&mut self, _: &BoundInputRef) {}
+
+    fn visit_binary_op(&mut self, expr: &BoundBinaryOp) {
+        self.visit_expr(expr.left_expr.as_ref());
+        self.visit_expr(expr.right_expr.as_ref());
+    }
+
+    fn visit_unary_op(&mut self, expr: &BoundUnaryOp) {
+        self.visit_expr(expr.expr.as_ref());
+    }
+
+    fn visit_type_cast(&mut self, expr: &BoundTypeCast) {
+        self.visit_expr(expr.expr.as_ref());
+    }
+
+    fn visit_agg_call(&mut self, agg: &BoundAggCall) {
+        for arg in &agg.args {
+            self.visit_expr(arg);
+        }
+    }
+
+    fn visit_is_null(&mut self, expr: &BoundIsNull) {
+        self.visit_expr(expr.expr.as_ref());
+    }
+
+    fn visit_expr_with_alias(&mut self, expr: &BoundExprWithAlias) {
+        self.visit_expr(expr.expr.as_ref());
+    }
+
+    fn visit_alias(&mut self, _: &BoundAlias) {}
+}
+
+pub trait ExprRewriter {
+    fn rewrite_expr(&self, expr: &mut BoundExpr) {
+        match expr {
+            BoundExpr::Constant(_) => self.rewrite_constant(expr),
+            BoundExpr::ColumnRef(_) => self.rewrite_column_ref(expr),
+            BoundExpr::InputRef(_) => self.rewrite_input_ref(expr),
+            BoundExpr::BinaryOp(_) => self.rewrite_binary_op(expr),
+            BoundExpr::UnaryOp(_) => self.rewrite_unary_op(expr),
+            BoundExpr::TypeCast(_) => self.rewrite_type_cast(expr),
+            BoundExpr::AggCall(_) => self.rewrite_agg_call(expr),
+            BoundExpr::IsNull(_) => self.rewrite_is_null(expr),
+            BoundExpr::ExprWithAlias(_) => self.rewrite_expr_with_alias(expr),
+            BoundExpr::Alias(_) => self.rewrite_alias(expr),
+        }
+    }
+
+    fn rewrite_constant(&self, _: &mut BoundExpr) {}
+
+    fn rewrite_column_ref(&self, _: &mut BoundExpr) {}
+
+    fn rewrite_input_ref(&self, _: &mut BoundExpr) {}
+
+    fn rewrite_binary_op(&self, expr: &mut BoundExpr) {
+        match expr {
+            BoundExpr::BinaryOp(expr) => {
+                self.rewrite_expr(expr.left_expr.as_mut());
+                self.rewrite_expr(expr.right_expr.as_mut());
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_unary_op(&self, expr: &mut BoundExpr) {
+        match expr {
+            BoundExpr::UnaryOp(expr) => self.rewrite_expr(expr.expr.as_mut()),
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_type_cast(&self, expr: &mut BoundExpr) {
+        match expr {
+            BoundExpr::TypeCast(expr) => self.rewrite_expr(expr.expr.as_mut()),
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_agg_call(&self, agg: &mut BoundExpr) {
+        match agg {
+            BoundExpr::AggCall(agg) => {
+                for arg in &mut agg.args {
+                    self.rewrite_expr(arg);
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_is_null(&self, expr: &mut BoundExpr) {
+        match expr {
+            BoundExpr::IsNull(expr) => self.rewrite_expr(expr.expr.as_mut()),
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_expr_with_alias(&self, expr: &mut BoundExpr) {
+        match expr {
+            BoundExpr::ExprWithAlias(expr) => self.rewrite_expr(expr.expr.as_mut()),
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_alias(&self, _: &mut BoundExpr) {}
+}

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -10,10 +10,12 @@ use crate::catalog::{
 use crate::parser::{Ident, ObjectName, Statement};
 use crate::types::{ColumnId, DataTypeKind, DataValue};
 
+mod expr_visitor;
 mod expression;
 pub(crate) mod statement;
 mod table_ref;
 
+pub use self::expr_visitor::*;
 pub use self::expression::*;
 pub use self::statement::*;
 pub use self::table_ref::*;

--- a/src/optimizer/logical_plan_rewriter/arith_expr_simplification.rs
+++ b/src/optimizer/logical_plan_rewriter/arith_expr_simplification.rs
@@ -17,8 +17,9 @@ use crate::types::DataValue::*;
 pub struct ArithExprSimplificationRule;
 
 impl ExprRewriter for ArithExprSimplificationRule {
-    fn rewrite_expr(&self, expr: &mut BoundExpr) {
-        // TODO: support more data types.
+    // TODO: support more data types.
+
+    fn rewrite_binary_op(&self, expr: &mut BoundExpr) {
         let new = match &expr {
             BinaryOp(op) => match (&op.op, &*op.left_expr, &*op.right_expr) {
                 // x + 0, 0 + x
@@ -42,13 +43,26 @@ impl ExprRewriter for ArithExprSimplificationRule {
                 // x / 1
                 (Divide, other, Constant(Int32(1))) => other.clone(),
                 (Divide, other, Constant(Float64(f))) if *f == 1.0 => other.clone(),
-
                 _ => return,
             },
+            _ => unreachable!(),
+        };
+        *expr = new;
+    }
+
+    fn rewrite_unary_op(&self, expr: &mut BoundExpr) {
+        let new = match &expr {
             UnaryOp(op) => match (&op.op, &*op.expr) {
                 (UnaryOperator::Plus, other) => other.clone(),
                 _ => return,
             },
+            _ => unreachable!(),
+        };
+        *expr = new;
+    }
+
+    fn rewrite_type_cast(&self, expr: &mut BoundExpr) {
+        let new = match &expr {
             TypeCast(op) => match (&op.ty, &*op.expr) {
                 (Ty::Boolean, k @ Constant(Bool(_))) => k.clone(),
                 (Ty::Int(_), k @ Constant(Int32(_))) => k.clone(),
@@ -57,7 +71,7 @@ impl ExprRewriter for ArithExprSimplificationRule {
                 (Ty::String, k @ Constant(String(_))) => k.clone(),
                 _ => return,
             },
-            _ => return,
+            _ => unreachable!(),
         };
         *expr = new;
     }

--- a/src/optimizer/logical_plan_rewriter/bool_expr_simplification.rs
+++ b/src/optimizer/logical_plan_rewriter/bool_expr_simplification.rs
@@ -20,7 +20,7 @@ use crate::types::DataValue::*;
 pub struct BoolExprSimplificationRule;
 
 impl ExprRewriter for BoolExprSimplificationRule {
-    fn rewrite_expr(&self, expr: &mut BoundExpr) {
+    fn rewrite_binary_op(&self, expr: &mut BoundExpr) {
         let new = match expr {
             BinaryOp(op) => {
                 self.rewrite_expr(&mut *op.left_expr);
@@ -39,8 +39,7 @@ impl ExprRewriter for BoolExprSimplificationRule {
                     _ => BinaryOp(op.clone()),
                 }
             }
-            // FIXME: rewrite child expressions
-            _ => expr.clone(),
+            _ => unreachable!(),
         };
         *expr = new;
     }

--- a/src/optimizer/logical_plan_rewriter/constant_folding.rs
+++ b/src/optimizer/logical_plan_rewriter/constant_folding.rs
@@ -1,5 +1,7 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
+use BoundExpr::*;
+
 use super::*;
 use crate::array::ArrayImpl;
 use crate::binder::BoundExpr;
@@ -14,8 +16,7 @@ use crate::binder::BoundExpr;
 pub struct ConstantFoldingRule;
 
 impl ExprRewriter for ConstantFoldingRule {
-    fn rewrite_expr(&self, expr: &mut BoundExpr) {
-        use BoundExpr::*;
+    fn rewrite_binary_op(&self, expr: &mut BoundExpr) {
         match expr {
             BinaryOp(op) => {
                 self.rewrite_expr(&mut *op.left_expr);
@@ -27,6 +28,12 @@ impl ExprRewriter for ConstantFoldingRule {
                     *expr = Constant(res);
                 }
             }
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_unary_op(&self, expr: &mut BoundExpr) {
+        match expr {
             UnaryOp(op) => {
                 self.rewrite_expr(&mut *op.expr);
                 if let Constant(v) = &*op.expr {
@@ -34,6 +41,12 @@ impl ExprRewriter for ConstantFoldingRule {
                     *expr = Constant(res);
                 }
             }
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_type_cast(&self, expr: &mut BoundExpr) {
+        match expr {
             TypeCast(cast) => {
                 self.rewrite_expr(&mut *cast.expr);
                 if let Constant(v) = &*cast.expr {
@@ -45,12 +58,7 @@ impl ExprRewriter for ConstantFoldingRule {
                     // TODO: raise an error
                 }
             }
-            AggCall(agg_call) => {
-                for expr in &mut agg_call.args {
-                    self.rewrite_expr(expr);
-                }
-            }
-            _ => {}
+            _ => unreachable!(),
         }
     }
 }

--- a/src/optimizer/logical_plan_rewriter/constant_moving.rs
+++ b/src/optimizer/logical_plan_rewriter/constant_moving.rs
@@ -17,7 +17,7 @@ use crate::parser::BinaryOperator::*;
 pub struct ConstantMovingRule;
 
 impl ExprRewriter for ConstantMovingRule {
-    fn rewrite_expr(&self, expr: &mut BoundExpr) {
+    fn rewrite_binary_op(&self, expr: &mut BoundExpr) {
         let new = match expr {
             BinaryOp(op) => match (&op.op, &*op.left_expr, &*op.right_expr) {
                 (Eq | NotEq | Gt | Lt | GtEq | LtEq, BinaryOp(bin_op), Constant(rval)) => {
@@ -58,7 +58,7 @@ impl ExprRewriter for ConstantMovingRule {
                 }
                 _ => return,
             },
-            _ => return,
+            _ => unreachable!(),
         };
         *expr = new;
     }

--- a/src/optimizer/logical_plan_rewriter/mod.rs
+++ b/src/optimizer/logical_plan_rewriter/mod.rs
@@ -20,12 +20,9 @@ pub use input_ref_resolver::*;
 use itertools::Itertools;
 use paste::paste;
 
-use crate::binder::BoundExpr;
+pub use crate::binder::ExprRewriter;
 use crate::for_all_plan_nodes;
 
-pub trait ExprRewriter {
-    fn rewrite_expr(&self, _expr: &mut BoundExpr) {}
-}
 macro_rules! def_rewriter {
   ([], $($node:ident),*) => {
 

--- a/src/optimizer/plan_nodes/logical_filter.rs
+++ b/src/optimizer/plan_nodes/logical_filter.rs
@@ -1,8 +1,6 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
-
 use std::fmt;
-
 
 use serde::Serialize;
 
@@ -100,8 +98,7 @@ mod tests {
     use sqlparser::ast::BinaryOperator;
 
     use super::*;
-    use crate::binder::{BoundBinaryOp};
-    
+    use crate::binder::BoundBinaryOp;
     use crate::types::{DataTypeExt, DataTypeKind, DataValue};
 
     #[test]
@@ -160,7 +157,7 @@ mod tests {
                     return_type: ty.clone(),
                 })),
                 right_expr: Box::new(BoundExpr::Constant(DataValue::Int32(5))),
-                return_type: Some(ty.clone()),
+                return_type: Some(ty),
             })
         );
         let child = plan.child.as_logical_table_scan().unwrap();

--- a/src/optimizer/plan_nodes/logical_filter.rs
+++ b/src/optimizer/plan_nodes/logical_filter.rs
@@ -1,11 +1,13 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
+
 use std::fmt;
+
 
 use serde::Serialize;
 
 use super::*;
-use crate::binder::BoundExpr;
+use crate::binder::{BoundExpr, ExprVisitor};
 use crate::optimizer::logical_plan_rewriter::ExprRewriter;
 
 /// The logical plan of filter operation.
@@ -52,10 +54,117 @@ impl PlanNode for LogicalFilter {
     fn estimated_cardinality(&self) -> usize {
         self.child().estimated_cardinality()
     }
+
+    fn prune_col(&self, required_cols: BitSet) -> PlanRef {
+        struct CollectRequiredCols(BitSet);
+        impl ExprVisitor for CollectRequiredCols {
+            fn visit_input_ref(&mut self, expr: &BoundInputRef) {
+                self.0.insert(expr.index);
+            }
+        }
+        let mut visitor = CollectRequiredCols(required_cols);
+        visitor.visit_expr(&self.expr);
+
+        struct ShiftLeft(usize);
+        impl ExprRewriter for ShiftLeft {
+            fn rewrite_input_ref(&self, expr: &mut BoundExpr) {
+                match expr {
+                    BoundExpr::InputRef(ref mut input_ref) => {
+                        input_ref.index -= self.0;
+                    }
+                    _ => unreachable!(),
+                }
+            }
+        }
+
+        let mut expr = self.expr.clone();
+        if let Some(min_id) = &visitor.0.iter().next() {
+            ShiftLeft(*min_id).rewrite_expr(&mut expr);
+        }
+        Self {
+            expr,
+            child: self.child.prune_col(visitor.0),
+        }
+        .into_plan_ref()
+    }
 }
 
 impl fmt::Display for LogicalFilter {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "PhysicalFilter: expr {:?}", self.expr)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlparser::ast::BinaryOperator;
+
+    use super::*;
+    use crate::binder::{BoundBinaryOp};
+    
+    use crate::types::{DataTypeExt, DataTypeKind, DataValue};
+
+    #[test]
+    /// Pruning
+    /// ```text
+    /// Filter(cond: input_ref(1)<5)
+    ///   TableScan(v1, v2, v3)
+    /// ```
+    /// with required columns [2] will result in
+    /// ```text
+    /// Filter(cond: input_ref(0)<5)
+    ///   TableScan(v2, v3)
+    /// ```
+    fn test_prune_filter() {
+        let ty = DataTypeKind::Int(None).not_null();
+        let col_descs = vec![
+            ty.clone().to_column("v1".into()),
+            ty.clone().to_column("v2".into()),
+            ty.clone().to_column("v3".into()),
+        ];
+        let table_scan = LogicalTableScan::new(
+            crate::catalog::TableRefId {
+                database_id: 0,
+                schema_id: 0,
+                table_id: 0,
+            },
+            vec![1, 2, 3],
+            col_descs.clone(),
+            false,
+            false,
+            None,
+        );
+        let filter = LogicalFilter::new(
+            BoundExpr::BinaryOp(BoundBinaryOp {
+                op: BinaryOperator::Lt,
+                left_expr: Box::new(BoundExpr::InputRef(BoundInputRef {
+                    index: 1,
+                    return_type: ty.clone(),
+                })),
+                right_expr: Box::new(BoundExpr::Constant(DataValue::Int32(5))),
+                return_type: Some(ty.clone()),
+            }),
+            table_scan.into_plan_ref(),
+        );
+
+        let mut required_cols = BitSet::new();
+        required_cols.insert(2);
+        let plan = filter.prune_col(required_cols);
+        let plan = plan.as_logical_filter().unwrap();
+        assert_eq!(
+            plan.expr,
+            BoundExpr::BinaryOp(BoundBinaryOp {
+                op: BinaryOperator::Lt,
+                left_expr: Box::new(BoundExpr::InputRef(BoundInputRef {
+                    index: 0,
+                    return_type: ty.clone(),
+                })),
+                right_expr: Box::new(BoundExpr::Constant(DataValue::Int32(5))),
+                return_type: Some(ty.clone()),
+            })
+        );
+        let child = plan.child.as_logical_table_scan().unwrap();
+        assert_eq!(child.column_descs(), &col_descs[1..]);
+        assert_eq!(child.column_ids(), &[2, 3]);
     }
 }

--- a/src/optimizer/plan_nodes/logical_table_scan.rs
+++ b/src/optimizer/plan_nodes/logical_table_scan.rs
@@ -2,7 +2,6 @@
 
 use std::fmt;
 
-
 use itertools::Itertools;
 use serde::Serialize;
 

--- a/src/optimizer/plan_nodes/logical_table_scan.rs
+++ b/src/optimizer/plan_nodes/logical_table_scan.rs
@@ -2,6 +2,7 @@
 
 use std::fmt;
 
+
 use itertools::Itertools;
 use serde::Serialize;
 
@@ -79,6 +80,27 @@ impl PlanNode for LogicalTableScan {
     // TODO: get statistics from storage system
     fn estimated_cardinality(&self) -> usize {
         1
+    }
+
+    fn prune_col(&self, required_cols: BitSet) -> PlanRef {
+        let (column_ids, column_descs) = required_cols
+            .iter()
+            .map(|id| {
+                (
+                    self.column_ids[id as usize],
+                    self.column_descs[id as usize].clone(),
+                )
+            })
+            .unzip();
+        Self {
+            table_ref_id: self.table_ref_id,
+            column_ids,
+            column_descs,
+            with_row_handler: self.with_row_handler,
+            is_sorted: self.is_sorted,
+            expr: self.expr.clone(),
+        }
+        .into_plan_ref()
     }
 }
 impl fmt::Display for LogicalTableScan {


### PR DESCRIPTION
- Introduce `ExprVisitor`, `ExprRewriter` (aka `ExprVisitorMut`?) to reduce duplicated traversing code. 
> Yes, we are implementing too many things on `BoundExpr`... Maybe we can implement some visitors for expr :)
>
> _Originally posted by @skyzh in https://github.com/risinglightdb/risinglight/issues/535#issuecomment-1055151048_
- Optimizer: Add a rule to merge nested projection & Implement `prune_col` for filter (which used the visitor)