### PR TITLE
feat(binder): support `primary key (a, b)` syntax

### DIFF
--- a/src/catalog/table.rs
+++ b/src/catalog/table.rs
@@ -21,6 +21,7 @@ struct Inner {
     #[allow(dead_code)]
     is_materialized_view: bool,
     next_column_id: ColumnId,
+    primary_key_ids: Vec<ColumnId>,
 }
 
 impl TableCatalog {
@@ -38,12 +39,29 @@ impl TableCatalog {
                 columns: BTreeMap::new(),
                 is_materialized_view,
                 next_column_id: 0,
+                primary_key_ids: Vec::new(),
             }),
         };
+        let mut pk_ids = vec![];
         for col_catalog in columns {
+            if col_catalog.is_primary() {
+                pk_ids.push(col_catalog.id());
+            }
             table_catalog.add_column(col_catalog).unwrap();
         }
+
+        table_catalog.set_primary_key_ids(&pk_ids);
         table_catalog
+    }
+
+    pub fn set_primary_key_ids(&self, pk_ids: &[ColumnId]) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.primary_key_ids = pk_ids.to_owned();
+    }
+
+    pub fn get_primary_key_ids(&self) -> Vec<ColumnId> {
+        let inner = self.inner.lock().unwrap();
+        inner.primary_key_ids.clone()
     }
 
     pub fn add_column(&self, col_catalog: ColumnCatalog) -> Result<ColumnId, CatalogError> {
@@ -128,5 +146,25 @@ mod tests {
         let col1_catalog = table_catalog.get_column_by_id(1).unwrap();
         assert_eq!(col1_catalog.name(), "b");
         assert_eq!(col1_catalog.datatype().kind(), DataTypeKind::Boolean);
+
+        // test with two primary key
+        let col0 = ColumnCatalog::new(
+            0,
+            DataTypeKind::Int(None)
+                .not_null()
+                .to_column_primary_key("a".into()),
+        );
+        let col1 = ColumnCatalog::new(
+            1,
+            DataTypeKind::Int(None)
+                .not_null()
+                .to_column_primary_key("b".into()),
+        );
+        let col2 = ColumnCatalog::new(2, DataTypeKind::Int(None).nullable().to_column("c".into()));
+        let col3 = ColumnCatalog::new(3, DataTypeKind::Int(None).nullable().to_column("d".into()));
+
+        let col_catalogs = vec![col0, col1, col2, col3];
+        let table_catalog = TableCatalog::new(0, "t".into(), col_catalogs, false);
+        assert_eq!(table_catalog.get_primary_key_ids(), vec![0, 1]);
     }
 }

--- a/tests/sql/filter.slt
+++ b/tests/sql/filter.slt
@@ -4,7 +4,7 @@ create table t (v1 int not null, v2 int not null, primary key(v1));
 statement ok
 insert into t values (1, 1), (4, 6), (3, 2), (2, 1)
 
-query I
+query I rowsort
 select v1 from t where v1 > 2
 ----
 4


### PR DESCRIPTION
Signed-off-by: Shmiwy <wyf000219@126.com>

#625 1st editon

support primary key (a, b) syntax by adding a field called `primary_key_ids` in `TableCatalog` without removng `is_primary field` from `ColumnDesc`. I will remove `is_primary` and refactor code when I want to extend the case to multiple sort keys.