### PR TITLE
feat(optimizer): support (filter_agg_rule + having clause)

### DIFF
--- a/src/binder/expression/column_ref.rs
+++ b/src/binder/expression/column_ref.rs
@@ -90,9 +90,15 @@ impl Binder {
                 }
             }
             if info == None {
-                if self.context.aliases.contains(column_name) {
+                if let Some(index) = self
+                    .context
+                    .aliases
+                    .iter()
+                    .position(|name| column_name == name)
+                {
                     Ok(BoundExpr::Alias(BoundAlias {
                         alias: column_name.clone(),
+                        return_type: self.context.aliases_expr_return_type[index].clone(),
                     }))
                 } else {
                     Err(BindError::InvalidColumn(column_name.clone()))

--- a/src/binder/expression/expr_with_alias.rs
+++ b/src/binder/expression/expr_with_alias.rs
@@ -27,6 +27,8 @@ impl std::fmt::Display for BoundExprWithAlias {
 #[derive(PartialEq, Clone, Serialize)]
 pub struct BoundAlias {
     pub alias: String,
+    pub return_type: Option<DataType>,
+    // TODO: Store a copy of the original expression ?
 }
 
 impl std::fmt::Debug for BoundAlias {
@@ -40,6 +42,9 @@ impl Binder {
     pub fn bind_alias(&mut self, expr: BoundExpr, ident: Ident) -> BoundExpr {
         let alias = ident.value;
         self.context.aliases.push(alias.clone());
+        self.context
+            .aliases_expr_return_type
+            .push(expr.return_type());
         BoundExpr::ExprWithAlias(BoundExprWithAlias {
             expr: Box::new(expr),
             alias,

--- a/src/binder/expression/mod.rs
+++ b/src/binder/expression/mod.rs
@@ -55,7 +55,7 @@ impl BoundExpr {
             Self::InputRef(expr) => Some(expr.return_type.clone()),
             Self::IsNull(_) => Some(DataTypeKind::Boolean.not_null()),
             Self::ExprWithAlias(expr) => expr.expr.return_type(),
-            Self::Alias(_) => None,
+            Self::Alias(expr) => expr.return_type.clone(),
         }
     }
 

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -8,7 +8,7 @@ use crate::catalog::{
     ColumnDesc, RootCatalog, TableRefId, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME,
 };
 use crate::parser::{Ident, ObjectName, Statement};
-use crate::types::{ColumnId, DataTypeKind, DataValue};
+use crate::types::{ColumnId, DataType, DataTypeKind, DataValue};
 
 mod expr_visitor;
 mod expression;
@@ -77,6 +77,8 @@ struct BinderContext {
     column_descs: HashMap<String, Vec<ColumnDesc>>,
     // Stores alias information
     aliases: Vec<String>,
+    // Stores alias expr return type
+    aliases_expr_return_type: Vec<Option<DataType>>,
 }
 
 /// The binder resolves all expressions referring to schema objects such as

--- a/src/binder/statement/select.rs
+++ b/src/binder/statement/select.rs
@@ -17,6 +17,7 @@ pub struct BoundSelect {
     pub orderby: Vec<BoundOrderBy>,
     pub limit: Option<BoundExpr>,
     pub offset: Option<BoundExpr>,
+    pub having: Option<BoundExpr>,
     // pub return_names: Vec<String>,
 }
 
@@ -103,6 +104,11 @@ impl Binder {
             group_by.push(self.bind_expr(group_key)?);
         }
 
+        let mut having = None;
+        if let Some(expr) = select.having.as_ref() {
+            having = Some(self.bind_expr(expr)?);
+        }
+
         let mut orderby = vec![];
         for e in &query.order_by {
             orderby.push(BoundOrderBy {
@@ -110,6 +116,7 @@ impl Binder {
                 descending: e.asc == Some(false),
             });
         }
+
         // Add referred columns for base table reference
         if let Some(table_ref) = &mut from_table {
             self.bind_column_ids(table_ref);
@@ -124,6 +131,7 @@ impl Binder {
             orderby,
             limit,
             offset,
+            having,
         }))
     }
 

--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -38,8 +38,11 @@ impl Optimizer {
         plan = arith_expr_simplification_rule.rewrite(plan);
         plan = bool_expr_simplification_rule.rewrite(plan);
         plan = constant_moving_rule.rewrite(plan);
-        let mut rules: Vec<Box<(dyn rules::Rule + 'static)>> =
-            vec![Box::new(FilterJoinRule {}), Box::new(LimitOrderRule {})];
+        let mut rules: Vec<Box<(dyn rules::Rule + 'static)>> = vec![
+            Box::new(FilterAggRule {}),
+            Box::new(FilterJoinRule {}),
+            Box::new(LimitOrderRule {}),
+        ];
         if self.enable_filter_scan {
             rules.push(Box::new(FilterScanRule {}));
         }

--- a/src/optimizer/rules/filter_agg_rule.rs
+++ b/src/optimizer/rules/filter_agg_rule.rs
@@ -1,0 +1,83 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use bit_set::BitSet;
+
+use super::*;
+use crate::binder::BoundExpr;
+use crate::optimizer::expr_utils::{conjunctions, input_col_refs, merge_conjunctions};
+use crate::optimizer::logical_plan_rewriter::ExprRewriter;
+use crate::optimizer::plan_nodes::{LogicalFilter, PlanTreeNodeUnary};
+
+pub struct FilterAggRule {}
+
+impl Rule for FilterAggRule {
+    fn apply(&self, plan: PlanRef) -> Result<PlanRef, ()> {
+        let filter = plan.as_logical_filter()?;
+        let child = filter.child();
+        let agg = child.as_logical_aggregate()?;
+        let filter_cond = filter.expr().clone();
+
+        let agg_calls_num = agg.agg_calls().len();
+        let group_keys_num = agg.group_keys().len();
+
+        let mut bitset = BitSet::new();
+        for i in group_keys_num..group_keys_num + agg_calls_num {
+            bitset.insert(i);
+        }
+        let conditions = conjunctions(filter_cond);
+        let mut pushed_conditions = Vec::new();
+        let mut remaining_conditions = Vec::new();
+        // We cannot push down expressions that contain aggregate function
+        for cond in conditions {
+            let cond_bitset = input_col_refs(&cond);
+            if cond_bitset.is_disjoint(&bitset) {
+                pushed_conditions.push(cond);
+            } else {
+                remaining_conditions.push(cond);
+            }
+        }
+
+        if pushed_conditions.is_empty() {
+            return Ok(plan.clone());
+        }
+
+        let input_ref_rewriter = InputRefRewriter {
+            input_refs: agg.group_keys(),
+        };
+
+        // rewrite the expression bindings
+        for condition in &mut pushed_conditions {
+            input_ref_rewriter.rewrite_expr(condition);
+        }
+
+        let pushed_cond = merge_conjunctions(pushed_conditions.into_iter());
+
+        let agg_input = agg.child();
+        let pushed_filter = Arc::new(LogicalFilter::new(pushed_cond, agg_input));
+        let agg = Arc::new(agg.clone_with_child(pushed_filter));
+
+        if remaining_conditions.is_empty() {
+            return Ok(agg);
+        }
+
+        let remaining_filter = merge_conjunctions(remaining_conditions.into_iter());
+        Ok(Arc::new(LogicalFilter::new(remaining_filter, agg)))
+    }
+}
+
+struct InputRefRewriter<'a> {
+    input_refs: &'a [BoundExpr],
+}
+
+impl<'a> ExprRewriter for InputRefRewriter<'a> {
+    fn rewrite_input_ref(&self, expr: &mut BoundExpr) {
+        match expr {
+            BoundExpr::InputRef(bref) => {
+                *expr = self.input_refs[bref.index].clone();
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/optimizer/rules/mod.rs
+++ b/src/optimizer/rules/mod.rs
@@ -2,9 +2,11 @@
 
 use super::plan_nodes::PlanRef;
 
+mod filter_agg_rule;
 mod filter_join_rule;
 mod filter_scan_rule;
 mod limit_order_rule;
+pub use filter_agg_rule::*;
 pub use filter_join_rule::*;
 pub use filter_scan_rule::*;
 pub use limit_order_rule::*;

--- a/tests/sql/having.slt
+++ b/tests/sql/having.slt
@@ -1,0 +1,46 @@
+# scalar having
+query I
+select 42 having 42 > 18
+----
+42
+
+# scalar having
+query I
+select 42 having 42 > 801
+----
+
+statement ok
+CREATE TABLE test (x INTEGER, y INTEGER);
+
+statement ok
+INSERT INTO test VALUES (1, 2), (2, 2), (11, 22)
+
+query II
+select y as b, sum(x) as sum from test group by b having b = 2
+----
+2 3
+
+query II
+select count(x) as a, y as b from test group by b having a > 1
+----
+2 2
+
+query II
+select count(x) as a, y + 1 as b from test group by b having b + 1 = 24;
+----
+1 23
+
+query II
+select x from test group by x having max(y) = 22 
+----
+11
+
+query II
+select y + 1 as i from test group by y + 1 having count(x) > 1 and y + 1 = 3 or y + 1 = 23 order by i;
+----
+3
+23
+
+statement error
+select count(x) from test group by count(x)
+


### PR DESCRIPTION
**Support having clause and alias**
```sql
select count(x) as a, y as b from test group by b having a > 1

select 42 having 42 > 18;
```
**Forbid to generate:**
```sql
select count(x) from test group by count(x)
```

**Support push the filter down below the agg**
**Before:**
```text
> explain select count(x), y + 1 from test group by y + 1 having count(x) > 1 and y + 1 = 2;
PhysicalProjection:
    InputRef #1
    InputRef #0
  PhysicalFilter: expr And(Gt(InputRef #1, Int32(1) (const)), Eq(InputRef #0, Int32(2) (const)))
    PhysicalHashAgg:
        (InputRef #1 + 1)
        count(InputRef #0) -> INT
      PhysicalTableScan:
          table #13,
          columns [0, 1],
          with_row_handler: false,
          is_sorted: false,
          expr: None
``` 
**After:**
```text
> explain select count(x), y + 1 from test group by y + 1 having count(x) > 1 and y + 1 = 2;
PhysicalProjection:
    InputRef #1
    InputRef #0
  PhysicalFilter: expr Gt(InputRef #1, Int32(1) (const))
    PhysicalHashAgg:
        (InputRef #1 + 1)
        count(InputRef #0) -> INT
      PhysicalTableScan:
          table #13,
          columns [0, 1],
          with_row_handler: false,
          is_sorted: false,
          expr: Eq(Plus(InputRef #1, Int32(1) (const)), Int32(2) (const))
```