### PR TITLE
refactor(planner): use AggInputRefResolver to handle group by expr

### DIFF
--- a/src/logical_planner/select.rs
+++ b/src/logical_planner/select.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 
 use super::*;
 use crate::binder::{
-    BoundAggCall, BoundExpr, BoundInputRef, BoundOrderBy, BoundSelect, BoundTableRef,
+    BoundAggCall, BoundExpr, BoundInputRef, BoundOrderBy, BoundSelect, BoundTableRef, ExprVisitor,
 };
 use crate::optimizer::plan_nodes::{
     Internal, LogicalAggregate, LogicalFilter, LogicalJoin, LogicalLimit, LogicalOrder,
@@ -65,16 +65,15 @@ impl LogicalPlaner {
             plan = Arc::new(LogicalFilter::new(expr, plan));
         }
 
-        let mut agg_extractor = AggExtractor::new(stmt.group_by.len());
-
-        if !stmt.group_by.is_empty() {
-            agg_extractor.validate_illegal_column(&stmt.select_list, &stmt.group_by)?;
-        }
+        let mut agg_extractor = AggExtractor::new();
         for expr in &mut stmt.select_list {
             agg_extractor.visit_select_expr(expr);
         }
         for expr in &mut stmt.group_by {
-            agg_extractor.visit_group_by_expr(expr, &mut stmt.select_list);
+            agg_extractor.visit_group_by_expr(expr, &stmt.select_list);
+        }
+        if !stmt.group_by.is_empty() {
+            agg_extractor.validate_illegal_column(&stmt.select_list)?;
         }
         if !agg_extractor.agg_calls.is_empty() || !agg_extractor.group_by_exprs.is_empty() {
             plan = Arc::new(LogicalAggregate::new(
@@ -173,59 +172,41 @@ impl LogicalPlaner {
     }
 }
 
-/// An expression visitor that extracts aggregation nodes and replaces them with `InputRef`.
-///
-/// For example:
-/// In SQL: `select sum(b) + a * count(a) from t group by a;`
-/// The expression `sum(b) + a * count(a)` will be rewritten to `InputRef(1) + a * InputRef(2)`,
-/// because the underlying aggregate plan will output `(a, sum(b), count(a))`. The group keys appear
-/// before aggregations.
+/// An expression visitor that extracts aggregation nodes and validate illegal select exprs.
+/// Visotor will also rewrite group by alias expression to corresponding select expression and then
+/// validate illegal select exprs.
 #[derive(Default)]
 struct AggExtractor {
     agg_calls: Vec<BoundAggCall>,
     group_by_exprs: Vec<BoundExpr>,
-    index: usize,
 }
 
 impl AggExtractor {
-    fn new(group_key_count: usize) -> Self {
+    fn new() -> Self {
         AggExtractor {
             agg_calls: vec![],
             group_by_exprs: vec![],
-            index: group_key_count,
         }
     }
 
-    /// validate select exprs must appear in the GROUP BY clause or be used in an aggregate function
+    /// Validate select exprs must appear in the GROUP BY clause or be used in an aggregate
+    /// function. Need `visit_group_by_expr` to rewrite the group by alias first.
+    /// TODO: add order by exprs validation
     fn validate_illegal_column(
         &mut self,
         select_exprs: &[BoundExpr],
-        group_by_exprs: &[BoundExpr],
     ) -> Result<(), LogicalPlanError> {
-        use BoundExpr::*;
-        let mut group_by_raw_exprs = vec![];
-        group_by_exprs.iter().for_each(|e| {
-            if let Alias(alias) = e {
-                let alias_expr = select_exprs.iter().find(|inner_expr| {
-                    if let ExprWithAlias(e) = inner_expr {
-                        e.alias == alias.alias
-                    } else {
-                        false
-                    }
-                });
-                if let Some(inner_expr) = alias_expr {
-                    group_by_raw_exprs.push(inner_expr.clone());
-                }
-            } else {
-                group_by_raw_exprs.push(e.clone());
-            }
-        });
+        use BoundExpr::ExprWithAlias;
 
-        for expr in select_exprs {
+        for mut expr in select_exprs {
+            if let ExprWithAlias(e) = expr {
+                expr = &*e.expr;
+            }
+
             if expr.contains_agg_call() {
                 continue;
             }
-            if !group_by_raw_exprs.iter().contains(expr) {
+            if !self.group_by_exprs.iter().contains(expr) {
                 return Err(LogicalPlanError::IllegalGroupBySQL(format!(r#"{}"#, expr)));
             }
         }
@@ -233,69 +214,34 @@ impl AggExtractor {
     }
 
     fn visit_select_expr(&mut self, expr: &mut BoundExpr) {
-        use BoundExpr::*;
-        match expr {
-            AggCall(agg) => {
-                let input_ref = InputRef(BoundInputRef {
-                    index: self.index,
-                    return_type: agg.return_type.clone(),
-                });
-                match std::mem::replace(expr, input_ref) {
-                    AggCall(agg) => self.agg_calls.push(agg),
-                    _ => unreachable!(),
-                }
-                self.index += 1;
+        struct Visitor<'a>(&'a mut Vec<BoundAggCall>);
+        impl<'a> ExprVisitor for Visitor<'a> {
+            fn visit_agg_call(&mut self, agg: &BoundAggCall) {
+                self.0.push(agg.clone());
             }
-            BinaryOp(bin_op) => {
-                self.visit_select_expr(&mut bin_op.left_expr);
-                self.visit_select_expr(&mut bin_op.right_expr);
-            }
-            UnaryOp(unary_op) => self.visit_select_expr(&mut unary_op.expr),
-            TypeCast(type_cast) => self.visit_select_expr(&mut type_cast.expr),
-            ExprWithAlias(expr_with_alias) => self.visit_select_expr(&mut expr_with_alias.expr),
-            IsNull(isnull) => self.visit_select_expr(&mut isnull.expr),
-            Constant(_) | ColumnRef(_) | InputRef(_) | Alias(_) => {}
         }
+        let mut agg_calls = vec![];
+        Visitor(&mut agg_calls).visit_expr(expr);
+        // TODO: handle duplicate agg_call
+        self.agg_calls.extend_from_slice(&agg_calls);
     }
 
-    fn visit_group_by_expr(&mut self, expr: &mut BoundExpr, select_list: &mut [BoundExpr]) {
+    fn visit_group_by_expr(&mut self, expr: &mut BoundExpr, select_list: &[BoundExpr]) {
         use BoundExpr::*;
         if let Alias(alias) = expr {
-            if let Some(i) = select_list.iter().position(|inner_expr| {
+            // rewrite group by alias to corresponding select expr
+            if let Some(expr) = select_list.iter().find_map(|inner_expr| {
                 if let ExprWithAlias(e) = inner_expr {
-                    e.alias == alias.alias
-                } else {
-                    false
+                    if e.alias == alias.alias {
+                        return Some(*e.expr.clone());
+                    }
                 }
+                None
             }) {
-                let select_item = &mut select_list[i];
-                self.group_by_exprs.push(std::mem::replace(
-                    select_item,
-                    InputRef(BoundInputRef {
-                        index: self.group_by_exprs.len(),
-                        return_type: select_item.return_type().unwrap(),
-                    }),
-                ));
+                self.group_by_exprs.push(expr);
                 return;
             }
         }
-
-        if let Some(i) = select_list.iter().position(|e| e == expr) {
-            match select_list[i] {
-                Constant(_) | ColumnRef(_) => self.group_by_exprs.push(select_list[i].clone()),
-                _ => {
-                    self.group_by_exprs.push(std::mem::replace(
-                        &mut select_list[i],
-                        InputRef(BoundInputRef {
-                            index: self.group_by_exprs.len(),
-                            return_type: expr.return_type().unwrap(),
-                        }),
-                    ));
-                }
-            }
-            return;
-        }
-
         self.group_by_exprs.push(expr.clone());
     }
 }
@@ -347,5 +293,73 @@ impl<'a> AliasExtractor<'a> {
             ColumnRef(_) => expr,
             _ => panic!("order-by expression should be column ref or expr alias"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlparser::ast::BinaryOperator;
+
+    use super::*;
+    use crate::binder::{BoundAlias, BoundBinaryOp, BoundColumnRef, BoundExprWithAlias};
+    use crate::catalog::ColumnRefId;
+    use crate::types::{DataTypeExt, DataTypeKind, DataValue};
+
+    #[test]
+    fn test_agg_extractor_validate_illegal_column() {
+        // case1 sql: select v2 + 1 from t group by v2 + 1
+        let v2_plus_1 = BoundExpr::BinaryOp(BoundBinaryOp {
+            op: BinaryOperator::Plus,
+            left_expr: build_column_ref(1, "v2".to_string()).into(),
+            right_expr: BoundExpr::Constant(DataValue::Int32(1)).into(),
+            return_type: Some(DataTypeKind::Int(None).not_null()),
+        });
+        assert!(
+            validate_illegal_column(&mut [v2_plus_1.clone()], &mut [v2_plus_1.clone()]).is_ok()
+        );
+
+        // case2 sql: select v2 + 1, v1 from t group by v2 + 1
+        let v1 = build_column_ref(0, "v1".to_string());
+        assert!(validate_illegal_column(
+            &mut [v2_plus_1.clone(), v1.clone()],
+            &mut [v2_plus_1.clone()]
+        )
+        .is_err());
+
+        // case3 sql: select v2 + 1 as a, v1 as b from t group by a
+        let v2_plus_1_alias_a = BoundExpr::ExprWithAlias(BoundExprWithAlias {
+            expr: v2_plus_1.into(),
+            alias: "a".to_string(),
+        });
+        let v1_alias_b = BoundExpr::ExprWithAlias(BoundExprWithAlias {
+            expr: v1.into(),
+            alias: "b".to_string(),
+        });
+        let alias_a = BoundExpr::Alias(BoundAlias {
+            alias: "a".to_string(),
+        });
+        assert!(
+            validate_illegal_column(&mut [v2_plus_1_alias_a, v1_alias_b], &mut [alias_a]).is_err()
+        );
+    }
+
+    fn build_column_ref(column_id: u32, column_name: String) -> BoundExpr {
+        BoundExpr::ColumnRef(BoundColumnRef {
+            column_ref_id: ColumnRefId::new(0, 0, 0, column_id),
+            is_primary_key: false,
+            desc: DataTypeKind::Int(None).not_null().to_column(column_name),
+        })
+    }
+
+    fn validate_illegal_column(
+        select_list: &mut [BoundExpr],
+        group_by_list: &mut [BoundExpr],
+    ) -> Result<(), LogicalPlanError> {
+        let mut extractor = AggExtractor::new();
+        for expr in group_by_list {
+            extractor.visit_group_by_expr(expr, select_list);
+        }
+        extractor.validate_illegal_column(select_list)?;
+        Ok(())
     }
 }

--- a/src/optimizer/logical_plan_rewriter/input_ref_resolver.rs
+++ b/src/optimizer/logical_plan_rewriter/input_ref_resolver.rs
@@ -86,7 +86,25 @@ impl PlanRewriter for InputRefResolver {
             .iter()
             .map(|e| Some(e.clone()))
             .collect();
-        let ret = Arc::new(proj.clone_with_rewrite_expr(new_child, self));
+
+        let ret = match new_child.node_type() {
+            PlanNodeType::LogicalAggregate => {
+                let group_keys = self
+                    .bindings
+                    .iter()
+                    .map(|it| it.clone().unwrap())
+                    .collect::<Vec<_>>();
+                let mut resolver = AggInputRefResolver::new(group_keys.len());
+                let mut select_list = proj.project_expressions().to_vec();
+                for expr in &mut select_list {
+                    resolver.resolve_select_expr(expr, &group_keys);
+                }
+                let new_proj = LogicalProjection::new(select_list, new_child.clone());
+                Arc::new(new_proj.clone_with_rewrite_expr(new_child, self))
+            }
+            _ => Arc::new(proj.clone_with_rewrite_expr(new_child, self)),
+        };
+
         self.bindings = bindings;
         ret
     }
@@ -108,5 +126,179 @@ impl PlanRewriter for InputRefResolver {
     }
     fn rewrite_logical_values(&mut self, plan: &LogicalValues) -> PlanRef {
         Arc::new(plan.clone_with_rewrite_expr(self))
+    }
+}
+
+/// Resolves select expression into `InputRef` using group by expressions
+/// for parent node of `LogicalAggregate`.
+#[derive(Default)]
+struct AggInputRefResolver {
+    agg_start_index: usize,
+}
+
+impl AggInputRefResolver {
+    fn new(group_key_count: usize) -> Self {
+        AggInputRefResolver {
+            agg_start_index: group_key_count,
+        }
+    }
+
+    /// using group by exprs to resolve select expr into `InputRef` which include two cases:
+    /// 1. found identical select expr in group by exprs and replace it with `InputRef`
+    /// 2. found aggregate function in select expr and replace it with `InputRef`
+    fn resolve_select_expr(&mut self, expr: &mut BoundExpr, group_keys: &Vec<BoundExpr>) {
+        use BoundExpr::*;
+
+        // if found identical select expr in group by exprs, replace select expr with `InputRef`
+        if let Some(i) = group_keys.iter().position(|e| e == expr) {
+            *expr = InputRef(BoundInputRef {
+                index: i,
+                return_type: expr.return_type().unwrap(),
+            });
+            return;
+        }
+
+        match expr {
+            // due to aggregate exprs are behind group by exprs, so we used group by exprs count as
+            // InputRef's based index
+            AggCall(agg) => {
+                *expr = InputRef(BoundInputRef {
+                    index: self.agg_start_index,
+                    return_type: agg.return_type.clone(),
+                });
+                self.agg_start_index += 1;
+            }
+            BinaryOp(bin_op) => {
+                self.resolve_select_expr(&mut bin_op.left_expr, group_keys);
+                self.resolve_select_expr(&mut bin_op.right_expr, group_keys);
+            }
+            UnaryOp(unary_op) => self.resolve_select_expr(&mut unary_op.expr, group_keys),
+            TypeCast(type_cast) => self.resolve_select_expr(&mut type_cast.expr, group_keys),
+            ExprWithAlias(expr_with_alias) => {
+                self.resolve_select_expr(&mut expr_with_alias.expr, group_keys)
+            }
+            IsNull(isnull) => self.resolve_select_expr(&mut isnull.expr, group_keys),
+            Constant(_) | ColumnRef(_) | InputRef(_) | Alias(_) => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlparser::ast::BinaryOperator;
+
+    use super::*;
+    use crate::binder::AggKind;
+    use crate::types::{DataTypeExt, DataTypeKind, DataValue};
+
+    #[test]
+    /// To be resolved SQL:
+    /// ```sql
+    /// select v2 + 1, sum(v1) from t group by v2 + 1
+    /// ```
+    /// After resolved select list: `[InputRef #0, InputRef #1]`
+    fn test_resolve_select_expr() {
+        let sum_v1_call = BoundExpr::AggCall(BoundAggCall {
+            kind: AggKind::Sum,
+            args: vec![BoundExpr::ColumnRef(BoundColumnRef {
+                column_ref_id: ColumnRefId::new(0, 0, 0, 0),
+                is_primary_key: false,
+                desc: DataTypeKind::Int(None).not_null().to_column("v1".into()),
+            })],
+            return_type: DataTypeKind::Int(None).not_null(),
+        });
+        let v2_plus_1_expr = BoundExpr::BinaryOp(BoundBinaryOp {
+            op: BinaryOperator::Plus,
+            left_expr: BoundExpr::ColumnRef(BoundColumnRef {
+                column_ref_id: ColumnRefId::new(0, 0, 0, 1),
+                is_primary_key: false,
+                desc: DataTypeKind::Int(None).not_null().to_column("v2".into()),
+            })
+            .into(),
+            right_expr: BoundExpr::Constant(DataValue::Int32(1)).into(),
+            return_type: Some(DataTypeKind::Int(None).not_null()),
+        });
+        let group_keys = vec![v2_plus_1_expr.clone()];
+        let mut select_list = vec![v2_plus_1_expr, sum_v1_call];
+
+        let mut resolver = AggInputRefResolver::new(group_keys.len());
+        for expr in &mut select_list {
+            resolver.resolve_select_expr(expr, &group_keys);
+        }
+
+        assert_eq!(
+            select_list[0],
+            BoundExpr::InputRef(BoundInputRef {
+                index: 0,
+                return_type: DataTypeKind::Int(None).not_null(),
+            })
+        );
+        assert_eq!(
+            select_list[1],
+            BoundExpr::InputRef(BoundInputRef {
+                index: 1,
+                return_type: DataTypeKind::Int(None).not_null(),
+            })
+        );
+    }
+
+    #[test]
+    /// To be resolved SQL:
+    /// ```sql
+    /// select v2 + 1 + sum(v1) from t group by v2 + 1
+    /// ```
+    /// After resolved select list: `[Plus(InputRef #0, InputRef #1)]`
+    fn test_resolve_select_expr_plus_agg_call() {
+        let sum_v1_call = BoundExpr::AggCall(BoundAggCall {
+            kind: AggKind::Sum,
+            args: vec![BoundExpr::ColumnRef(BoundColumnRef {
+                column_ref_id: ColumnRefId::new(0, 0, 0, 0),
+                is_primary_key: false,
+                desc: DataTypeKind::Int(None).not_null().to_column("v1".into()),
+            })],
+            return_type: DataTypeKind::Int(None).not_null(),
+        });
+        let v2_expr = BoundExpr::ColumnRef(BoundColumnRef {
+            column_ref_id: ColumnRefId::new(0, 0, 0, 1),
+            is_primary_key: false,
+            desc: DataTypeKind::Int(None).not_null().to_column("v2".into()),
+        });
+        let v2_plus_1_expr = BoundExpr::BinaryOp(BoundBinaryOp {
+            op: BinaryOperator::Plus,
+            left_expr: v2_expr.into(),
+            right_expr: BoundExpr::Constant(DataValue::Int32(1)).into(),
+            return_type: Some(DataTypeKind::Int(None).not_null()),
+        });
+        let v2_plus_1_plus_sum_expr = BoundExpr::BinaryOp(BoundBinaryOp {
+            op: BinaryOperator::Plus,
+            left_expr: v2_plus_1_expr.clone().into(),
+            right_expr: sum_v1_call.into(),
+            return_type: Some(DataTypeKind::Int(None).not_null()),
+        });
+        let group_keys = vec![v2_plus_1_expr];
+        let mut select_list = vec![v2_plus_1_plus_sum_expr];
+
+        let mut resolver = AggInputRefResolver::new(group_keys.len());
+        for expr in &mut select_list {
+            resolver.resolve_select_expr(expr, &group_keys);
+        }
+
+        assert_eq!(
+            select_list[0],
+            BoundExpr::BinaryOp(BoundBinaryOp {
+                op: BinaryOperator::Plus,
+                left_expr: BoundExpr::InputRef(BoundInputRef {
+                    index: 0,
+                    return_type: DataTypeKind::Int(None).not_null(),
+                })
+                .into(),
+                right_expr: BoundExpr::InputRef(BoundInputRef {
+                    index: 1,
+                    return_type: DataTypeKind::Int(None).not_null(),
+                })
+                .into(),
+                return_type: Some(DataTypeKind::Int(None).not_null()),
+            })
+        );
     }
 }

--- a/tests/sql/group_by.slt
+++ b/tests/sql/group_by.slt
@@ -21,26 +21,35 @@ select v2 + 1, sum(v1) from t group by v2 + 1
 2 3
 3 7
 
-query II rowsort
+query III rowsort
 select sum(v1), v2 + 1 as a, count(*) from t group by a
 ----
 3 2 2
 7 3 2
 5 4 1
 
-query II rowsort
+query III rowsort
 select v2, v2 + 1, sum(v1) from t group by v2 + 1, v2
 ----
 1 2 3
 3 4 5
 2 3 7
 
-query II rowsort
+query III rowsort
 select v2, v2 + 1, sum(v1) from t group by v2 + 1, v2 order by v2
 ----
 1 2 3
 3 4 5
 2 3 7
+
+query I rowsort
+select v1 + 1 + count(*) from t group by v1 + 1
+----
+3
+4
+5
+6
+7
 
 statement ok
 drop table t


### PR DESCRIPTION
fix part of https://github.com/risinglightdb/risinglight/issues/539

the original group by expression support (https://github.com/risinglightdb/risinglight/pull/535) seems not very clear for resolving `InputRef`, so I refactor the main logic to `InputRefResolver`. And fix panic for:
```sql 
select v2 + 1 + count(*) from t group by v2 + 1;
```

but it still leaves some issues:

- panic `select v2 + 2 + count(*) from t group by v2 + 1;`

Signed-off-by: Fedomn <fedomn.ma@gmail.com>