### PR TITLE
chore(ci): install protoc by direct download

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,12 +7,16 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  PROTOC_NO_VENDOR: 1
 
 jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: arduino/setup-protoc@v1
+        with:
+          version: "3.x"
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  CACHE_KEY_SUFFIX: v20220409
   PROTOC_NO_VENDOR: 1
 
 jobs:
@@ -20,6 +21,13 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}
       - name: Bench
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,16 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CACHE_KEY_SUFFIX: v20220118
+  PROTOC_NO_VENDOR: 1
 
 jobs:
   fmt:
     runs-on: ubuntu-latest
-    env:
-      PROTOC_NO_VENDOR: 1
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get install -y protobuf-compiler
+      - uses: arduino/setup-protoc@v1
+        with:
+          version: "3.x"
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
@@ -35,12 +36,13 @@ jobs:
       PROTOC_NO_VENDOR: 1
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get install -y protobuf-compiler
+      - uses: arduino/setup-protoc@v1
+        with:
+          version: "3.x"
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-      - name: Download nextest
-        run: curl -fsSL https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      - uses: taiki-e/install-action@nextest
       - name: Test
         run: cargo nextest run --workspace --no-fail-fast --all-features --locked
       - name: Doctest
@@ -48,11 +50,11 @@ jobs:
 
   tpch-test:
     runs-on: ubuntu-latest
-    env:
-      PROTOC_NO_VENDOR: 1
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get install -y protobuf-compiler
+      - uses: arduino/setup-protoc@v1
+        with:
+          version: "3.x"
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,11 +79,15 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}
-      - name: Run TPC-H test
+      - name: Generate TPC-H 1GB dataset
         run: |
           rm -rf risinglight.secondary.db
           make tpch
+      - name: Build RisingLight (in release mode)
+        run: |
           cargo build --release
+      - name: Run TPC-H Test
+        run: |
           sudo ./target/release/risinglight -f tests/sql/tpch/create.sql
           sudo ./target/release/risinglight -f tests/sql/tpch/import.sql
           sudo ./target/release/risinglight -f tests/sql/tpch-full/_tpch_full.slt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CACHE_KEY_SUFFIX: v20220118
+  CACHE_KEY_SUFFIX: v20220409
   PROTOC_NO_VENDOR: 1
 
 jobs:
@@ -25,6 +25,13 @@ jobs:
         with:
           profile: minimal
           components: rustfmt, clippy
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}
       - name: Check code format
         run: cargo fmt --all -- --check
       - name: Clippy
@@ -42,6 +49,13 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}
       - uses: taiki-e/install-action@nextest
       - name: Test
         run: cargo nextest run --workspace --no-fail-fast --all-features --locked
@@ -58,6 +72,13 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}
       - name: Run TPC-H test
         run: |
           rm -rf risinglight.secondary.db


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

Directly downloading from protoc pre-built binary could be a little bit faster 🤪 Also, we download protoc compiler in bench workflow.