### PR TITLE
fix(executor): output no chunks from dummy

### DIFF
--- a/src/executor/dummy_scan.rs
+++ b/src/executor/dummy_scan.rs
@@ -7,7 +7,5 @@ pub struct DummyScanExecutor;
 
 impl DummyScanExecutor {
     #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
-    pub async fn execute(self) {
-        yield DataChunk::single(0);
-    }
+    pub async fn execute(self) {}
 }

--- a/tests/sql/count.slt
+++ b/tests/sql/count.slt
@@ -41,3 +41,8 @@ query I
 select count(*) from t where v > 5
 ----
 2
+
+query I
+select count(*) from t where 0 = 1
+----
+0


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

Now `count(*)` will output `0` if condition is always false.