### PR TITLE
feat(storage): use variable size encoding to compress rle count

### DIFF
--- a/src/storage/secondary/block/rle_block_builder.rs
+++ b/src/storage/secondary/block/rle_block_builder.rs
@@ -59,19 +59,19 @@ pub fn decode_u32_slice(bytes: &[u8]) -> Result<(u32, usize), DecodeError> {
     b = unsafe { *bytes.get_unchecked(1) };
     part0 += u32::from(b) << 7;
     if b < 0x80 {
-        return Ok((u32::from(part0), 2));
+        return Ok((part0, 2));
     };
     part0 -= 0x80 << 7;
     b = unsafe { *bytes.get_unchecked(2) };
     part0 += u32::from(b) << 14;
     if b < 0x80 {
-        return Ok((u32::from(part0), 3));
+        return Ok((part0, 3));
     };
     part0 -= 0x80 << 14;
     b = unsafe { *bytes.get_unchecked(3) };
     part0 += u32::from(b) << 21;
     if b < 0x80 {
-        return Ok((u32::from(part0), 4));
+        return Ok((part0, 4));
     };
     part0 -= 0x80 << 21;
     b = unsafe { *bytes.get_unchecked(4) };

--- a/src/storage/secondary/block/rle_block_builder.rs
+++ b/src/storage/secondary/block/rle_block_builder.rs
@@ -104,7 +104,7 @@ impl<A, B> RleBlockBuilder<A, B>
 where
     A: Array,
     B: BlockBuilder<A>,
-    A::Item: PartialEq, // 可以实现== 比较
+    A::Item: PartialEq, 
 {
     pub fn new(block_builder: B) -> Self {
         Self {
@@ -130,8 +130,6 @@ where
             self.cur_count = 1;
             return;
         }
-        // x.to_owned() ==> borrow -> owned
-        // .as_ref() ===>
         if item != self.previous_value.as_ref().map(|x| x.borrow()) || self.cur_count == u32::MAX {
             self.previous_value = item.map(|x| x.to_owned());
             self.block_builder.append(item);

--- a/src/storage/secondary/block/rle_block_builder.rs
+++ b/src/storage/secondary/block/rle_block_builder.rs
@@ -9,6 +9,7 @@ use risinglight_proto::rowset::BlockStatistics;
 use super::BlockBuilder;
 use crate::array::Array;
 
+// Copyright 2022 tokio. Licensed under Apache-2.0
 /// encode u32 to multiple u8
 pub fn encode_32<B>(mut value: u32, buf: &mut B)
 where
@@ -81,11 +82,12 @@ pub fn decode_u32_slice(bytes: &[u8]) -> Result<(u32, usize), DecodeError> {
     };
     Err(DecodeError::new("invalid varint"))
 }
+// Copyright 2022 tokio. Licensed under Apache-2.0
 
 /// Encodes fixed-width data into a block with run-length encoding. The layout is
 /// rle counts and data from other block builder
 /// ```plain
-/// | rle_counts_num (u32) | rle_count (u16) | rle_count | data | data | (may be bit) |
+/// | rle_counts_num (u32) | rle_block_length (u32) | rle_count(u32) | rle_count | data | data | (may be bit) |
 /// ```
 pub struct RleBlockBuilder<A, B>
 where

--- a/src/storage/secondary/block/rle_block_builder.rs
+++ b/src/storage/secondary/block/rle_block_builder.rs
@@ -2,17 +2,92 @@
 
 use std::borrow::Borrow;
 
-use bytes::BufMut;
+use bytes::{Buf, BufMut};
+use prost::DecodeError;
 use risinglight_proto::rowset::BlockStatistics;
 
 use super::BlockBuilder;
 use crate::array::Array;
+
+fn encode_32<B>(mut value: u32, buf: &mut B)
+where
+    B: BufMut,
+{
+    loop {
+        if value < 0x80 {
+            buf.put_u8(value as u8);
+            break;
+        } else {
+            buf.put_u8(((value & 0x7F) | 0x80) as u8);
+            value >>= 7;
+        }
+    }
+}
+
+fn decode_u32<B>(buf: &mut B) -> Result<Vec<u32>, DecodeError>
+where
+    B: Buf,
+{
+    // &mut
+    let mut bytes = buf.chunk();
+    let len = bytes.len();
+    if len == 0 {
+        return Err(DecodeError::new("invalid varint"));
+    }
+    let mut ret: Vec<u32> = Vec::new();
+    let mut tot = 0;
+    while tot < len {
+        let (value, advance) = decode_u32_slice(bytes)?;
+        ret.push(value);
+        bytes.advance(advance);
+        tot += advance;
+    }
+    Ok(ret)
+}
+
+// 使用inline加速, 注意一个mut 引用可以调用一个非mut引用的函数
+#[inline]
+fn decode_u32_slice(bytes: &[u8]) -> Result<(u32, usize), DecodeError> {
+    assert!(!bytes.is_empty());
+    let mut b: u8 = unsafe { *bytes.get_unchecked(0) };
+    // u32 最多是5位
+    let mut part0: u32 = u32::from(b);
+    if b < 0x80 {
+        return Ok((u32::from(part0), 1));
+    };
+    part0 -= 0x80;
+    b = unsafe { *bytes.get_unchecked(1) };
+    part0 += u32::from(b) << 7;
+    if b < 0x80 {
+        return Ok((u32::from(part0), 2));
+    };
+    part0 -= 0x80 << 7;
+    b = unsafe { *bytes.get_unchecked(2) };
+    part0 += u32::from(b) << 14;
+    if b < 0x80 {
+        return Ok((u32::from(part0), 3));
+    };
+    part0 -= 0x80 << 14;
+    b = unsafe { *bytes.get_unchecked(3) };
+    part0 += u32::from(b) << 21;
+    if b < 0x80 {
+        return Ok((u32::from(part0), 4));
+    };
+    part0 -= 0x80 << 21;
+    b = unsafe { *bytes.get_unchecked(4) };
+    if b < 0x0f {
+        // or it will overflow
+        return Ok((part0 + (u32::from(b) << 28), 5));
+    };
+    Err(DecodeError::new("invalid varint"))
+}
 
 /// Encodes fixed-width data into a block with run-length encoding. The layout is
 /// rle counts and data from other block builder
 /// ```plain
 /// | rle_counts_num (u32) | rle_count (u16) | rle_count | data | data | (may be bit) |
 /// ```
+// rle == run-length encoding
 pub struct RleBlockBuilder<A, B>
 where
     A: Array,
@@ -20,16 +95,19 @@ where
     A::Item: PartialEq,
 {
     block_builder: B,
-    rle_counts: Vec<u16>,
+    // 其实要求的就是把rle_count压缩
+    rle_counts: Vec<u32>,
+    // rle_counts
     previous_value: Option<<A::Item as ToOwned>::Owned>,
-    cur_count: u16,
+    // previous_value A::Item
+    cur_count: u32,
 }
 
 impl<A, B> RleBlockBuilder<A, B>
 where
     A: Array,
     B: BlockBuilder<A>,
-    A::Item: PartialEq,
+    A::Item: PartialEq, // 可以实现== 比较
 {
     pub fn new(block_builder: B) -> Self {
         Self {
@@ -55,7 +133,16 @@ where
             self.cur_count = 1;
             return;
         }
-        if item != self.previous_value.as_ref().map(|x| x.borrow()) || self.cur_count == u16::MAX {
+        // x.to_owned() ==> create owned data from borrowed data, usually by cloning
+        // as_ref() ==> converts from &Option<T> to Option<&T>
+
+        // 我们可以这样理解, rust里面的reference 相当于是一个指针，也是一个类型, 所以其实也可以
+        // 视作有所有权
+        // 注意rust里面有四个概念需要区分一下
+        // map因为调用的参数是self, 所以会消耗自己
+        // 使用as_ref可以在不消耗自己的
+        // u32::MAX
+        if item != self.previous_value.as_ref().map(|x| x.borrow()) || self.cur_count == u32::MAX {
             self.previous_value = item.map(|x| x.to_owned());
             self.block_builder.append(item);
             self.rle_counts.push(self.cur_count);
@@ -87,9 +174,13 @@ where
             return encoded_data;
         }
         self.rle_counts.push(self.cur_count);
+
+        // 几个关键点, as 关键字可以实现类型强转
         encoded_data.put_u32_le(self.rle_counts.len() as u32);
+
+        // 关键在于count这个地方可以改成把每一个count 通过variable encoding
         for count in self.rle_counts {
-            encoded_data.put_u16_le(count);
+            encode_32(count, &mut encoded_data);
         }
         let data = self.block_builder.finish();
         encoded_data.extend(data);

--- a/src/storage/secondary/block/rle_block_iterator.rs
+++ b/src/storage/secondary/block/rle_block_iterator.rs
@@ -61,7 +61,7 @@ where
         let mut slice = &rle_block[..];
         let rle_block = decode_u32(&mut slice).unwrap();
         let mut row_count: usize = 0;
-        for count in rle_block.iter() {
+        for count in &rle_block {
             row_count += *count as usize;
         }
 
@@ -79,8 +79,7 @@ where
     }
 
     fn get_cur_rle_count(&mut self) -> u32 {
-        let cur_rle_count = self.rle_block[self.cur_row];
-        cur_rle_count
+        self.rle_block[self.cur_row]
     }
 
     fn get_next_element(&mut self) -> Option<Option<<A::Item as ToOwned>::Owned>> {

--- a/src/storage/secondary/block/rle_block_iterator.rs
+++ b/src/storage/secondary/block/rle_block_iterator.rs
@@ -9,7 +9,6 @@ use crate::array::{Array, ArrayBuilder};
 use crate::storage::secondary::block::{decode_u32, decode_u32_slice};
 pub fn decode_rle_block(data: Block) -> (usize, Block, Block) {
     let mut buffer = &data[..];
-    // 重新创建了一个对于data的引用
     let rle_num = buffer.get_u32_le() as usize;
     let rle_length = std::mem::size_of::<u32>() * 2 + buffer.get_u32_le() as usize;
     let rle_data = data.slice(std::mem::size_of::<u32>() * 2..rle_length);


### PR DESCRIPTION
Signed-off-by: xinchengforgit 2419743144@qq.com

This PR try to solve #531.
I have some basic thoughts about variable size encoding, but there are some tests that I don't know how to modify, please give me some suggestions.

I use variable size encoding, and replace the u16 with u32, so that we can support a larger range number while saving the used space.