### PR TITLE
storage: use Arc<Version> during pin and unpin

### DIFF
--- a/src/storage/secondary/compactor.rs
+++ b/src/storage/secondary/compactor.rs
@@ -172,7 +172,8 @@ impl Compactor {
         loop {
             {
                 let tables = self.storage.tables.read().clone();
-                let (epoch, snapshot) = self.storage.version.pin();
+                let version = self.storage.version.pin();
+                let snapshot = version.as_ref().snapshot.as_ref();
                 for (_, table) in tables {
                     if let Some(_guard) = self
                         .storage
@@ -189,7 +190,6 @@ impl Compactor {
                     Err(tokio::sync::oneshot::error::TryRecvError::Closed) => break,
                     _ => {}
                 }
-                self.storage.version.unpin(epoch);
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
         }

--- a/src/storage/secondary/version_manager.rs
+++ b/src/storage/secondary/version_manager.rs
@@ -137,7 +137,7 @@ pub struct VersionManagerInner {
 pub struct VersionManager {
     /// Inner structure of `VersionManager`. This structure is protected by a parking lot Mutex, so
     /// as to support quick lock and unlock.
-    inner: PLMutex<VersionManagerInner>,
+    inner: Arc<PLMutex<VersionManagerInner>>,
 
     /// Manifest file. We only allow one thread to commit changes, and `commit_changes` will hold
     /// this lock until complete. As the commit procedure involves async waiting, we need to use an
@@ -159,7 +159,7 @@ impl VersionManager {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         Self {
             manifest: Mutex::new(manifest),
-            inner: PLMutex::new(VersionManagerInner::default()),
+            inner: Arc::from(PLMutex::new(VersionManagerInner::default())),
             tx,
             rx: PLMutex::new(Some(rx)),
             storage_options,
@@ -255,29 +255,18 @@ impl VersionManager {
     }
 
     /// Pin a snapshot of one epoch, so that all files at this epoch won't be deleted.
-    pub fn pin(&self) -> (u64, Arc<Snapshot>) {
+    /// Unpin will be done during Dropping Arc<Version>
+    pub fn pin(&self) -> Arc<Version> {
         let mut inner = self.inner.lock();
         let epoch = inner.epoch;
         *inner.ref_cnt.entry(epoch).or_default() += 1;
-        (epoch, inner.status.get(&epoch).unwrap().clone())
-    }
-
-    /// Unpin a snapshot of one epoch. When reference counter becomes 0, files might be vacuumed.
-    pub fn unpin(&self, epoch: u64) {
-        let mut inner = self.inner.lock();
-        let ref_cnt = inner
-            .ref_cnt
-            .get_mut(&epoch)
-            .expect("epoch not registered!");
-        *ref_cnt -= 1;
-        if *ref_cnt == 0 {
-            inner.ref_cnt.remove(&epoch).unwrap();
-
-            if epoch != inner.epoch {
-                // TODO: precisely pass the epoch number that can be vacuum.
-                self.tx.send(()).unwrap();
-            }
-        }
+        let v = Version {
+            epoch,
+            snapshot: inner.status.get(&epoch).unwrap().clone(),
+            inner: self.inner.clone(),
+            tx: self.tx.clone(),
+        };
+        Arc::from(v)
     }
 
     pub fn get_rowset(&self, table_id: u32, rowset_id: u32) -> Arc<DiskRowset> {
@@ -346,5 +335,32 @@ impl VersionManager {
             }
         }
         Ok(())
+    }
+}
+
+pub struct Version {
+    pub epoch: u64,
+    pub snapshot: Arc<Snapshot>,
+    inner: Arc<PLMutex<VersionManagerInner>>,
+    tx: tokio::sync::mpsc::UnboundedSender<()>,
+}
+
+impl Drop for Version {
+    /// Unpin a snapshot of one epoch. When reference counter becomes 0, files might be vacuumed.
+    fn drop(&mut self) {
+        let mut inner = self.inner.lock();
+        let ref_cnt = inner
+            .ref_cnt
+            .get_mut(&self.epoch)
+            .expect("epoch not registered!");
+        *ref_cnt -= 1;
+        if *ref_cnt == 0 {
+            inner.ref_cnt.remove(&self.epoch).unwrap();
+
+            if self.epoch != inner.epoch {
+                // TODO: precisely pass the epoch number that can be vacuum.
+                self.tx.send(()).unwrap();
+            }
+        }
     }
 }


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

close https://github.com/risinglightdb/risinglight/issues/537

Currently, we use `pin` and `unpin` manually in code. In this request, we use `Arc<Version>` to help us automatically unpin instead of manual code.