### PR TITLE
fix: 'unsupported command' everywhere

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,12 @@ fn read_sql(rl: &mut Editor<()>) -> Result<String, ReadlineError> {
         if line.is_empty() {
             continue;
         }
+
+        // internal commands starts with "\"
+        if line.starts_with('\\') && sql.is_empty() {
+            return Ok(line);
+        }
+
         sql.push_str(line.as_str());
         if line.ends_with(';') {
             return Ok(sql);


### PR DESCRIPTION
Signed-off-by: cadl <ctrlaltdeleteliu@gmail.com>

After #662, the internal command does not work. Make some fixes.

before:
```
> \dt
? ;
Internal error: unsupported command
> \dt;
Internal error: unsupported command
>
```

after:
```
> \dt
+---+----------+---+------------+---+--------------+
| 0 | postgres | 1 | pg_catalog | 0 | contributors |
+---+----------+---+------------+---+--------------+
in 0.001s
> select * from foo;
bind error: invalid table foo
> select *
? from foo;
bind error: invalid table foo
```