### PR TITLE
chore: remove header in `DataChunk`.

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -195,17 +195,18 @@ impl Database {
 
             let executor_builder = ExecutorBuilder::new(context.clone(), self.storage.clone());
             let executor = executor_builder.clone().build(optimized_plan);
-            let mut output: Vec<DataChunk> = executor.try_collect().await.map_err(|e| {
+            let output: Vec<DataChunk> = executor.try_collect().await.map_err(|e| {
                 debug!("error: {}", e);
                 e
             })?;
             for chunk in &output {
                 debug!("output:\n{}", chunk);
             }
-            if !column_names.is_empty() && !output.is_empty() {
-                output[0].set_header(column_names);
+            let mut chunk = Chunk::new(output);
+            if !column_names.is_empty() && !chunk.data_chunks().is_empty() {
+                chunk.set_header(column_names);
             }
-            outputs.push(Chunk::new(output));
+            outputs.push(chunk);
         }
         Ok(outputs)
     }

--- a/src/executor/delete.rs
+++ b/src/executor/delete.rs
@@ -53,8 +53,7 @@ impl<S: Storage> DeleteExecutor<S> {
         match context.spawn(|token| async move { self.execute_inner(token).await }) {
             Some(handler) => {
                 let cnt = handler.await.expect("failed to join delete thread")?;
-                let mut chunk = DataChunk::single(cnt as i32);
-                chunk.set_header(vec!["$delete.row_counts".to_string()]);
+                let chunk = DataChunk::single(cnt as i32);
                 yield chunk;
             }
             None => return Err(ExecutorError::Abort),

--- a/src/executor/drop.rs
+++ b/src/executor/drop.rs
@@ -19,8 +19,7 @@ impl<S: Storage> DropExecutor<S> {
             Object::Table(ref_id) => self.storage.drop_table(ref_id).await?,
         }
 
-        let mut chunk = DataChunk::single(0);
-        chunk.set_header(vec!["$drop".to_string()]);
+        let chunk = DataChunk::single(0);
         yield chunk
     }
 }

--- a/src/executor/explain.rs
+++ b/src/executor/explain.rs
@@ -13,10 +13,9 @@ impl ExplainExecutor {
     pub fn execute(self) -> BoxedExecutor {
         let mut explain_result = String::new();
         self.plan.child().explain(0, &mut explain_result).unwrap();
-        let mut chunk = DataChunk::from_iter([ArrayImpl::Utf8(Utf8Array::from_iter([Some(
+        let chunk = DataChunk::from_iter([ArrayImpl::Utf8(Utf8Array::from_iter([Some(
             explain_result,
         )]))]);
-        chunk.set_header(vec!["$explain".to_string()]);
         async_stream::try_stream! {
             yield chunk;
         }

--- a/src/executor/insert.rs
+++ b/src/executor/insert.rs
@@ -61,8 +61,7 @@ impl<S: Storage> InsertExecutor<S> {
         match context.spawn(|token| async move { self.execute_inner(token).await }) {
             Some(handler) => {
                 let cnt = handler.await.expect("failed to join insert thread")?;
-                let mut chunk = DataChunk::single(cnt as i32);
-                chunk.set_header(vec!["$insert.row_counts".to_string()]);
+                let chunk = DataChunk::single(cnt as i32);
                 yield chunk;
             }
             None => return Err(ExecutorError::Abort),

--- a/src/optimizer/plan_nodes/logical_delete.rs
+++ b/src/optimizer/plan_nodes/logical_delete.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 
 use super::*;
 use crate::catalog::TableRefId;
+use crate::types::DataTypeKind;
 
 /// The logical plan of `DELETE`.
 #[derive(Debug, Clone, Serialize)]
@@ -37,7 +38,15 @@ impl PlanTreeNodeUnary for LogicalDelete {
     }
 }
 impl_plan_tree_node_for_unary!(LogicalDelete);
-impl PlanNode for LogicalDelete {}
+impl PlanNode for LogicalDelete {
+    fn schema(&self) -> Vec<ColumnDesc> {
+        vec![ColumnDesc::new(
+            DataType::new(DataTypeKind::Int(None), false),
+            "$delete.row_counts".to_string(),
+            false,
+        )]
+    }
+}
 
 impl fmt::Display for LogicalDelete {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/optimizer/plan_nodes/logical_drop.rs
+++ b/src/optimizer/plan_nodes/logical_drop.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 
 use super::*;
 use crate::binder::statement::drop::Object;
+use crate::types::DataTypeKind;
 
 /// The logical plan of `DROP`.
 #[derive(Debug, Clone, Serialize)]
@@ -25,7 +26,15 @@ impl LogicalDrop {
 }
 impl PlanTreeNodeLeaf for LogicalDrop {}
 impl_plan_tree_node_for_leaf!(LogicalDrop);
-impl PlanNode for LogicalDrop {}
+impl PlanNode for LogicalDrop {
+    fn schema(&self) -> Vec<ColumnDesc> {
+        vec![ColumnDesc::new(
+            DataType::new(DataTypeKind::Int(None), false),
+            "$drop".to_string(),
+            false,
+        )]
+    }
+}
 
 impl fmt::Display for LogicalDrop {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/optimizer/plan_nodes/logical_explain.rs
+++ b/src/optimizer/plan_nodes/logical_explain.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use serde::Serialize;
 
 use super::*;
+use crate::types::DataTypeKind;
 
 /// The logical plan of `EXPLAIN`.
 #[derive(Debug, Clone, Serialize)]
@@ -38,6 +39,13 @@ impl PlanNode for LogicalExplain {
         let out_types_num = self.plan.out_types().len();
         self.clone_with_child(self.plan.prune_col(BitSet::from_iter(0..out_types_num)))
             .into_plan_ref()
+    }
+    fn schema(&self) -> Vec<ColumnDesc> {
+        vec![ColumnDesc::new(
+            DataType::new(DataTypeKind::Int(None), false),
+            "$explain".to_string(),
+            false,
+        )]
     }
 }
 

--- a/src/optimizer/plan_nodes/logical_insert.rs
+++ b/src/optimizer/plan_nodes/logical_insert.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 
 use super::*;
 use crate::catalog::TableRefId;
-use crate::types::ColumnId;
+use crate::types::{ColumnId, DataTypeKind};
 
 /// The logical plan of `INSERT`.
 #[derive(Debug, Clone, Serialize)]
@@ -47,7 +47,15 @@ impl PlanTreeNodeUnary for LogicalInsert {
 }
 impl_plan_tree_node_for_unary!(LogicalInsert);
 
-impl PlanNode for LogicalInsert {}
+impl PlanNode for LogicalInsert {
+    fn schema(&self) -> Vec<ColumnDesc> {
+        vec![ColumnDesc::new(
+            DataType::new(DataTypeKind::Int(None), false),
+            "$insert.row_counts".to_string(),
+            false,
+        )]
+    }
+}
 
 impl fmt::Display for LogicalInsert {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Signed-off-by: RinChanNOWWW <hzy427@gmail.com>

close https://github.com/risinglightdb/risinglight/issues/435

Remove the member `header` in the struct `DataChunk`. And it seems that there is no need to add a wrapper struct `ResultChunk`. Adding `ResultChunk` will complicate the executors.