### PR TITLE
fix(storage): checksum BlockType in block header

### DIFF
--- a/src/storage/secondary/block.rs
+++ b/src/storage/secondary/block.rs
@@ -118,17 +118,17 @@ impl BlockCacheKey {
 }
 
 #[derive(Default, Debug, Clone)]
-pub struct BlockHeader {
+pub struct BlockMeta {
     pub block_type: BlockType,
     pub checksum_type: ChecksumType,
     pub checksum: u64,
 }
 
-pub const BLOCK_HEADER_NON_CHECKSUM_SIZE: usize = 4;
-pub const BLOCK_HEADER_CHECKSUM_SIZE: usize = 4 + 8;
-pub const BLOCK_HEADER_SIZE: usize = BLOCK_HEADER_NON_CHECKSUM_SIZE + BLOCK_HEADER_CHECKSUM_SIZE;
+pub const BLOCK_META_NON_CHECKSUM_SIZE: usize = 4;
+pub const BLOCK_META_CHECKSUM_SIZE: usize = 4 + 8;
+pub const BLOCK_META_SIZE: usize = BLOCK_META_NON_CHECKSUM_SIZE + BLOCK_META_CHECKSUM_SIZE;
 
-impl BlockHeader {
+impl BlockMeta {
     pub fn encode_except_checksum(&self, buf: &mut impl BufMut) {
         buf.put_i32(self.block_type.into());
     }

--- a/src/storage/secondary/block.rs
+++ b/src/storage/secondary/block.rs
@@ -51,8 +51,8 @@ pub type Block = Bytes;
 /// In RisingLight, the block encoding scheme is as follows:
 ///
 /// ```plain
-/// | block_type | cksum_type | cksum  |    data     |
-/// |    4B      |     4B     |   8B   |  variable   |
+/// |    data     | block_type | cksum_type | cksum  |
+/// |  variable   |    4B      |     4B     |   8B   |
 /// ```
 pub trait BlockBuilder<A: Array> {
     /// Append one data into the block.
@@ -124,11 +124,16 @@ pub struct BlockHeader {
     pub checksum: u64,
 }
 
-pub const BLOCK_HEADER_SIZE: usize = 4 + 4 + 8;
+pub const BLOCK_HEADER_NON_CHECKSUM_SIZE: usize = 4;
+pub const BLOCK_HEADER_CHECKSUM_SIZE: usize = 4 + 8;
+pub const BLOCK_HEADER_SIZE: usize = BLOCK_HEADER_NON_CHECKSUM_SIZE + BLOCK_HEADER_CHECKSUM_SIZE;
 
 impl BlockHeader {
-    pub fn encode(&self, buf: &mut impl BufMut) {
+    pub fn encode_except_checksum(&self, buf: &mut impl BufMut) {
         buf.put_i32(self.block_type.into());
+    }
+
+    pub fn encode_checksum(&self, buf: &mut impl BufMut) {
         buf.put_i32(self.checksum_type.into());
         buf.put_u64(self.checksum);
     }

--- a/src/storage/secondary/block/block_index_builder.rs
+++ b/src/storage/secondary/block/block_index_builder.rs
@@ -3,7 +3,7 @@
 use risinglight_proto::rowset::block_index::BlockType;
 use risinglight_proto::rowset::{BlockIndex, BlockStatistics};
 
-use super::{BlockHeader, BLOCK_HEADER_NON_CHECKSUM_SIZE, BLOCK_HEADER_SIZE};
+use super::{BlockMeta, BLOCK_META_NON_CHECKSUM_SIZE, BLOCK_META_SIZE};
 use crate::storage::secondary::{build_checksum, ColumnBuilderOptions};
 
 /// Builds the block index.
@@ -46,7 +46,7 @@ impl BlockIndexBuilder {
     ) {
         self.indexes.push(BlockIndex {
             offset: column_data.len() as u64,
-            length: block_data.len() as u64 + BLOCK_HEADER_SIZE as u64,
+            length: block_data.len() as u64 + BLOCK_META_SIZE as u64,
             first_rowid: self.last_row_count as u32,
             row_count: (self.row_count - self.last_row_count) as u32,
             /// TODO(chi): support sort key
@@ -58,12 +58,12 @@ impl BlockIndexBuilder {
         // the new block will begin at the current row count
         self.last_row_count = self.row_count;
 
-        self.block_header.resize(BLOCK_HEADER_SIZE, 0);
-        let mut block_header_nonchecksum = &mut self.block_header[..BLOCK_HEADER_NON_CHECKSUM_SIZE];
+        self.block_header.resize(BLOCK_META_SIZE, 0);
+        let mut block_header_nonchecksum = &mut self.block_header[..BLOCK_META_NON_CHECKSUM_SIZE];
 
         let checksum_type = self.options.checksum_type;
 
-        let mut header = BlockHeader {
+        let mut header = BlockMeta {
             block_type,
             checksum_type,
             checksum: 0,
@@ -71,14 +71,14 @@ impl BlockIndexBuilder {
         header.encode_except_checksum(&mut block_header_nonchecksum);
         debug_assert!(block_header_nonchecksum.is_empty());
         // add block_type to block_data
-        block_data.extend_from_slice(&self.block_header[..BLOCK_HEADER_NON_CHECKSUM_SIZE]);
+        block_data.extend_from_slice(&self.block_header[..BLOCK_META_NON_CHECKSUM_SIZE]);
 
         // calculate checksum and add
         header.checksum = build_checksum(header.checksum_type, block_data);
-        let mut block_header_checksum = &mut self.block_header[BLOCK_HEADER_NON_CHECKSUM_SIZE..];
+        let mut block_header_checksum = &mut self.block_header[BLOCK_META_NON_CHECKSUM_SIZE..];
         header.encode_checksum(&mut block_header_checksum);
         debug_assert!(block_header_checksum.is_empty());
-        block_data.extend_from_slice(&self.block_header[BLOCK_HEADER_NON_CHECKSUM_SIZE..]);
+        block_data.extend_from_slice(&self.block_header[BLOCK_META_NON_CHECKSUM_SIZE..]);
 
         // add data to the column file
         column_data.append(block_data);


### PR DESCRIPTION
What's changed:
- Split the encode of `BlockHeader` to checksum and non-checksum
- Take non-checksum part of header (currently BlockType) to checksum calculation
- Move `BlockHeader` to the footer of block
- Change checksum validation logic

close #247 

Signed-off-by: unconsolable <chenzhipeng2012@gmail.com>