### PR TITLE
feat(executor): introduce DataChunkBuilder and split chunks in Order …

### DIFF
--- a/src/binder/expression/agg_call.rs
+++ b/src/binder/expression/agg_call.rs
@@ -89,16 +89,7 @@ impl Binder {
             }
         }
         let (kind, return_type) = match func.name.to_string().to_lowercase().as_str() {
-            "avg" => {
-                let agg_kind = AggKind::Avg;
-                let mut default_data_type = Some(DataType::new(DataTypeKind::Double, false));
-                if let Some(ref data_type) = args[0].return_type() {
-                    if let DataTypeKind::Decimal(_, _) = data_type.kind {
-                        default_data_type = args[0].return_type();
-                    }
-                }
-                (agg_kind, default_data_type)
-            }
+            "avg" => (AggKind::Avg, args[0].return_type()),
             "count" => {
                 if args.is_empty() {
                     let first_index_column = BoundExpr::InputRef(BoundInputRef {

--- a/src/binder/expression/agg_call.rs
+++ b/src/binder/expression/agg_call.rs
@@ -89,10 +89,16 @@ impl Binder {
             }
         }
         let (kind, return_type) = match func.name.to_string().to_lowercase().as_str() {
-            "avg" => (
-                AggKind::Avg,
-                Some(DataType::new(DataTypeKind::Double, false)),
-            ),
+            "avg" => {
+                let agg_kind = AggKind::Avg;
+                let mut default_data_type = Some(DataType::new(DataTypeKind::Double, false));
+                if let Some(ref data_type) = args[0].return_type() {
+                    if let DataTypeKind::Decimal(_, _) = data_type.kind {
+                        default_data_type = args[0].return_type();
+                    }
+                }
+                (agg_kind, default_data_type)
+            }
             "count" => {
                 if args.is_empty() {
                     let first_index_column = BoundExpr::InputRef(BoundInputRef {

--- a/src/executor/limit.rs
+++ b/src/executor/limit.rs
@@ -1,13 +1,15 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use super::*;
-use crate::array::DataChunk;
+use crate::array::{DataChunk, DataChunkBuilder};
+use crate::types::DataType;
 
 /// The executor of a limit operation.
 pub struct LimitExecutor {
     pub child: BoxedExecutor,
     pub offset: usize,
     pub limit: usize,
+    pub output_types: Vec<DataType>,
 }
 
 impl LimitExecutor {
@@ -15,17 +17,14 @@ impl LimitExecutor {
     pub async fn execute(self) {
         // the number of rows have been processed
         let mut processed = 0;
-        let mut dummy_chunk = None;
+        let mut builder = DataChunkBuilder::new(self.output_types.iter(), PROCESSING_WINDOW_SIZE);
 
         #[for_await]
         for batch in self.child {
-            let batch = batch?;
-            if dummy_chunk.is_none() {
-                dummy_chunk = Some(batch.slice(0..0));
-                if self.offset == 0 && self.limit == 0 {
-                    break;
-                }
+            if self.limit == 0 {
+                break;
             }
+            let batch = batch?;
             let cardinality = batch.cardinality();
             let start = processed.max(self.offset) - processed;
             let end = (processed + cardinality).min(self.offset + self.limit) - processed;
@@ -33,20 +32,18 @@ impl LimitExecutor {
             if start >= end {
                 continue;
             }
-            if (start..end) == (0..cardinality) {
-                yield batch;
-            } else {
-                yield batch.slice(start..end);
+            for row in batch.rows().skip(start).take(end - start) {
+                if let Some(chunk) = builder.push_row(row.values()) {
+                    yield chunk
+                }
             }
             if processed >= self.offset + self.limit {
                 break;
             }
         }
 
-        if processed <= self.offset || self.limit == 0 {
-            if let Some(chunk) = dummy_chunk {
-                yield chunk;
-            }
+        if let Some(chunk) = { builder }.take() {
+            yield chunk;
         }
     }
 }
@@ -60,11 +57,14 @@ mod tests {
 
     use super::*;
     use crate::array::ArrayImpl;
+    use crate::types::DataTypeKind;
 
     #[test_case(&[(0..6)], 1, 4, &[(1..5)])]
     #[test_case(&[(0..6)], 0, 10, &[(0..6)])]
-    #[test_case(&[(0..6)], 10, 0, &[(0..0)])]
-    #[test_case(&[(0..2), (2..4), (4..6)], 1, 4, &[(1..2), (2..4), (4..5)])]
+    #[test_case(&[(0..6)], 10, 0, &[])]
+    #[test_case(&[(0..2), (2..4), (4..6)], 1, 4, &[(1..5)])]
+    #[test_case(&[(0..2), (2..4), (4..6)], 1, 2, &[(1..3)])]
+    #[test_case(&[(0..2), (2..4), (4..6)], 3, 0, &[])]
     #[tokio::test]
     async fn limit(
         inputs: &'static [Range<i32>],
@@ -76,6 +76,7 @@ mod tests {
             child: futures::stream::iter(inputs.iter().map(range_to_chunk).map(Ok)).boxed(),
             offset,
             limit,
+            output_types: vec![DataType::new(DataTypeKind::Int(None), false)],
         };
         let actual = executor.execute().try_collect::<Vec<_>>().await.unwrap();
         let outputs = outputs.iter().map(range_to_chunk).collect_vec();

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -371,6 +371,7 @@ impl PlanVisitor<BoxedExecutor> for ExecutorBuilder {
             OrderExecutor {
                 comparators: plan.logical().comparators().to_vec(),
                 child: self.visit(plan.child()).unwrap(),
+                output_types: plan.logical().out_types(),
             }
             .execute(),
             "OrderExecutor",
@@ -383,6 +384,7 @@ impl PlanVisitor<BoxedExecutor> for ExecutorBuilder {
                 child: self.visit(plan.child()).unwrap(),
                 offset: plan.logical().offset(),
                 limit: plan.logical().limit(),
+                output_types: plan.logical().out_types(),
             }
             .execute(),
             "LimitExecutor",

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -384,7 +384,6 @@ impl PlanVisitor<BoxedExecutor> for ExecutorBuilder {
                 child: self.visit(plan.child()).unwrap(),
                 offset: plan.logical().offset(),
                 limit: plan.logical().limit(),
-                output_types: plan.logical().out_types(),
             }
             .execute(),
             "LimitExecutor",

--- a/src/executor/top_n.rs
+++ b/src/executor/top_n.rs
@@ -46,7 +46,7 @@ impl TopNExecutor {
         });
 
         let mut builder = DataChunkBuilder::new(self.output_types.iter(), PROCESSING_WINDOW_SIZE);
-        for ref row in heap
+        for row in heap
             .into_sorted_vec()
             .into_iter()
             .skip(self.offset)
@@ -77,13 +77,11 @@ mod tests {
 
     #[test_case(&[(0..6)], 1, 4, false, &[(1..5)])]
     #[test_case(&[(0..6)], 0, 10, false, &[(0..6)])]
-    // todo: introduce DataChunkBuilder in TopNExecutor & LimitExecutor
-    // #[test_case(&[(0..6)], 10, 0, false, &[(0..0)])]
+    #[test_case(&[(0..6)], 10, 0, false, &[])]
     #[test_case(&[(0..2), (2..4), (4..6)], 1, 4, false, &[(1..5)])]
     #[test_case(&[(0..6)], 1, 4, true, &[(1..5)])]
     #[test_case(&[(0..6)], 0, 10, true, &[(0..6)])]
-    // todo: introduce DataChunkBuilder in TopNExecutor & LimitExecutor
-    // #[test_case(&[(0..6)], 10, 0, true, &[(0..0)])]
+    #[test_case(&[(0..6)], 10, 0, true, &[])]
     #[test_case(&[(0..2), (2..4), (4..6)], 1, 4, true, &[(1..5)])]
     #[tokio::test]
     async fn simple(
@@ -131,7 +129,7 @@ mod tests {
         inputs: Vec<DataChunk>,
         offset: usize,
         limit: usize,
-        inputs_type: Vec<DataType>,
+        input_types: Vec<DataType>,
         catalog: Vec<ColumnCatalog>,
         idx_desc: Vec<(usize, bool)>,
     ) -> (TopNExecutor, LimitExecutor) {
@@ -142,17 +140,19 @@ mod tests {
             offset,
             limit,
             comparators: comparators.clone(),
-            output_types: inputs_type,
+            output_types: input_types.clone(),
         };
 
         let limit_order = LimitExecutor {
             child: OrderExecutor {
                 child: futures::stream::iter(inputs.into_iter().map(Ok)).boxed(),
                 comparators,
+                output_types: input_types.clone(),
             }
             .execute(),
             offset,
             limit,
+            output_types: input_types,
         };
         (top_n, limit_order)
     }

--- a/src/executor/top_n.rs
+++ b/src/executor/top_n.rs
@@ -147,12 +147,11 @@ mod tests {
             child: OrderExecutor {
                 child: futures::stream::iter(inputs.into_iter().map(Ok)).boxed(),
                 comparators,
-                output_types: input_types.clone(),
+                output_types: input_types,
             }
             .execute(),
             offset,
             limit,
-            output_types: input_types,
         };
         (top_n, limit_order)
     }


### PR DESCRIPTION
…and Limit
issue #611 
1. Fix panic bug and add test cases. 
```sql
select * 
from t 
limit 0 offset 3
```
2. Don't modify average_agg return type ~~when aggregated coloum datatype is Decimal~~.
3. Introduce DataChunkBuilder and split chunks in Order ~~and Limit~~.


Signed-off-by: Qi Wang <wangqiim@163.com>