### PR TITLE
feat(Optimizer): eliminate common sub-expressions

### DIFF
--- a/src/optimizer/mod.rs
+++ b/src/optimizer/mod.rs
@@ -48,6 +48,14 @@ impl Optimizer {
         }
         let hep_optimizer = HeuristicOptimizer { rules };
         plan = hep_optimizer.optimize(plan);
+
+        let rules: Vec<Box<(dyn rules::Rule + 'static)>> = vec![
+            Box::new(ProjectEliminateCSE {}),
+            Box::new(AggregateEliminateCSE {}),
+        ];
+        let hep_optimizer = HeuristicOptimizer { rules };
+        plan = hep_optimizer.optimize(plan);
+
         let out_types_num = plan.out_types().len();
         plan = plan.prune_col(BitSet::from_iter(0..out_types_num));
         let mut phy_converter = PhysicalConverter;

--- a/src/optimizer/plan_nodes/logical_projection.rs
+++ b/src/optimizer/plan_nodes/logical_projection.rs
@@ -37,17 +37,6 @@ impl ExprRewriter for Substitute {
 
 impl LogicalProjection {
     pub fn new(project_expressions: Vec<BoundExpr>, child: PlanRef) -> Self {
-        if let Ok(child) = child.as_logical_projection() {
-            let subst = Substitute {
-                mapping: child.project_expressions.clone(),
-            };
-            let mut exprs = project_expressions;
-            exprs.iter_mut().for_each(|expr| subst.rewrite_expr(expr));
-            return LogicalProjection {
-                project_expressions: exprs,
-                child: child.child.clone(),
-            };
-        }
         Self {
             project_expressions,
             child,

--- a/src/optimizer/plan_nodes/logical_projection.rs
+++ b/src/optimizer/plan_nodes/logical_projection.rs
@@ -162,56 +162,6 @@ mod tests {
     }
 
     #[test]
-    fn test_nested_projection() {
-        let inner = LogicalProjection::new(
-            vec![
-                BoundExpr::ColumnRef(BoundColumnRef {
-                    column_ref_id: ColumnRefId::new(0, 0, 0, 0),
-                    is_primary_key: false,
-                    desc: DataTypeKind::Int(None).not_null().to_column("v1".into()),
-                }),
-                BoundExpr::TypeCast(BoundTypeCast {
-                    expr: Box::new(BoundExpr::Constant(DataValue::Int32(0))),
-                    ty: DataTypeKind::Int(None),
-                }),
-                BoundExpr::ExprWithAlias(BoundExprWithAlias {
-                    expr: Box::new(BoundExpr::Constant(DataValue::Int32(0))),
-                    alias: "alias".to_string(),
-                }),
-                BoundExpr::Constant(DataValue::Int32(0)),
-            ],
-            Arc::new(Dummy::new(Vec::new())),
-        );
-
-        let outer = LogicalProjection::new(
-            vec![
-                BoundExpr::InputRef(BoundInputRef {
-                    index: 0,
-                    return_type: DataTypeKind::Int(None).not_null(),
-                }),
-                BoundExpr::Constant(DataValue::Int32(0)),
-            ],
-            Arc::new(inner),
-        );
-
-        let column_names = outer.out_names();
-        assert_eq!(column_names[0], "v1");
-        assert_eq!(column_names[1], "?column?");
-        assert!(outer.child.as_dummy().is_ok());
-
-        let outermost = LogicalProjection::new(
-            vec![BoundExpr::InputRef(BoundInputRef {
-                index: 0,
-                return_type: DataTypeKind::Int(None).not_null(),
-            })],
-            Arc::new(outer),
-        );
-
-        assert_eq!(outermost.out_names()[0], "v1");
-        assert!(outermost.child.as_dummy().is_ok());
-    }
-
-    #[test]
     fn test_prune_projection() {
         let ty = DataTypeKind::Int(None).not_null();
         let col_descs = vec![

--- a/src/optimizer/rules/eliminate_cse_rule.rs
+++ b/src/optimizer/rules/eliminate_cse_rule.rs
@@ -1,0 +1,331 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use sqlparser::ast::BinaryOperator;
+
+use super::*;
+use crate::binder::*;
+use crate::optimizer::plan_nodes::{
+    IntoPlanRef, LogicalAggregate, LogicalProjection, PlanTreeNodeUnary,
+};
+
+pub struct ProjectEliminateCSE {}
+pub struct AggregateEliminateCSE {}
+
+impl Rule for ProjectEliminateCSE {
+    fn apply(&self, plan: PlanRef) -> Result<PlanRef, ()> {
+        let projection = plan.as_logical_projection()?;
+        let mut cse_eliminator = CSEEliminator::new();
+        let mut proj_exprs = projection.project_expressions().to_vec();
+        // Search Phase
+        cse_eliminator.search(proj_exprs.iter());
+
+        if !cse_eliminator.can_collect() {
+            // No common sub-expressions
+            return Ok(plan);
+        }
+
+        // Collect Phase
+        cse_eliminator.collect(proj_exprs.iter());
+
+        // Rewrite Phase
+        cse_eliminator.replace(proj_exprs.iter_mut());
+
+        let child =
+            LogicalProjection::new(cse_eliminator.new_projection_exprs(), projection.child());
+        Ok(LogicalProjection::new(proj_exprs, child.into_plan_ref()).into_plan_ref())
+    }
+}
+
+impl Rule for AggregateEliminateCSE {
+    fn apply(&self, plan: PlanRef) -> Result<PlanRef, ()> {
+        let agg = plan.as_logical_aggregate()?;
+        let mut cse_eliminator = CSEEliminator::new();
+        let mut group_keys = agg.group_keys().to_vec();
+        let mut agg_calls = agg.agg_calls().to_vec();
+        // Search Phase
+        let exprs_iter = group_keys
+            .iter()
+            .chain(agg_calls.iter().flat_map(|calls| calls.args.iter()));
+        cse_eliminator.search(exprs_iter.clone());
+
+        if !cse_eliminator.can_collect() {
+            // No common sub-expressions
+            return Ok(plan);
+        }
+
+        // Collect Phase
+        cse_eliminator.collect(exprs_iter);
+
+        let exprs_iter = group_keys
+            .iter_mut()
+            .chain(agg_calls.iter_mut().flat_map(|calls| calls.args.iter_mut()));
+        cse_eliminator.replace(exprs_iter);
+
+        let child = LogicalProjection::new(cse_eliminator.new_projection_exprs(), agg.child());
+        Ok(LogicalAggregate::new(agg_calls, group_keys, child.into_plan_ref()).into_plan_ref())
+    }
+}
+
+#[derive(PartialEq, Debug)]
+enum EliminatorState {
+    Search,
+    Collect,
+    Replace,
+    End,
+}
+
+struct CSEEliminator {
+    exprs_maps: Vec<BoundExpr>, // TODO: HashMap
+    counts: Vec<(usize, bool)>,
+    new_projection_exprs: Vec<BoundExpr>,
+    state: EliminatorState,
+}
+
+impl CSEEliminator {
+    fn new() -> Self {
+        Self {
+            exprs_maps: vec![],
+            counts: vec![],
+            new_projection_exprs: vec![],
+            state: EliminatorState::Search,
+        }
+    }
+
+    fn find_common_expressions(&mut self, expr: &BoundExpr) {
+        if let Some(idx) = self.exprs_maps.iter().position(|e| e == expr) {
+            self.counts[idx].0 += 1;
+        } else {
+            self.exprs_maps.push(expr.clone());
+            self.counts.push((1, false));
+        }
+    }
+
+    fn collect_new_input_ref_exprs(&mut self, expr: &BoundExpr) {
+        if !self
+            .new_projection_exprs
+            .iter()
+            .any(|proj_expr| proj_expr == expr)
+        {
+            self.new_projection_exprs.push(expr.clone());
+        }
+    }
+
+    fn collect_new_proj_exprs(&mut self, expr: &BoundExpr) -> bool {
+        if let Some(idx) = self
+            .exprs_maps
+            .iter()
+            .position(|proj_expr| proj_expr == expr)
+        {
+            let (count, occupied) = self.counts[idx];
+            if count > 1 && !occupied {
+                self.new_projection_exprs.push(expr.clone());
+                self.counts[idx].1 = true;
+            }
+            return count > 1;
+        }
+        false
+    }
+
+    fn replace_expr(&self, expr: &mut BoundExpr) -> bool {
+        assert_eq!(self.state, EliminatorState::Replace);
+        if let Some(idx) = self
+            .new_projection_exprs
+            .iter()
+            .position(|proj_expr| proj_expr == expr)
+        {
+            *expr = BoundExpr::InputRef(BoundInputRef {
+                index: idx,
+                return_type: expr.return_type().unwrap(),
+            });
+            true
+        } else {
+            false
+        }
+    }
+
+    fn advance_state(&mut self) {
+        match &mut self.state {
+            state @ EliminatorState::Search => {
+                if self.counts.iter().any(|(count, _)| count > &1) {
+                    *state = EliminatorState::Collect;
+                } else {
+                    *state = EliminatorState::End;
+                }
+            }
+            state @ EliminatorState::Collect => *state = EliminatorState::Replace,
+            state @ EliminatorState::Replace => *state = EliminatorState::End,
+            _ => unreachable!(),
+        }
+    }
+
+    fn new_projection_exprs(&mut self) -> Vec<BoundExpr> {
+        assert_eq!(self.state, EliminatorState::End);
+        std::mem::take(&mut self.new_projection_exprs)
+    }
+
+    fn can_collect(&self) -> bool {
+        self.state == EliminatorState::Collect
+    }
+
+    // Search and extract common sub-expressions
+    fn search<'a>(&mut self, exprs: impl Iterator<Item = &'a BoundExpr>) {
+        assert_eq!(self.state, EliminatorState::Search);
+        exprs.for_each(|expr| self.visit_expr(expr));
+        self.advance_state();
+    }
+
+    // Collect new projection expressions for child projection operator
+    fn collect<'a>(&mut self, exprs: impl Iterator<Item = &'a BoundExpr>) {
+        assert_eq!(self.state, EliminatorState::Collect);
+        assert!(self.can_collect());
+        exprs.for_each(|expr| self.visit_expr(expr));
+        self.advance_state();
+    }
+    // Rewrite current operator's expressions
+    fn replace<'a>(&mut self, exprs: impl Iterator<Item = &'a mut BoundExpr>) {
+        assert_eq!(self.state, EliminatorState::Replace);
+        exprs.for_each(|expr| self.rewrite_expr(expr));
+        self.advance_state();
+    }
+}
+
+impl ExprVisitor for CSEEliminator {
+    fn visit_input_ref(&mut self, expr: &BoundInputRef) {
+        if let EliminatorState::Collect = self.state {
+            self.collect_new_input_ref_exprs(&BoundExpr::InputRef(expr.clone()))
+        }
+    }
+
+    fn visit_binary_op(&mut self, expr: &BoundBinaryOp) {
+        match expr.op {
+            // Keep short-circuit to avoid unnecessary calculations
+            BinaryOperator::And | BinaryOperator::Or => {
+                if let EliminatorState::Search = self.state {
+                    self.visit_expr(expr.left_expr.as_ref());
+                    return;
+                }
+            }
+            _ => (),
+        }
+
+        match self.state {
+            EliminatorState::Search => {
+                self.find_common_expressions(&BoundExpr::BinaryOp(expr.clone()))
+            }
+            EliminatorState::Collect => {
+                if self.collect_new_proj_exprs(&BoundExpr::BinaryOp(expr.clone())) {
+                    return;
+                }
+            }
+            _ => (),
+        }
+
+        self.visit_expr(expr.left_expr.as_ref());
+        self.visit_expr(expr.right_expr.as_ref());
+    }
+
+    fn visit_unary_op(&mut self, expr: &BoundUnaryOp) {
+        match self.state {
+            EliminatorState::Search => {
+                self.find_common_expressions(&BoundExpr::UnaryOp(expr.clone()))
+            }
+            EliminatorState::Collect => {
+                if self.collect_new_proj_exprs(&BoundExpr::UnaryOp(expr.clone())) {
+                    return;
+                }
+            }
+            _ => (),
+        }
+        self.visit_expr(expr.expr.as_ref());
+    }
+
+    fn visit_type_cast(&mut self, expr: &BoundTypeCast) {
+        match self.state {
+            EliminatorState::Search => {
+                self.find_common_expressions(&BoundExpr::TypeCast(expr.clone()))
+            }
+            EliminatorState::Collect => {
+                if self.collect_new_proj_exprs(&BoundExpr::TypeCast(expr.clone())) {
+                    return;
+                }
+            }
+            _ => (),
+        }
+        self.visit_expr(expr.expr.as_ref());
+    }
+
+    fn visit_is_null(&mut self, expr: &BoundIsNull) {
+        match self.state {
+            EliminatorState::Search => {
+                self.find_common_expressions(&BoundExpr::IsNull(expr.clone()))
+            }
+            EliminatorState::Collect => {
+                if self.collect_new_proj_exprs(&BoundExpr::IsNull(expr.clone())) {
+                    return;
+                }
+            }
+            _ => (),
+        }
+        self.visit_expr(expr.expr.as_ref());
+    }
+}
+
+impl ExprRewriter for CSEEliminator {
+    fn rewrite_input_ref(&self, expr: &mut BoundExpr) {
+        match expr {
+            BoundExpr::InputRef(_) => {
+                self.replace_expr(expr);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_binary_op(&self, expr: &mut BoundExpr) {
+        if self.replace_expr(expr) {
+            return;
+        }
+        match expr {
+            BoundExpr::BinaryOp(e) => {
+                self.rewrite_expr(e.left_expr.as_mut());
+                self.rewrite_expr(e.right_expr.as_mut());
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_unary_op(&self, expr: &mut BoundExpr) {
+        if self.replace_expr(expr) {
+            return;
+        }
+        match expr {
+            BoundExpr::UnaryOp(e) => {
+                self.rewrite_expr(e.expr.as_mut());
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_type_cast(&self, expr: &mut BoundExpr) {
+        if self.replace_expr(expr) {
+            return;
+        }
+        match expr {
+            BoundExpr::TypeCast(e) => {
+                self.rewrite_expr(e.expr.as_mut());
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn rewrite_is_null(&self, expr: &mut BoundExpr) {
+        if self.replace_expr(expr) {
+            return;
+        }
+        match expr {
+            BoundExpr::IsNull(e) => {
+                self.rewrite_expr(e.expr.as_mut());
+            }
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/optimizer/rules/mod.rs
+++ b/src/optimizer/rules/mod.rs
@@ -2,10 +2,12 @@
 
 use super::plan_nodes::PlanRef;
 
+mod eliminate_cse_rule;
 mod filter_agg_rule;
 mod filter_join_rule;
 mod filter_scan_rule;
 mod limit_order_rule;
+pub use eliminate_cse_rule::*;
 pub use filter_agg_rule::*;
 pub use filter_join_rule::*;
 pub use filter_scan_rule::*;

--- a/tests/planner_test/eliminate_cse.planner.sql
+++ b/tests/planner_test/eliminate_cse.planner.sql
@@ -1,0 +1,92 @@
+-- eliminate cse
+EXPLAIN SELECT count(x + 5), count(x + 5) FROM test;
+
+/*
+PhysicalProjection:
+    InputRef #0
+    InputRef #0
+  PhysicalSimpleAgg:
+      count(InputRef #0) -> INT
+    PhysicalProjection:
+        (InputRef #0 + 5)
+      PhysicalTableScan:
+          table #0,
+          columns [0],
+          with_row_handler: false,
+          is_sorted: false,
+          expr: None
+*/
+
+-- eliminate cse
+EXPLAIN SELECT x + y + 5, x + y, x + y + 5 FROM test;
+
+/*
+PhysicalProjection:
+    InputRef #0
+    InputRef #1
+    InputRef #0
+  PhysicalProjection:
+      (InputRef #0 + 5)
+      InputRef #0
+    PhysicalProjection:
+        (InputRef #0 + InputRef #1)
+      PhysicalTableScan:
+          table #0,
+          columns [0, 1],
+          with_row_handler: false,
+          is_sorted: false,
+          expr: None
+*/
+
+-- eliminate cse
+EXPLAIN SELECT x + 5 < y, x + 5 FROM test;
+
+/*
+PhysicalProjection:
+    (InputRef #0 < InputRef #1)
+    InputRef #0
+  PhysicalProjection:
+      (InputRef #0 + 5)
+      InputRef #1
+    PhysicalTableScan:
+        table #0,
+        columns [0, 1],
+        with_row_handler: false,
+        is_sorted: false,
+        expr: None
+*/
+
+-- keep short circuit
+EXPLAIN SELECT x + 5 < y AND x + y < 3, x + y FROM test;
+
+/*
+PhysicalProjection:
+    (((InputRef #0 + 5) < InputRef #1) AND ((InputRef #0 + InputRef #1) < 3))
+    (InputRef #0 + InputRef #1)
+  PhysicalTableScan:
+      table #0,
+      columns [0, 1],
+      with_row_handler: false,
+      is_sorted: false,
+      expr: None
+*/
+
+-- eliminate cse
+EXPLAIN SELECT x + y < 3 AND x + 5 < y, x + y FROM test;
+
+/*
+PhysicalProjection:
+    ((InputRef #0 < 3) AND ((InputRef #1 + 5) < InputRef #2))
+    InputRef #0
+  PhysicalProjection:
+      (InputRef #0 + InputRef #1)
+      InputRef #0
+      InputRef #1
+    PhysicalTableScan:
+        table #0,
+        columns [0, 1],
+        with_row_handler: false,
+        is_sorted: false,
+        expr: None
+*/
+

--- a/tests/planner_test/eliminate_cse.yml
+++ b/tests/planner_test/eliminate_cse.yml
@@ -1,0 +1,39 @@
+- sql: |
+    EXPLAIN SELECT count(x + 5), count(x + 5) FROM test;
+  desc: eliminate cse
+  before:
+    - create table test(x int)
+  tasks:
+    - print
+
+- sql: |
+    EXPLAIN SELECT x + y + 5, x + y, x + y + 5 FROM test;
+  desc: eliminate cse
+  before:
+    - create table test(x int, y INT)
+  tasks:
+    - print
+
+- sql: |
+    EXPLAIN SELECT x + 5 < y, x + 5 FROM test;
+  desc: eliminate cse
+  before:
+    - create table test(x int, y INT)
+  tasks:
+    - print
+
+- sql: |
+    EXPLAIN SELECT x + 5 < y AND x + y < 3, x + y FROM test;
+  desc: keep short circuit
+  before:
+    - create table test(x int, y INT)
+  tasks:
+    - print
+
+- sql: |
+    EXPLAIN SELECT x + y < 3 AND x + 5 < y, x + y FROM test;
+  desc: eliminate cse
+  before:
+    - create table test(x int, y INT)
+  tasks:
+    - print

--- a/tests/planner_test/tpch.planner.sql
+++ b/tests/planner_test/tpch.planner.sql
@@ -126,23 +126,32 @@ PhysicalOrder:
       (InputRef #8 / InputRef #9) (alias to avg_disc)
       InputRef #10 (alias to count_order)
     PhysicalHashAgg:
+        InputRef #0
         InputRef #1
-        InputRef #2
+        sum(InputRef #2) -> NUMERIC(15,2)
         sum(InputRef #3) -> NUMERIC(15,2)
-        sum(InputRef #4) -> NUMERIC(15,2)
-        sum((InputRef #4 * (1 - InputRef #5))) -> NUMERIC(15,2) (null)
-        sum(((InputRef #4 * (1 - InputRef #5)) * (1 + InputRef #6))) -> NUMERIC(15,2) (null)
+        sum(InputRef #4) -> NUMERIC(15,2) (null)
+        sum((InputRef #4 * (1 + InputRef #5))) -> NUMERIC(15,2) (null)
+        count(InputRef #2) -> INT
         count(InputRef #3) -> INT
-        count(InputRef #4) -> INT
-        sum(InputRef #5) -> NUMERIC(15,2)
-        count(InputRef #5) -> INT
-        count(InputRef #0) -> INT
-      PhysicalTableScan:
-          table #7,
-          columns [10, 8, 9, 4, 5, 6, 7],
-          with_row_handler: false,
-          is_sorted: false,
-          expr: LtEq(InputRef #0, Date(Date(10490)) (const))
+        sum(InputRef #6) -> NUMERIC(15,2)
+        count(InputRef #6) -> INT
+        count(InputRef #7) -> INT
+      PhysicalProjection:
+          InputRef #1
+          InputRef #2
+          InputRef #3
+          InputRef #4
+          (InputRef #4 * (1 - InputRef #5))
+          InputRef #6
+          InputRef #5
+          InputRef #0
+        PhysicalTableScan:
+            table #7,
+            columns [10, 8, 9, 4, 5, 6, 7],
+            with_row_handler: false,
+            is_sorted: false,
+            expr: LtEq(InputRef #0, Date(Date(10490)) (const))
 */
 
 -- tpch-q3: TPC-H Q3


### PR DESCRIPTION
Signed-off-by: lokax <m632656684@gmail.com>

Implement this feature #658  for projection and aggregate.

I removed  projection merge rule in LogicalProjection::new(), because  we will need a projection below the current projection in some case.

like this:
```sql
> explain select l_extendedprice * (1 - l_discount), l_extendedprice * (1 - l_discount) * (1 + l_tax) from lineitem;
PhysicalProjection:
    InputRef #0
    (InputRef #0 * (1 + InputRef #1))
  PhysicalProjection:
      (InputRef #0 * (1 - InputRef #1))
      InputRef #2
    PhysicalTableScan:
        table #64,
        columns [5, 6, 7],
        with_row_handler: false,
        is_sorted: false,
        expr: None
```

In the above example, it will evaluate `(1 - l_discount)` 2 times and `l_extendedprice * A` 2 times before optimization. This would not be a problem as long as the expression itself is not expensive. However,  evaluating a expensive scalar function multiple times could incur a performance overhead. After optimization, common sub-expressions are evaluated only once.


