### PR TITLE
feat(optimizer): push the filter down below the agg

### DIFF
--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -38,8 +38,11 @@ impl Optimizer {
         plan = arith_expr_simplification_rule.rewrite(plan);
         plan = bool_expr_simplification_rule.rewrite(plan);
         plan = constant_moving_rule.rewrite(plan);
-        let mut rules: Vec<Box<(dyn rules::Rule + 'static)>> =
-            vec![Box::new(FilterJoinRule {}), Box::new(LimitOrderRule {})];
+        let mut rules: Vec<Box<(dyn rules::Rule + 'static)>> = vec![
+            Box::new(FilterAggRule {}),
+            Box::new(FilterJoinRule {}),
+            Box::new(LimitOrderRule {}),
+        ];
         if self.enable_filter_scan {
             rules.push(Box::new(FilterScanRule {}));
         }

--- a/src/optimizer/rules/filter_agg_rule.rs
+++ b/src/optimizer/rules/filter_agg_rule.rs
@@ -1,0 +1,83 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use bit_set::BitSet;
+
+use super::*;
+use crate::binder::BoundExpr;
+use crate::optimizer::expr_utils::{conjunctions, input_col_refs, merge_conjunctions};
+use crate::optimizer::logical_plan_rewriter::ExprRewriter;
+use crate::optimizer::plan_nodes::{LogicalFilter, PlanTreeNodeUnary};
+
+pub struct FilterAggRule {}
+
+impl Rule for FilterAggRule {
+    fn apply(&self, plan: PlanRef) -> Result<PlanRef, ()> {
+        let filter = plan.as_logical_filter()?;
+        let child = filter.child();
+        let agg = child.as_logical_aggregate()?;
+        let filter_cond = filter.expr().clone();
+
+        let agg_calls_num = agg.agg_calls().len();
+        let group_keys_num = agg.group_keys().len();
+
+        let mut bitset = BitSet::new();
+        for i in group_keys_num..group_keys_num + agg_calls_num {
+            bitset.insert(i);
+        }
+        let conditions = conjunctions(filter_cond);
+        let mut pushed_conditions = Vec::new();
+        let mut remaining_conditions = Vec::new();
+        // We cannot push down expressions that contain aggregate function
+        for cond in conditions {
+            let cond_bitset = input_col_refs(&cond);
+            if cond_bitset.is_disjoint(&bitset) {
+                pushed_conditions.push(cond);
+            } else {
+                remaining_conditions.push(cond);
+            }
+        }
+
+        if pushed_conditions.is_empty() {
+            return Ok(plan.clone());
+        }
+
+        let input_ref_rewriter = InputRefRewriter {
+            input_refs: agg.group_keys(),
+        };
+
+        // rewrite the expression bindings
+        for condition in &mut pushed_conditions {
+            input_ref_rewriter.rewrite_expr(condition);
+        }
+
+        let pushed_cond = merge_conjunctions(pushed_conditions.into_iter());
+
+        let agg_input = agg.child();
+        let pushed_filter = Arc::new(LogicalFilter::new(pushed_cond, agg_input));
+        let agg = Arc::new(agg.clone_with_child(pushed_filter));
+
+        if remaining_conditions.is_empty() {
+            return Ok(agg);
+        }
+
+        let remaining_filter = merge_conjunctions(remaining_conditions.into_iter());
+        Ok(Arc::new(LogicalFilter::new(remaining_filter, agg)))
+    }
+}
+
+struct InputRefRewriter<'a> {
+    input_refs: &'a [BoundExpr],
+}
+
+impl<'a> ExprRewriter for InputRefRewriter<'a> {
+    fn rewrite_input_ref(&self, expr: &mut BoundExpr) {
+        match expr {
+            BoundExpr::InputRef(bref) => {
+                *expr = self.input_refs[bref.index].clone();
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/optimizer/rules/mod.rs
+++ b/src/optimizer/rules/mod.rs
@@ -2,9 +2,11 @@
 
 use super::plan_nodes::PlanRef;
 
+mod filter_agg_rule;
 mod filter_join_rule;
 mod filter_scan_rule;
 mod limit_order_rule;
+pub use filter_agg_rule::*;
 pub use filter_join_rule::*;
 pub use filter_scan_rule::*;
 pub use limit_order_rule::*;


### PR DESCRIPTION
Signed-off-by: lokax <m632656684@gmail.com>

**Support push the filter down below the agg**
**Before:**
```text
> explain select count(x), y + 1 from test group by y + 1 having count(x) > 1 and y + 1 = 2;
PhysicalProjection:
    InputRef #1
    InputRef #0
  PhysicalFilter: expr And(Gt(InputRef #1, Int32(1) (const)), Eq(InputRef #0, Int32(2) (const)))
    PhysicalHashAgg:
        (InputRef #1 + 1)
        count(InputRef #0) -> INT
      PhysicalTableScan:
          table #13,
          columns [0, 1],
          with_row_handler: false,
          is_sorted: false,
          expr: None
``` 
**After:**
```text
> explain select count(x), y + 1 from test group by y + 1 having count(x) > 1 and y + 1 = 2;
PhysicalProjection:
    InputRef #1
    InputRef #0
  PhysicalFilter: expr Gt(InputRef #1, Int32(1) (const))
    PhysicalHashAgg:
        (InputRef #1 + 1)
        count(InputRef #0) -> INT
      PhysicalTableScan:
          table #13,
          columns [0, 1],
          with_row_handler: false,
          is_sorted: false,
          expr: Eq(Plus(InputRef #1, Int32(1) (const)), Int32(2) (const))
```