### PR TITLE
feat: support multi ordered primary key

### DIFF
--- a/src/binder/statement/create_table.rs
+++ b/src/binder/statement/create_table.rs
@@ -91,8 +91,8 @@ impl Binder {
         }
     }
 
-    // get primary keys' id in declared order。
-    // we use index in columns vector as column id
+    /// get primary keys' id in declared order。
+    /// we use index in columns vector as column id
     fn ordered_pks_from_columns(columns: &[ColumnDef]) -> Vec<ColumnId> {
         let mut ordered_pks = Vec::new();
 
@@ -111,9 +111,9 @@ impl Binder {
         ordered_pks
     }
 
-    // We have used `pks_name_from_constraints` to get the primary keys' name sorted by declaration
-    // order in "primary key(c1, c2..)" syntax. Now we transfer the name to id to get the sorted
-    // ID
+    /// We have used `pks_name_from_constraints` to get the primary keys' name sorted by declaration
+    /// order in "primary key(c1, c2..)" syntax. Now we transfer the name to id to get the sorted
+    /// ID
     fn ordered_pks_from_constraint(pks_name: &[String], columns: &[ColumnDef]) -> Vec<ColumnId> {
         let mut ordered_pks = vec![0; pks_name.len()];
         let mut pos_in_ordered_pk = HashMap::new(); // used to get pos from column name
@@ -131,7 +131,7 @@ impl Binder {
         });
         ordered_pks
     }
-    // get the primary keys' name sorted by declaration order in "primary key(c1, c2..)" syntax.
+    /// get the primary keys' name sorted by declaration order in "primary key(c1, c2..)" syntax.
     fn pks_name_from_constraints(constraints: &[TableConstraint]) -> Vec<String> {
         let mut pks_name_from_constraints = vec![];
 

--- a/src/binder/statement/create_table.rs
+++ b/src/binder/statement/create_table.rs
@@ -1,5 +1,4 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
-
 use sqlparser::ast::TableConstraint;
 
 use super::*;
@@ -14,6 +13,7 @@ pub struct BoundCreateTable {
     pub schema_id: SchemaId,
     pub table_name: String,
     pub columns: Vec<ColumnCatalog>,
+    pub ordered_pk_ids: Vec<ColumnId>,
 }
 
 impl Binder {
@@ -45,57 +45,73 @@ impl Binder {
                     }
                 }
 
-                // record primary key names declared by "primary key" keywords
-                // if a sql like " create table t (a int, b int, c int, d int, primary key(a, b)); "
-                // then after the for loop, the extra_pk_name will contain "a" and "b"
-                let mut extra_pk_name: HashSet<String> = HashSet::new();
-                for constraint in constraints {
-                    match constraint {
-                        TableConstraint::Unique {
-                            is_primary,
-                            columns,
-                            ..
-                        } if *is_primary => columns.iter().for_each(|indent| {
-                            extra_pk_name.insert(indent.value.clone());
-                        }),
+                // column name -> index in `ordered_pk_ids` vector
+                let ordered_pk_pos = Binder::get_extra_pks(constraints);
+                // whether we have primary key declared by "primary key(c1, c2..) syntax"
+                let flag = !ordered_pk_pos.is_empty();
+                // ordered primary ids declared by "primary key(c1, c2..) syntax"
+                let mut ordered_pk_ids = vec![0; ordered_pk_pos.len()];
+                let mut col_catalogs = vec![];
 
-                        _ => todo!(),
+                for (idx, colum_def) in columns.iter().enumerate() {
+                    let mut is_primary = false;
+                    let mut col = ColumnCatalog::from(colum_def, &mut is_primary);
+                    if flag && is_primary {
+                        // we can't support sql query like
+                        // "create table (a int primary key, b int not null, primary key(b));"
+                        // declaring pk both in column's option and 'primary key(c1..)' syntax"
+                        return Err(BindError::NotSupportedTSQL);
+                    } else if is_primary {
+                        // primary key is declared only in column's options
+                        ordered_pk_ids.push(idx as ColumnId);
+                    } else if ordered_pk_pos.contains_key(col.name()) {
+                        // primary key is declared only by "primary key(c1, c2) syntax"
+                        let pos = *(ordered_pk_pos.get(col.name()).unwrap());
+                        ordered_pk_ids[pos] = idx as ColumnId;
+                        col.set_primary(true); // TODO: remove this line in the future
                     }
+                    col.set_id(idx as ColumnId);
+                    col_catalogs.push(col);
                 }
 
-                let columns = columns
-                    .iter()
-                    .enumerate()
-                    .map(|(idx, col)| {
-                        let mut col = ColumnCatalog::from(col);
-                        if extra_pk_name.contains(col.name()) && !col.is_primary() {
-                            col.set_primary(true);
-                        }
-                        col.set_id(idx as ColumnId);
-                        col
-                    })
-                    .collect();
                 Ok(BoundCreateTable {
                     database_id: db.id(),
                     schema_id: schema.id(),
                     table_name: table_name.into(),
-                    columns,
+                    columns: col_catalogs,
+                    ordered_pk_ids,
                 })
             }
             _ => panic!("mismatched statement type"),
         }
     }
+
+    fn get_extra_pks(constraints: &Vec<TableConstraint>) -> HashMap<String, usize> {
+        let mut ordered_pk_pos: HashMap<String, usize> = HashMap::new();
+        for constraint in constraints {
+            match constraint {
+                TableConstraint::Unique {
+                    is_primary,
+                    columns,
+                    ..
+                } if *is_primary => columns.iter().enumerate().for_each(|(index, indent)| {
+                    ordered_pk_pos.insert(indent.value.clone(), index);
+                }),
+                _ => todo!(),
+            }
+        }
+        ordered_pk_pos
+    }
 }
 
-impl From<&ColumnDef> for ColumnCatalog {
-    fn from(cdef: &ColumnDef) -> Self {
+impl ColumnCatalog {
+    fn from(cdef: &ColumnDef, is_primary_: &mut bool) -> Self {
         let mut is_nullable = true;
-        let mut is_primary_ = false;
         for opt in &cdef.options {
             match opt.option {
                 ColumnOption::Null => is_nullable = true,
                 ColumnOption::NotNull => is_nullable = false,
-                ColumnOption::Unique { is_primary } => is_primary_ = is_primary,
+                ColumnOption::Unique { is_primary } => *is_primary_ = is_primary,
                 _ => todo!("column options"),
             }
         }
@@ -104,7 +120,7 @@ impl From<&ColumnDef> for ColumnCatalog {
             ColumnDesc::new(
                 DataType::new(cdef.data_type.clone(), is_nullable),
                 cdef.name.value.to_lowercase(),
-                is_primary_,
+                *is_primary_,
             ),
         )
     }
@@ -124,10 +140,14 @@ mod tests {
         let catalog = Arc::new(RootCatalog::new());
         let mut binder = Binder::new(catalog.clone());
         let sql = "
-            create table t1 (v1 int not null, v2 int); 
+            create table t1 (v1 int not null, v2 int);
             create table t2 (a int not null, a int not null);
             create table t3 (v1 int not null);
-            create table t4 (a int not null, b int not null, c int, primary key(a,b));";
+            create table t4 (a int not null, b int not null, c int, primary key(a, b));
+            create table t5 (a int not null, b int not null, c int, primary key(b, a));
+            create table t6 (a int primary key, b int not null, c int not null, primary key(b, c));
+            create table t7 (a int primary key, b int)";
+
         let stmts = parse(sql).unwrap();
 
         assert_eq!(
@@ -139,13 +159,14 @@ mod tests {
                 columns: vec![
                     ColumnCatalog::new(
                         0,
-                        DataTypeKind::Int(None).not_null().to_column("v1".into())
+                        DataTypeKind::Int(None).not_null().to_column("v1".into()),
                     ),
                     ColumnCatalog::new(
                         1,
-                        DataTypeKind::Int(None).nullable().to_column("v2".into())
+                        DataTypeKind::Int(None).nullable().to_column("v2".into()),
                     ),
                 ],
+                ordered_pk_ids: vec![],
             }
         );
 
@@ -156,7 +177,9 @@ mod tests {
 
         let database = catalog.get_database_by_id(0).unwrap();
         let schema = database.get_schema_by_id(0).unwrap();
-        schema.add_table("t3".into(), vec![], false).unwrap();
+        schema
+            .add_table("t3".into(), vec![], false, vec![])
+            .unwrap();
         assert_eq!(
             binder.bind_create_table(&stmts[2]),
             Err(BindError::DuplicatedTable("t3".into()))
@@ -181,11 +204,58 @@ mod tests {
                             .not_null()
                             .to_column_primary_key("b".into()),
                     ),
-                    ColumnCatalog::new(
-                        2,
-                        DataTypeKind::Int(None).nullable().to_column("c".into(),),
-                    ),
+                    ColumnCatalog::new(2, DataTypeKind::Int(None).nullable().to_column("c".into())),
                 ],
+                ordered_pk_ids: vec![0, 1],
+            }
+        );
+
+        assert_eq!(
+            binder.bind_create_table(&stmts[4]).unwrap(),
+            BoundCreateTable {
+                database_id: 0,
+                schema_id: 0,
+                table_name: "t5".into(),
+                columns: vec![
+                    ColumnCatalog::new(
+                        0,
+                        DataTypeKind::Int(None)
+                            .not_null()
+                            .to_column_primary_key("a".into()),
+                    ),
+                    ColumnCatalog::new(
+                        1,
+                        DataTypeKind::Int(None)
+                            .not_null()
+                            .to_column_primary_key("b".into()),
+                    ),
+                    ColumnCatalog::new(2, DataTypeKind::Int(None).nullable().to_column("c".into())),
+                ],
+                ordered_pk_ids: vec![1, 0],
+            }
+        );
+
+        assert_eq!(
+            binder.bind_create_table(&stmts[5]),
+            Err(BindError::NotSupportedTSQL)
+        );
+
+        assert_eq!(
+            binder.bind_create_table(&stmts[6]).unwrap(),
+            BoundCreateTable {
+                database_id: 0,
+                schema_id: 0,
+                table_name: "t7".into(),
+                columns: vec![
+                    ColumnCatalog::new(
+                        0,
+                        DataTypeKind::Int(None)
+                            .nullable()
+                            .to_column_primary_key("a".into()),
+                    ),
+                    ColumnCatalog::new(1, DataTypeKind::Int(None).nullable().to_column("b".into()),),
+                ],
+                ordered_pk_ids: vec![0],
             }
         );
     }

--- a/src/binder/statement/drop.rs
+++ b/src/binder/statement/drop.rs
@@ -64,7 +64,9 @@ mod tests {
 
         let database = catalog.get_database_by_id(0).unwrap();
         let schema = database.get_schema_by_id(0).unwrap();
-        schema.add_table("mytable".into(), vec![], false).unwrap();
+        schema
+            .add_table("mytable".into(), vec![], false, vec![])
+            .unwrap();
 
         let stmts = parse("drop table mytable").unwrap();
         assert_eq!(

--- a/src/binder/statement/insert.rs
+++ b/src/binder/statement/insert.rs
@@ -232,6 +232,7 @@ mod tests {
                     ColumnCatalog::new(1, DataTypeKind::Int(None).not_null().to_column("b".into())),
                 ],
                 false,
+                vec![],
             )
             .unwrap();
 

--- a/src/catalog/database.rs
+++ b/src/catalog/database.rs
@@ -104,6 +104,7 @@ impl DatabaseCatalog {
                         .to_column("github_id".into()),
                 )],
                 false,
+                vec![],
             )
             .unwrap();
     }

--- a/src/catalog/schema.rs
+++ b/src/catalog/schema.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use super::{CatalogError, ColumnCatalog, TableCatalog};
-use crate::types::{SchemaId, TableId};
+use crate::types::{ColumnId, SchemaId, TableId};
 
 /// The catalog of a schema.
 pub struct SchemaCatalog {
@@ -37,6 +37,7 @@ impl SchemaCatalog {
         name: String,
         columns: Vec<ColumnCatalog>,
         is_materialized_view: bool,
+        ordered_pk_ids: Vec<ColumnId>,
     ) -> Result<TableId, CatalogError> {
         let mut inner = self.inner.lock().unwrap();
         if inner.table_idxs.contains_key(&name) {
@@ -49,6 +50,7 @@ impl SchemaCatalog {
             name.clone(),
             columns,
             is_materialized_view,
+            ordered_pk_ids,
         ));
         inner.table_idxs.insert(name, table_id);
         inner.tables.insert(table_id, table_catalog);

--- a/src/db.rs
+++ b/src/db.rs
@@ -181,6 +181,7 @@ impl Database {
         // TODO: parallelize
         let mut outputs: Vec<Chunk> = vec![];
         for stmt in stmts {
+            debug!("{:#?}", stmt);
             let stmt = binder.bind(&stmt)?;
             debug!("{:#?}", stmt);
             let logical_plan = logical_planner.plan(stmt)?;

--- a/src/executor/insert.rs
+++ b/src/executor/insert.rs
@@ -135,6 +135,7 @@ mod tests {
                 ColumnCatalog::new(0, DataTypeKind::Int(None).not_null().to_column("v1".into())),
                 ColumnCatalog::new(1, DataTypeKind::Int(None).not_null().to_column("v2".into())),
             ],
+            vec![],
         ));
         let mut executor = CreateTableExecutor {
             plan,

--- a/src/logical_planner/create.rs
+++ b/src/logical_planner/create.rs
@@ -11,6 +11,7 @@ impl LogicalPlaner {
             stmt.schema_id,
             stmt.table_name,
             stmt.columns,
+            stmt.ordered_pk_ids,
         )))
     }
 }

--- a/src/optimizer/plan_nodes/logical_create_table.rs
+++ b/src/optimizer/plan_nodes/logical_create_table.rs
@@ -57,8 +57,8 @@ impl LogicalCreateTable {
     }
 
     /// Get the logical create table's `ordered_pk_ids`.
-    pub fn ordered_pk_ids(&self) -> Vec<ColumnId> {
-        self.ordered_pk_ids.clone()
+    pub fn ordered_pk_ids(&self) -> &[ColumnId] {
+        self.ordered_pk_ids.as_ref()
     }
 }
 

--- a/src/optimizer/plan_nodes/logical_create_table.rs
+++ b/src/optimizer/plan_nodes/logical_create_table.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 
 use super::*;
 use crate::catalog::ColumnCatalog;
-use crate::types::{DataTypeKind, DatabaseId, SchemaId};
+use crate::types::{ColumnId, DataTypeKind, DatabaseId, SchemaId};
 
 /// The logical plan of `CREATE TABLE`.
 #[derive(Debug, Clone, Serialize)]
@@ -16,6 +16,7 @@ pub struct LogicalCreateTable {
     schema_id: SchemaId,
     table_name: String,
     columns: Vec<ColumnCatalog>,
+    ordered_pk_ids: Vec<ColumnId>,
 }
 
 impl LogicalCreateTable {
@@ -24,12 +25,14 @@ impl LogicalCreateTable {
         schema_id: SchemaId,
         table_name: String,
         columns: Vec<ColumnCatalog>,
+        ordered_pk_ids: Vec<ColumnId>,
     ) -> Self {
         Self {
             database_id,
             schema_id,
             table_name,
             columns,
+            ordered_pk_ids,
         }
     }
 
@@ -52,7 +55,13 @@ impl LogicalCreateTable {
     pub fn columns(&self) -> &[ColumnCatalog] {
         self.columns.as_ref()
     }
+
+    /// Get the logical create table's `ordered_pk_ids`.
+    pub fn ordered_pk_ids(&self) -> Vec<ColumnId> {
+        self.ordered_pk_ids.clone()
+    }
 }
+
 impl PlanTreeNodeLeaf for LogicalCreateTable {}
 
 impl_plan_tree_node_for_leaf!(LogicalCreateTable);

--- a/src/storage/memory/mod.rs
+++ b/src/storage/memory/mod.rs
@@ -74,7 +74,7 @@ impl Storage for InMemoryStorage {
         schema_id: SchemaId,
         table_name: &'a str,
         column_descs: &'a [ColumnCatalog],
-        ordered_pk_ids: Vec<ColumnId>,
+        ordered_pk_ids: &'a [ColumnId],
     ) -> Self::CreateTableResultFuture<'a> {
         async move {
             let db = self
@@ -92,7 +92,7 @@ impl Storage for InMemoryStorage {
                     table_name.into(),
                     column_descs.to_vec(),
                     false,
-                    ordered_pk_ids,
+                    ordered_pk_ids.to_vec(),
                 )
                 .map_err(|_| StorageError::Duplicated("table", table_name.into()))?;
 

--- a/src/storage/memory/mod.rs
+++ b/src/storage/memory/mod.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, Mutex};
 
 use super::{Storage, StorageError, StorageResult, TracedStorageError};
 use crate::catalog::{ColumnCatalog, RootCatalog, RootCatalogRef, TableRefId};
-use crate::types::{DatabaseId, SchemaId};
+use crate::types::{ColumnId, DatabaseId, SchemaId};
 
 mod table;
 pub use table::InMemoryTable;
@@ -74,6 +74,7 @@ impl Storage for InMemoryStorage {
         schema_id: SchemaId,
         table_name: &'a str,
         column_descs: &'a [ColumnCatalog],
+        ordered_pk_ids: Vec<ColumnId>,
     ) -> Self::CreateTableResultFuture<'a> {
         async move {
             let db = self
@@ -87,7 +88,12 @@ impl Storage for InMemoryStorage {
                 return Err(TracedStorageError::duplicated("table", table_name));
             }
             let table_id = schema
-                .add_table(table_name.into(), column_descs.to_vec(), false)
+                .add_table(
+                    table_name.into(),
+                    column_descs.to_vec(),
+                    false,
+                    ordered_pk_ids,
+                )
                 .map_err(|_| StorageError::Duplicated("table", table_name.into()))?;
 
             let id = TableRefId {

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -75,7 +75,7 @@ pub trait Storage: Sync + Send + 'static {
         schema_id: SchemaId,
         table_name: &'a str,
         column_descs: &'a [ColumnCatalog],
-        ordered_pk_ids: Vec<ColumnId>,
+        ordered_pk_ids: &'a [ColumnId],
     ) -> Self::CreateTableResultFuture<'a>;
 
     fn get_table(&self, table_id: TableRefId) -> StorageResult<Self::TableType>;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -21,7 +21,7 @@ use enum_dispatch::enum_dispatch;
 use crate::array::{ArrayImpl, DataChunk};
 use crate::binder::BoundExpr;
 use crate::catalog::{ColumnCatalog, TableRefId};
-use crate::types::{DatabaseId, SchemaId};
+use crate::types::{ColumnId, DatabaseId, SchemaId};
 
 #[enum_dispatch(StorageDispatch)]
 #[derive(Clone)]
@@ -75,6 +75,7 @@ pub trait Storage: Sync + Send + 'static {
         schema_id: SchemaId,
         table_name: &'a str,
         column_descs: &'a [ColumnCatalog],
+        ordered_pk_ids: Vec<ColumnId>,
     ) -> Self::CreateTableResultFuture<'a>;
 
     fn get_table(&self, table_id: TableRefId) -> StorageResult<Self::TableType>;

--- a/src/storage/secondary/manifest.rs
+++ b/src/storage/secondary/manifest.rs
@@ -199,14 +199,14 @@ impl SecondaryStorage {
         schema_id: SchemaId,
         table_name: &str,
         column_descs: &[ColumnCatalog],
-        ordered_pk_ids: Vec<ColumnId>,
+        ordered_pk_ids: &[ColumnId],
     ) -> StorageResult<()> {
         let entry = CreateTableEntry {
             database_id,
             schema_id,
             table_name: table_name.to_string(),
             column_descs: column_descs.to_vec(),
-            ordered_pk_ids,
+            ordered_pk_ids: ordered_pk_ids.to_vec(),
         };
 
         // persist to manifest first

--- a/src/storage/secondary/mod.rs
+++ b/src/storage/secondary/mod.rs
@@ -163,7 +163,7 @@ impl Storage for SecondaryStorage {
         schema_id: SchemaId,
         table_name: &'a str,
         column_descs: &'a [ColumnCatalog],
-        ordered_pk_ids: Vec<ColumnId>,
+        ordered_pk_ids: &'a [ColumnId],
     ) -> Self::CreateTableResultFuture<'a> {
         async move {
             self.create_table_inner(

--- a/src/storage/secondary/mod.rs
+++ b/src/storage/secondary/mod.rs
@@ -163,10 +163,17 @@ impl Storage for SecondaryStorage {
         schema_id: SchemaId,
         table_name: &'a str,
         column_descs: &'a [ColumnCatalog],
+        ordered_pk_ids: Vec<ColumnId>,
     ) -> Self::CreateTableResultFuture<'a> {
         async move {
-            self.create_table_inner(database_id, schema_id, table_name, column_descs)
-                .await
+            self.create_table_inner(
+                database_id,
+                schema_id,
+                table_name,
+                column_descs,
+                ordered_pk_ids,
+            )
+            .await
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Shmiwy <wyf000219@126.com>

try to implementation #625

at this moment, I just append `ordered_pk_ids` to `tableCatalog` withoud using  `is_primary` filed in `ColumnDesc`. It will make removing  `is_primary` in the future easier.