### PR TITLE
chore: switch sqlparser-rs to crates.io version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,8 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.13.1-alpha.0"
-source = "git+https://github.com/risinglightdb/sqlparser-rs?rev=edead1b#edead1bf3d758831de4423a781d4813385f15ff6"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9a527b68048eb95495a1508f6c8395c8defcff5ecdbe8ad4106d08a2ef2a3c"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 smallvec = { version = "1", features = ["serde"] }
 sqllogictest = "0.3"
-sqlparser = { git = "https://github.com/risinglightdb/sqlparser-rs", rev = "edead1b", features = ["serde"] }
+sqlparser = { version = "0.16", features = ["serde"] }
 thiserror = "1"
 tikv-jemallocator = { version = "0.4", optional = true }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

Our patch for sqlparser-rs has been upstreamed: https://github.com/sqlparser-rs/sqlparser-rs/pull/446.

No more blockers to publishing RisingLight! #574
