### PR TITLE
fix(planner): enhance group by illegal column validation

### DIFF
--- a/tests/sql/group_by.slt
+++ b/tests/sql/group_by.slt
@@ -13,6 +13,8 @@ select v2 + 1 as a, v1 as b from t group by a
 statement error
 select v2, v2 + 1, sum(v1) from t group by v2 + 1
 
+statement error
+select v2 + 2 + count(*) from t group by v2 + 1
 
 query II rowsort
 select v2 + 1, sum(v1) from t group by v2 + 1

--- a/tests/sql/group_by.slt
+++ b/tests/sql/group_by.slt
@@ -16,6 +16,9 @@ select v2, v2 + 1, sum(v1) from t group by v2 + 1
 statement error
 select v2 + 2 + count(*) from t group by v2 + 1
 
+statement error
+select v2 + count(*) from t group by v2 order by v1;
+
 query II rowsort
 select v2 + 1, sum(v1) from t group by v2 + 1
 ----


### PR DESCRIPTION
fix part of https://github.com/risinglightdb/risinglight/issues/539

including two enhanced validation for `groupby` illegal columns:
- `select v2 + 2 + count(*) from t group by v2 + 1;`
- `select v2 + count(*) from t group by v2 order by v1;`

Signed-off-by: Fedomn <fedomn.ma@gmail.com>