### PR TITLE
chore(tracing): remove enable_tracing option from db interface

### DIFF
--- a/benches/e2e.rs
+++ b/benches/e2e.rs
@@ -9,8 +9,7 @@ fn create_table(c: &mut Criterion) {
         b.to_async(&runtime).iter_batched(
             Database::new_in_memory,
             |db| async move {
-                let enable_tracing = false;
-                db.run("create table t(v1 int, v2 int, v3 int)", enable_tracing)
+                db.run("create table t(v1 int, v2 int, v3 int)")
                     .await
                     .unwrap()
             },
@@ -30,17 +29,16 @@ fn insert(c: &mut Criterion) {
                 .chain(std::iter::repeat("(1,10,100),").take(size - 1))
                 .chain(std::iter::once("(1,10,100)"))
                 .collect::<String>();
-            let enable_tracing = false;
             b.to_async(&runtime).iter_batched(
                 || async {
                     let db = Database::new_in_memory();
-                    db.run("create table t(v1 int, v2 int, v3 int)", enable_tracing)
+                    db.run("create table t(v1 int, v2 int, v3 int)")
                         .await
                         .unwrap();
                     db
                 },
                 |db| async {
-                    db.await.run(&sql, enable_tracing).await.unwrap();
+                    db.await.run(&sql).await.unwrap();
                 },
                 BatchSize::LargeInput,
             );
@@ -60,21 +58,15 @@ fn select_add(c: &mut Criterion) {
                 .chain(std::iter::repeat("(1,10),").take(size - 1))
                 .chain(std::iter::once("(1,10)"))
                 .collect::<String>();
-            let enable_tracing = false;
             b.to_async(&runtime).iter_batched(
                 || async {
                     let db = Database::new_in_memory();
-                    db.run("create table t(v1 int, v2 int)", enable_tracing)
-                        .await
-                        .unwrap();
-                    db.run(&insert_sql, enable_tracing).await.unwrap();
+                    db.run("create table t(v1 int, v2 int)").await.unwrap();
+                    db.run(&insert_sql).await.unwrap();
                     db
                 },
                 |db| async {
-                    db.await
-                        .run("select v1 + v2 from t", enable_tracing)
-                        .await
-                        .unwrap();
+                    db.await.run("select v1 + v2 from t").await.unwrap();
                 },
                 BatchSize::LargeInput,
             );

--- a/src/optimizer/logical_plan_rewriter/arith_expr_simplification.rs
+++ b/src/optimizer/logical_plan_rewriter/arith_expr_simplification.rs
@@ -122,8 +122,7 @@ mod tests {
         let create_stmt = "create table t(a int)";
         let sql0 = "select a + 0 from t";
         // a + 0 should be converted to a
-        let enable_tracing = false;
-        let _ = db.run(create_stmt, enable_tracing).await;
+        let _ = db.run(create_stmt).await;
 
         let plans = db.generate_execution_plan(sql0).unwrap();
         assert_eq!(plans.len(), 1);

--- a/src/storage/secondary/storage.rs
+++ b/src/storage/secondary/storage.rs
@@ -15,7 +15,7 @@ use crate::catalog::RootCatalog;
 use crate::storage::secondary::manifest::*;
 use crate::storage::secondary::transaction_manager::TransactionManager;
 use crate::storage::secondary::version_manager::{EpochOp, VersionManager};
-use crate::storage::secondary::DeleteVector;
+use crate::storage::secondary::{DeleteVector, IOBackend};
 
 impl SecondaryStorage {
     pub(super) async fn bootstrap(options: StorageOptions) -> StorageResult<Self> {
@@ -34,7 +34,9 @@ impl SecondaryStorage {
             fs::create_dir(&dv_directory).await?;
         }
 
-        let mut manifest = Manifest::open(options.path.join("manifest.json")).await?;
+        let enable_fsync = !matches!(options.io_backend, IOBackend::InMemory(_));
+
+        let mut manifest = Manifest::open(options.path.join("manifest.json"), enable_fsync).await?;
 
         let manifest_ops = manifest.replay().await?;
 

--- a/tests/sqllogictest/src/lib.rs
+++ b/tests/sqllogictest/src/lib.rs
@@ -69,8 +69,7 @@ struct DatabaseWrapper {
 impl sqllogictest::AsyncDB for DatabaseWrapper {
     type Error = Error;
     async fn run(&mut self, sql: &str) -> Result<String, Self::Error> {
-        let enable_tracing = false;
-        let chunks = self.db.run(sql, enable_tracing).await?;
+        let chunks = self.db.run(sql).await?;
         let output = chunks
             .iter()
             .map(datachunk_to_sqllogictest_string)


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

TL;DR, the db interface itself should not expose `enable_tracing`. Tracing is enabled automatically if there's a parent tracing span in current thread.

Also remove fsync from manifest if is in-memory backend. 2x faster for storage e2e tests.

ref https://github.com/risinglightdb/risinglight/pull/586