### PR TITLE
feat: introduce ordered float

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
+name = "ordered-float"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129d36517b53c461acc6e1580aeb919c8ae6708a4b1eae61c4463a615d4f0411"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +1737,7 @@ dependencies = [
  "minitrace",
  "moka",
  "num-traits",
+ "ordered-float",
  "parking_lot 0.12.1",
  "paste",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ manifest-dir-macros = "0.1.11"
 minitrace = "0.4.0"
 moka = { version = "0.9", features = ["future"] }
 num-traits = "0.2"
+ordered-float = { version = "3", features = ["serde"] }
 parking_lot = "0.12"
 paste = "1"
 prost = "0.11.0"

--- a/src/array/data_chunk.rs
+++ b/src/array/data_chunk.rs
@@ -10,7 +10,7 @@ use crate::types::DataValue;
 /// A collection of arrays.
 ///
 /// A data chunk is a horizontal subset of a query result.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DataChunk {
     arrays: Arc<[ArrayImpl]>,
 }
@@ -131,7 +131,7 @@ impl fmt::Debug for DataChunk {
 }
 
 /// A chunk is a wrapper sturct for many data chunks.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Chunk {
     data_chunks: Vec<DataChunk>,
     header: Option<Vec<String>>,

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -11,7 +11,7 @@ use rust_decimal::prelude::FromStr;
 use rust_decimal::Decimal;
 
 use crate::types::{
-    Blob, ConvertError, DataType, DataValue, Date, Interval, PhysicalDataTypeKind, F64,
+    Blob, ConvertError, DataType, DataValue, Date, Interval, PhysicalDataTypeKind, F32, F64,
 };
 
 mod data_chunk;
@@ -157,6 +157,7 @@ impl<A: Array> ArrayExt for A {
 pub type BoolArray = PrimitiveArray<bool>;
 pub type I32Array = PrimitiveArray<i32>;
 pub type I64Array = PrimitiveArray<i64>;
+pub type F32Array = PrimitiveArray<F32>;
 pub type F64Array = PrimitiveArray<F64>;
 pub type DecimalArray = PrimitiveArray<Decimal>;
 pub type DateArray = PrimitiveArray<Date>;
@@ -181,6 +182,7 @@ pub enum ArrayImpl {
 pub type BoolArrayBuilder = PrimitiveArrayBuilder<bool>;
 pub type I32ArrayBuilder = PrimitiveArrayBuilder<i32>;
 pub type I64ArrayBuilder = PrimitiveArrayBuilder<i64>;
+pub type F32ArrayBuilder = PrimitiveArrayBuilder<F32>;
 pub type F64ArrayBuilder = PrimitiveArrayBuilder<F64>;
 pub type DecimalArrayBuilder = PrimitiveArrayBuilder<Decimal>;
 pub type DateArrayBuilder = PrimitiveArrayBuilder<Date>;

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -10,7 +10,9 @@ use paste::paste;
 use rust_decimal::prelude::FromStr;
 use rust_decimal::Decimal;
 
-use crate::types::{Blob, ConvertError, DataType, DataValue, Date, Interval, PhysicalDataTypeKind};
+use crate::types::{
+    Blob, ConvertError, DataType, DataValue, Date, Interval, PhysicalDataTypeKind, F64,
+};
 
 mod data_chunk;
 mod data_chunk_builder;
@@ -155,13 +157,13 @@ impl<A: Array> ArrayExt for A {
 pub type BoolArray = PrimitiveArray<bool>;
 pub type I32Array = PrimitiveArray<i32>;
 pub type I64Array = PrimitiveArray<i64>;
-pub type F64Array = PrimitiveArray<f64>;
+pub type F64Array = PrimitiveArray<F64>;
 pub type DecimalArray = PrimitiveArray<Decimal>;
 pub type DateArray = PrimitiveArray<Date>;
 pub type IntervalArray = PrimitiveArray<Interval>;
 
 /// Embeds all types of arrays in `array` module.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum ArrayImpl {
     Bool(Arc<BoolArray>),
     // Int16(PrimitiveArray<i16>),
@@ -179,7 +181,7 @@ pub enum ArrayImpl {
 pub type BoolArrayBuilder = PrimitiveArrayBuilder<bool>;
 pub type I32ArrayBuilder = PrimitiveArrayBuilder<i32>;
 pub type I64ArrayBuilder = PrimitiveArrayBuilder<i64>;
-pub type F64ArrayBuilder = PrimitiveArrayBuilder<f64>;
+pub type F64ArrayBuilder = PrimitiveArrayBuilder<F64>;
 pub type DecimalArrayBuilder = PrimitiveArrayBuilder<Decimal>;
 pub type DateArrayBuilder = PrimitiveArrayBuilder<Date>;
 pub type IntervalArrayBuilder = PrimitiveArrayBuilder<Interval>;
@@ -411,7 +413,7 @@ impl ArrayBuilderImpl {
                     .map_err(|e| ConvertError::ParseInt(s.to_string(), e))?,
             )),
             Self::Float64(a) => a.push(Some(
-                &s.parse::<f64>()
+                &s.parse::<F64>()
                     .map_err(|e| ConvertError::ParseFloat(s.to_string(), e))?,
             )),
             Self::Utf8(a) => a.push(Some(s)),

--- a/src/array/primitive_array.rs
+++ b/src/array/primitive_array.rs
@@ -7,7 +7,7 @@ use bitvec::vec::BitVec;
 use serde::{Deserialize, Serialize};
 
 use super::{Array, ArrayBuilder, ArrayEstimateExt, ArrayFromDataExt, ArrayValidExt};
-use crate::types::NativeType;
+use crate::types::{NativeType, F32, F64};
 
 mod simd;
 pub use self::simd::*;
@@ -35,6 +35,28 @@ impl<T: NativeType> FromIterator<Option<T>> for PrimitiveArray<T> {
 impl<T: NativeType> FromIterator<T> for PrimitiveArray<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let data: Vec<T> = iter.into_iter().collect();
+        let size = data.len();
+        Self {
+            data,
+            valid: BitVec::repeat(true, size),
+        }
+    }
+}
+
+impl FromIterator<f32> for PrimitiveArray<F32> {
+    fn from_iter<I: IntoIterator<Item = f32>>(iter: I) -> Self {
+        let data: Vec<F32> = iter.into_iter().map(F32::from).collect();
+        let size = data.len();
+        Self {
+            data,
+            valid: BitVec::repeat(true, size),
+        }
+    }
+}
+
+impl FromIterator<f64> for PrimitiveArray<F64> {
+    fn from_iter<I: IntoIterator<Item = f64>>(iter: I) -> Self {
+        let data: Vec<F64> = iter.into_iter().map(F64::from).collect();
         let size = data.len();
         Self {
             data,

--- a/src/array/primitive_array.rs
+++ b/src/array/primitive_array.rs
@@ -12,8 +12,8 @@ use crate::types::NativeType;
 mod simd;
 pub use self::simd::*;
 
-/// A collection of primitive types, such as `i32`, `f32`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// A collection of primitive types, such as `i32`, `F32`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PrimitiveArray<T: NativeType> {
     valid: BitVec,
     data: Vec<T>,
@@ -125,6 +125,7 @@ mod tests {
     use rust_decimal::Decimal;
 
     use super::*;
+    use crate::types::{F32, F64};
 
     fn test_builder<T: FromPrimitive + NativeType>() {
         let iter = (0..1000).map(|x| if x % 2 == 0 { None } else { T::from_usize(x) });
@@ -152,12 +153,12 @@ mod tests {
 
     #[test]
     fn test_builder_f32() {
-        test_builder::<f32>();
+        test_builder::<F32>();
     }
 
     #[test]
     fn test_builder_f64() {
-        test_builder::<f64>();
+        test_builder::<F64>();
     }
 
     #[test]

--- a/src/array/primitive_array/simd.rs
+++ b/src/array/primitive_array/simd.rs
@@ -1,11 +1,12 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::iter::Sum;
-use std::simd::{LaneCount, Simd, SimdElement, SimdInt, SimdUint, SupportedLaneCount};
+use std::simd::{LaneCount, Simd, SimdElement, SimdFloat, SimdInt, SimdUint, SupportedLaneCount};
 
 use bitvec::prelude::{BitSlice, Lsb0};
 
 use super::*;
+use crate::array::{F32Array, F64Array};
 
 impl<T: NativeType> PrimitiveArray<T> {
     /// Returns a batch iterator for SIMD.
@@ -108,7 +109,39 @@ macro_rules! impl_sum {
         }
     )*}
 }
-impl_sum!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize); // FIXME: add f32, f64
+impl_sum!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64);
+
+impl F32Array {
+    /// Cast the element type to native `f32`.
+    pub fn as_native(&self) -> &PrimitiveArray<f32> {
+        // safety: `f32` and `F32` have the same memory layout.
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl PrimitiveArray<f32> {
+    /// Cast the element type to ordered `F32`.
+    pub fn into_ordered(self) -> F32Array {
+        // safety: `f32` and `F32` have the same memory layout.
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl F64Array {
+    /// Cast the element type to native `f64`.
+    pub fn as_native(&self) -> &PrimitiveArray<f64> {
+        // safety: `f64` and `F64` have the same memory layout.
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl PrimitiveArray<f64> {
+    /// Cast the element type to ordered `F64`.
+    pub fn into_ordered(self) -> F64Array {
+        // safety: `f64` and `F64` have the same memory layout.
+        unsafe { std::mem::transmute(self) }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/array/primitive_array/simd.rs
+++ b/src/array/primitive_array/simd.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::iter::Sum;
-use std::simd::{LaneCount, Simd, SimdElement, SimdFloat, SimdInt, SimdUint, SupportedLaneCount};
+use std::simd::{LaneCount, Simd, SimdElement, SimdInt, SimdUint, SupportedLaneCount};
 
 use bitvec::prelude::{BitSlice, Lsb0};
 
@@ -108,7 +108,7 @@ macro_rules! impl_sum {
         }
     )*}
 }
-impl_sum!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize, f32, f64);
+impl_sum!(i8, i16, i32, i64, isize, u8, u16, u32, u64, usize); // FIXME: add f32, f64
 
 #[cfg(test)]
 mod tests {

--- a/src/array/utf8_array.rs
+++ b/src/array/utf8_array.rs
@@ -11,7 +11,7 @@ use super::{Array, ArrayBuilder, ArrayEstimateExt, ArrayValidExt};
 use crate::types::BlobRef;
 
 /// A collection of variable-length values.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct BytesArray<T: ValueRef + ?Sized> {
     offset: Vec<usize>,
     valid: BitVec,

--- a/src/binder/expression/mod.rs
+++ b/src/binder/expression/mod.rs
@@ -7,7 +7,7 @@ use sqlparser::ast::BinaryOperator;
 use super::*;
 use crate::catalog::ColumnRefId;
 use crate::parser::{DateTimeField, Expr, Function, UnaryOperator, Value};
-use crate::types::{DataType, DataTypeExt, DataTypeKind, DataValue, Interval};
+use crate::types::{DataType, DataTypeExt, DataTypeKind, DataValue, Interval, F64};
 
 mod agg_call;
 mod binary_op;
@@ -271,7 +271,7 @@ impl From<&Value> for DataValue {
                     Self::Int32(int)
                 } else if let Ok(bigint) = n.parse::<i64>() {
                     Self::Int64(bigint)
-                } else if let Ok(float) = n.parse::<f64>() {
+                } else if let Ok(float) = n.parse::<F64>() {
                     Self::Float64(float)
                 } else {
                     panic!("invalid digit: {}", n);
@@ -321,11 +321,11 @@ mod tests {
     // test when BoundExpr is Constant
     #[test]
     fn test_format_name_constant() {
-        let expr = BoundExpr::Constant(DataValue::Int32(1_i32));
+        let expr = BoundExpr::Constant(DataValue::Int32(1));
         assert_eq!("1", expr.format_name(&vec![]));
-        let expr = BoundExpr::Constant(DataValue::Int64(1_i64));
+        let expr = BoundExpr::Constant(DataValue::Int64(1));
         assert_eq!("1", expr.format_name(&vec![]));
-        let expr = BoundExpr::Constant(DataValue::Float64(32.0_f64));
+        let expr = BoundExpr::Constant(DataValue::Float64(32.0.into()));
         assert_eq!("32.000", expr.format_name(&vec![]));
     }
 
@@ -356,7 +356,7 @@ mod tests {
                 index: 0,
                 return_type: left_data_type.clone(),
             });
-            let right_expr = BoundExpr::Constant(DataValue::Int64(1_i64));
+            let right_expr = BoundExpr::Constant(DataValue::Int64(1));
             let child_schema = vec![ColumnDesc::new(left_data_type, "a".to_string(), false)];
             let expr = BoundExpr::BinaryOp(BoundBinaryOp {
                 op: BinaryOperator::Plus,

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -52,7 +52,7 @@ impl TableRefId {
 }
 
 /// The reference ID of a column.
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Serialize)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Serialize)]
 pub struct ColumnRefId {
     pub database_id: DatabaseId,
     pub schema_id: SchemaId,

--- a/src/executor/aggregation/min_max.rs
+++ b/src/executor/aggregation/min_max.rs
@@ -37,7 +37,6 @@ min_max_func_gen!(min_i32, i32, i32, min);
 min_max_func_gen!(max_i32, i32, i32, max);
 min_max_func_gen!(min_i64, i64, i64, min);
 min_max_func_gen!(max_i64, i64, i64, max);
-// TODO: To support min and max on `f64`, we should implement std::cmp::Ord for `f64`
 
 impl AggregationState for MinMaxAggregationState {
     fn update(&mut self, array: &ArrayImpl) -> Result<(), ExecutorError> {

--- a/src/executor/aggregation/sum.rs
+++ b/src/executor/aggregation/sum.rs
@@ -4,7 +4,7 @@ use rust_decimal::Decimal;
 
 use super::*;
 use crate::array::Array;
-use crate::types::DataTypeKind;
+use crate::types::{DataTypeKind, F64};
 
 /// State for sum aggregation
 pub struct SumAggregationState {
@@ -35,7 +35,7 @@ macro_rules! sum_func_gen {
 
 sum_func_gen!(sum_i32, i32, i32);
 sum_func_gen!(sum_i64, i64, i64);
-sum_func_gen!(sum_f64, f64, f64);
+sum_func_gen!(sum_f64, F64, F64);
 sum_func_gen!(sum_decimal, Decimal, Decimal);
 
 impl AggregationState for SumAggregationState {
@@ -87,7 +87,7 @@ impl AggregationState for SumAggregationState {
                 }
             }
             (ArrayImpl::Float64(arr), DataTypeKind::Double) => {
-                let mut temp: Option<f64> = None;
+                let mut temp: Option<F64> = None;
                 #[cfg(feature = "simd")]
                 {
                     use crate::array::ArrayValidExt;

--- a/src/executor/aggregation/sum.rs
+++ b/src/executor/aggregation/sum.rs
@@ -93,7 +93,7 @@ impl AggregationState for SumAggregationState {
                     use crate::array::ArrayValidExt;
                     let bitmap = arr.get_valid_bitmap();
                     if bitmap.any() {
-                        temp = Some(arr.batch_iter::<32>().sum());
+                        temp = Some(arr.as_native().batch_iter::<32>().sum::<f64>().into());
                     }
                 }
                 #[cfg(not(feature = "simd"))]
@@ -183,6 +183,6 @@ mod tests {
         let mut state = SumAggregationState::new(DataTypeKind::Double);
         let array = ArrayImpl::new_float64([0.1, 0.2, 0.3, 0.4].into_iter().collect());
         state.update(&array).unwrap();
-        assert_eq!(state.output(), DataValue::Float64(1.));
+        assert_eq!(state.output(), DataValue::Float64(1.0.into()));
     }
 }

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -144,7 +144,7 @@ impl ArrayImpl {
                     #[cfg(feature = "simd")]
                     (A::Int64(a), A::Int64(b)) => A::new_int64(simd_op::<_, _, _, 64>(a, b, |a, b| a $op b)),
                     #[cfg(feature = "simd")]
-                    (A::Float64(a), A::Float64(b)) => A::new_float64(simd_op::<_, _, _, 32>(a, b, |a, b| a $op b)),
+                    (A::Float64(a), A::Float64(b)) => A::new_float64(simd_op::<_, _, _, 32>(a.as_native(), b.as_native(), |a, b| a $op b).into_ordered()),
 
                     #[cfg(not(feature = "simd"))]
                     (A::Int32(a), A::Int32(b)) => A::new_int32(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -7,7 +7,7 @@ use std::borrow::Borrow;
 use crate::array::*;
 use crate::binder::BoundExpr;
 use crate::parser::{BinaryOperator, UnaryOperator};
-use crate::types::{Blob, ConvertError, DataTypeExt, DataTypeKind, DataValue, Date};
+use crate::types::{Blob, ConvertError, DataTypeExt, DataTypeKind, DataValue, Date, F64};
 
 impl BoundExpr {
     /// Evaluate the given expression as an array.
@@ -151,7 +151,7 @@ impl ArrayImpl {
                     #[cfg(not(feature = "simd"))]
                     (A::Int64(a), A::Int64(b)) => A::new_int64(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     #[cfg(not(feature = "simd"))]
-                    (A::Float64(a), A::Float64(b)) => A::new_float64(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
+                    (A::Float64(a), A::Float64(b)) => A::new_float64(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op *b)),
 
                     (A::Decimal(a), A::Decimal(b)) => A::new_decimal(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Date(a), A::Interval(b)) => A::new_date(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op *b)),
@@ -165,8 +165,7 @@ impl ArrayImpl {
                     (A::Bool(a), A::Bool(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Int32(a), A::Int32(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Int64(a), A::Int64(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
-                    #[allow(clippy::float_cmp)]
-                    (A::Float64(a), A::Float64(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
+                    (A::Float64(a), A::Float64(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op *b)),
                     (A::Utf8(a), A::Utf8(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Date(a), A::Date(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Decimal(a), A::Decimal(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
@@ -223,7 +222,7 @@ impl ArrayImpl {
                 Type::Int(_) => Self::new_int32(unary_op(a.as_ref(), |&b| b as i32)),
                 Type::BigInt(_) => Self::new_int64(unary_op(a.as_ref(), |&b| b as i64)),
                 Type::Float(_) | Type::Double => {
-                    Self::new_float64(unary_op(a.as_ref(), |&b| b as u8 as f64))
+                    Self::new_float64(unary_op(a.as_ref(), |&b| F64::from(b as u8 as f64)))
                 }
                 Type::String | Type::Char(_) | Type::Varchar(_) => {
                     Self::new_utf8(unary_op(a.as_ref(), |&b| if b { "true" } else { "false" }))
@@ -239,7 +238,7 @@ impl ArrayImpl {
                 Type::Int(_) => Self::Int32(a.clone()),
                 Type::BigInt(_) => Self::new_int64(unary_op(a.as_ref(), |&b| b as i64)),
                 Type::Float(_) | Type::Double => {
-                    Self::new_float64(unary_op(a.as_ref(), |&i| i as f64))
+                    Self::new_float64(unary_op(a.as_ref(), |&i| F64::from(i as f64)))
                 }
                 Type::String | Type::Char(_) | Type::Varchar(_) => {
                     Self::new_utf8(unary_op(a.as_ref(), |&i| i.to_string()))
@@ -258,7 +257,7 @@ impl ArrayImpl {
                 })?),
                 Type::BigInt(_) => Self::Int64(a.clone()),
                 Type::Float(_) | Type::Double => {
-                    Self::new_float64(unary_op(a.as_ref(), |&i| i as f64))
+                    Self::new_float64(unary_op(a.as_ref(), |&i| F64::from(i as f64)))
                 }
                 Type::String | Type::Char(_) | Type::Varchar(_) => {
                     Self::new_utf8(unary_op(a.as_ref(), |&i| i.to_string()))
@@ -294,7 +293,7 @@ impl ArrayImpl {
                 Type::Decimal(_, scale) => {
                     Self::new_decimal(try_unary_op(
                         a.as_ref(),
-                        |&f| match Decimal::from_f64_retain(f) {
+                        |&f| match Decimal::from_f64_retain(f.0) {
                             Some(mut d) => {
                                 if let Some(s) = scale {
                                     d.rescale(s as u32);
@@ -323,7 +322,7 @@ impl ArrayImpl {
                 })?),
                 Type::Float(_) | Type::Double => {
                     Self::new_float64(try_unary_op(a.as_ref(), |s| {
-                        s.parse::<f64>()
+                        s.parse::<F64>()
                             .map_err(|e| ConvertError::ParseFloat(s.to_string(), e))
                     })?)
                 }
@@ -358,10 +357,12 @@ impl ArrayImpl {
                 })?),
                 Type::Float(_) | Type::Double => {
                     Self::new_float64(try_unary_op(a.as_ref(), |&d| {
-                        d.to_f64().ok_or(ConvertError::FromDecimalError(
-                            DataTypeKind::Double,
-                            DataValue::Decimal(d),
-                        ))
+                        d.to_f64()
+                            .map(F64::from)
+                            .ok_or(ConvertError::FromDecimalError(
+                                DataTypeKind::Double,
+                                DataValue::Decimal(d),
+                            ))
                     })?)
                 }
                 Type::String | Type::Char(_) | Type::Varchar(_) => {

--- a/src/function/abs.rs
+++ b/src/function/abs.rs
@@ -59,7 +59,7 @@ impl Function for AbsFunction {
                 let mut builder = F64ArrayBuilder::new();
                 for val in f64_arr.iter() {
                     match val {
-                        Some(val) => builder.push(Some(&(*val).abs())),
+                        Some(val) => builder.push(Some(&val.abs().into())),
                         None => builder.push(None),
                     }
                 }

--- a/src/optimizer/logical_plan_rewriter/arith_expr_simplification.rs
+++ b/src/optimizer/logical_plan_rewriter/arith_expr_simplification.rs
@@ -33,8 +33,8 @@ impl ExprRewriter for ArithExprSimplificationRule {
                 // x * 0, 0 * x
                 (Multiply, Constant(Int32(0)), _) => Constant(Int32(0)),
                 (Multiply, _, Constant(Int32(0))) => Constant(Int32(0)),
-                (Multiply, Constant(Float64(f)), _) if *f == 0.0 => Constant(Float64(0.0)),
-                (Multiply, _, Constant(Float64(f))) if *f == 0.0 => Constant(Float64(0.0)),
+                (Multiply, Constant(Float64(f)), _) if *f == 0.0 => Constant(Float64(0.0.into())),
+                (Multiply, _, Constant(Float64(f))) if *f == 0.0 => Constant(Float64(0.0.into())),
                 // x * 1, 1 * x
                 (Multiply, Constant(Int32(1)), other) => other.clone(),
                 (Multiply, other, Constant(Int32(1))) => other.clone(),

--- a/src/storage/secondary/column/primitive_column_builder.rs
+++ b/src/storage/secondary/column/primitive_column_builder.rs
@@ -14,7 +14,7 @@ use super::ColumnBuilder;
 use crate::array::Array;
 use crate::storage::secondary::block::RleBlockBuilder;
 use crate::storage::secondary::EncodeType;
-use crate::types::{Date, Interval};
+use crate::types::{Date, Interval, F64};
 
 /// All supported block builders for primitive types.
 pub(super) enum BlockBuilderImpl<T: PrimitiveFixedWidthEncode> {
@@ -26,7 +26,7 @@ pub(super) enum BlockBuilderImpl<T: PrimitiveFixedWidthEncode> {
 
 pub type I32ColumnBuilder = PrimitiveColumnBuilder<i32>;
 pub type I64ColumnBuilder = PrimitiveColumnBuilder<i64>;
-pub type F64ColumnBuilder = PrimitiveColumnBuilder<f64>;
+pub type F64ColumnBuilder = PrimitiveColumnBuilder<F64>;
 pub type BoolColumnBuilder = PrimitiveColumnBuilder<bool>;
 pub type DecimalColumnBuilder = PrimitiveColumnBuilder<Decimal>;
 pub type DateColumnBuilder = PrimitiveColumnBuilder<Date>;

--- a/src/storage/secondary/column/primitive_column_factory.rs
+++ b/src/storage/secondary/column/primitive_column_factory.rs
@@ -13,7 +13,7 @@ use super::super::{
 use super::{BlockIteratorFactory, ConcreteColumnIterator};
 use crate::array::Array;
 use crate::storage::secondary::block::{decode_rle_block, FakeBlockIterator, RleBlockIterator};
-use crate::types::{Date, Interval};
+use crate::types::{Date, Interval, F64};
 
 /// All supported block iterators for primitive types.
 pub enum PrimitiveBlockIteratorImpl<T: PrimitiveFixedWidthEncode> {
@@ -80,7 +80,7 @@ pub type PrimitiveColumnIterator<T> = ConcreteColumnIterator<
 
 pub type I32ColumnIterator = PrimitiveColumnIterator<i32>;
 pub type I64ColumnIterator = PrimitiveColumnIterator<i64>;
-pub type F64ColumnIterator = PrimitiveColumnIterator<f64>;
+pub type F64ColumnIterator = PrimitiveColumnIterator<F64>;
 pub type BoolColumnIterator = PrimitiveColumnIterator<bool>;
 pub type DecimalColumnIterator = PrimitiveColumnIterator<Decimal>;
 pub type DateColumnIterator = PrimitiveColumnIterator<Date>;

--- a/src/storage/secondary/encode.rs
+++ b/src/storage/secondary/encode.rs
@@ -1,13 +1,14 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use bytes::{Buf, BufMut};
+use ordered_float::OrderedFloat;
 use rust_decimal::Decimal;
 
 use crate::array::{
     Array, BlobArray, BoolArray, DateArray, DecimalArray, F64Array, I32Array, I64Array,
     IntervalArray, Utf8Array,
 };
-use crate::types::{BlobRef, Date, Interval};
+use crate::types::{BlobRef, Date, Interval, F64};
 
 /// Encode a primitive value into fixed-width buffer
 pub trait PrimitiveFixedWidthEncode: Copy + Clone + 'static + Send + Sync + PartialEq {
@@ -68,18 +69,18 @@ impl PrimitiveFixedWidthEncode for i64 {
     }
 }
 
-impl PrimitiveFixedWidthEncode for f64 {
-    const WIDTH: usize = std::mem::size_of::<f64>();
-    const DEFAULT_VALUE: &'static f64 = &0.0;
+impl PrimitiveFixedWidthEncode for F64 {
+    const WIDTH: usize = std::mem::size_of::<F64>();
+    const DEFAULT_VALUE: &'static F64 = &OrderedFloat(0.0);
 
     type ArrayType = F64Array;
 
     fn encode(&self, buffer: &mut impl BufMut) {
-        buffer.put_f64_le(*self);
+        buffer.put_f64_le(self.0);
     }
 
     fn decode(buffer: &mut impl Buf) -> Self {
-        buffer.get_f64_le()
+        buffer.get_f64_le().into()
     }
 }
 

--- a/src/types/blob.rs
+++ b/src/types/blob.rs
@@ -94,7 +94,7 @@ impl fmt::Display for Blob {
 
 /// A slice of a blob.
 #[repr(transparent)]
-#[derive(PartialEq, PartialOrd, RefCast, Hash, Eq)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, RefCast, Hash)]
 pub struct BlobRef([u8]);
 
 impl BlobRef {

--- a/src/types/date.rs
+++ b/src/types/date.rs
@@ -13,7 +13,7 @@ use crate::types::Interval;
 pub const UNIX_EPOCH_DAYS: i32 = 719_163;
 
 /// Date type
-#[derive(PartialOrd, PartialEq, Debug, Copy, Clone, Default, Hash, Eq, Serialize)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Debug, Copy, Clone, Default, Hash, Serialize)]
 pub struct Date(i32);
 
 impl Date {

--- a/src/types/interval.rs
+++ b/src/types/interval.rs
@@ -6,7 +6,7 @@ use std::ops::Neg;
 use serde::Serialize;
 
 /// Interval type
-#[derive(PartialOrd, PartialEq, Debug, Copy, Clone, Default, Hash, Eq, Serialize)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Debug, Copy, Clone, Default, Hash, Serialize)]
 pub struct Interval {
     months: i32,
     days: i32,

--- a/src/types/native.rs
+++ b/src/types/native.rs
@@ -6,9 +6,10 @@ use rust_decimal::Decimal;
 
 use super::date::Date;
 use super::interval::Interval;
+use super::{F32, F64};
 
 pub trait NativeType:
-    PartialOrd + PartialEq + Debug + Copy + Send + Sync + Sized + Default + 'static
+    PartialOrd + Ord + PartialEq + Eq + Debug + Copy + Send + Sync + Sized + Default + 'static
 {
 }
 
@@ -18,5 +19,5 @@ macro_rules! impl_native {
     }
 }
 impl_native!(
-    u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64, bool, Decimal, Date, Interval
+    u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, F32, F64, bool, Decimal, Date, Interval
 );

--- a/src/types/native.rs
+++ b/src/types/native.rs
@@ -9,7 +9,7 @@ use super::interval::Interval;
 use super::{F32, F64};
 
 pub trait NativeType:
-    PartialOrd + Ord + PartialEq + Eq + Debug + Copy + Send + Sync + Sized + Default + 'static
+    PartialOrd + PartialEq + Debug + Copy + Send + Sync + Sized + Default + 'static
 {
 }
 
@@ -19,5 +19,6 @@ macro_rules! impl_native {
     }
 }
 impl_native!(
-    u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, F32, F64, bool, Decimal, Date, Interval
+    u8, u16, u32, u64, usize, i8, i16, i32, i64, isize, f32, f64, F32, F64, bool, Decimal, Date,
+    Interval
 );


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

This PR introduces ordered float to replace the native f32 & f64, which allows us to derive `Eq`, `Ord` and `Hash` for various types. resolve #670.

BTW, I'm attempting to integrate [egg](https://egraphs-good.github.io/) as our optimization framework. The ordered float seems to be a blocker to it.