### PR TITLE
feat(binder): introduce egg binder for queries 

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -505,6 +505,15 @@ macro_rules! impl_array {
                     )*
                 }
             }
+
+            /// Return a string describing the type of this array.
+            pub fn type_string(&self) -> &str {
+                match self {
+                    $(
+                        Self::$Abc(_) => stringify!($Abc),
+                    )*
+                }
+            }
         }
     }
 }

--- a/src/binder_v2/expr.rs
+++ b/src/binder_v2/expr.rs
@@ -1,0 +1,237 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use super::*;
+use crate::catalog::ColumnRefId;
+use crate::parser::{
+    BinaryOperator, DateTimeField, Expr, Function, FunctionArg, FunctionArgExpr, UnaryOperator,
+    Value,
+};
+use crate::types::{DataTypeKind, DataValue, Interval, F64};
+
+impl Binder {
+    /// Bind an expression.
+    pub fn bind_expr(&mut self, expr: Expr) -> Result {
+        match expr {
+            Expr::Value(v) => Ok(self.egraph.add(Node::Constant(v.into()))),
+            Expr::Identifier(ident) => self.bind_ident([ident]),
+            Expr::CompoundIdentifier(idents) => self.bind_ident(idents),
+            Expr::BinaryOp { left, op, right } => self.bind_binary_op(*left, op, *right),
+            Expr::UnaryOp { op, expr } => self.bind_unary_op(op, *expr),
+            Expr::Nested(expr) => self.bind_expr(*expr),
+            Expr::Cast { expr, data_type } => self.bind_cast(*expr, data_type),
+            Expr::Function(func) => self.bind_function(func),
+            Expr::IsNull(expr) => self.bind_is_null(*expr),
+            Expr::IsNotNull(expr) => {
+                let isnull = self.bind_is_null(*expr)?;
+                Ok(self.egraph.add(Node::Not(isnull)))
+            }
+            Expr::TypedString { data_type, value } => self.bind_typed_string(data_type, value),
+            Expr::Between {
+                expr,
+                negated,
+                low,
+                high,
+            } => self.bind_between(*expr, negated, *low, *high),
+            _ => todo!("bind expression: {:?}", expr),
+        }
+    }
+
+    fn bind_ident(&mut self, idents: impl IntoIterator<Item = Ident>) -> Result {
+        let idents = idents
+            .into_iter()
+            .map(|ident| Ident::new(ident.value.to_lowercase()))
+            .collect_vec();
+        let (_schema_name, table_name, column_name) = match idents.as_slice() {
+            [column] => (None, None, &column.value),
+            [table, column] => (None, Some(&table.value), &column.value),
+            [schema, table, column] => (Some(&schema.value), Some(&table.value), &column.value),
+            _ => return Err(BindError::InvalidTableName(idents)),
+        };
+        if let Some(name) = table_name {
+            let table_ref_id = *self
+                .current_ctx()
+                .tables
+                .get(name)
+                .ok_or_else(|| BindError::InvalidTable(name.clone()))?;
+            let table = self.catalog.get_table(&table_ref_id).unwrap();
+            let col = table
+                .get_column_by_name(column_name)
+                .ok_or_else(|| BindError::InvalidColumn(column_name.into()))?;
+            let column_ref_id = ColumnRefId::from_table(table_ref_id, col.id());
+            return Ok(self.egraph.add(Node::Column(column_ref_id)));
+        }
+        // find column in all tables
+        let mut column_ids = self.current_ctx().tables.values().filter_map(|table_id| {
+            self.catalog
+                .get_table(table_id)
+                .unwrap()
+                .get_column_by_name(column_name)
+                .map(|col| ColumnRefId::from_table(*table_id, col.id()))
+        });
+
+        if let Some(column_ref_id) = column_ids.next() {
+            if column_ids.next().is_some() {
+                return Err(BindError::AmbiguousColumn(column_name.into()));
+            }
+            return Ok(self.egraph.add(Node::Column(column_ref_id)));
+        }
+        if let Some(id) = self.current_ctx().aliases.get(column_name) {
+            return Ok(*id);
+        }
+        Err(BindError::InvalidColumn(column_name.into()))
+    }
+
+    fn bind_binary_op(&mut self, left: Expr, op: BinaryOperator, right: Expr) -> Result {
+        use BinaryOperator::*;
+
+        let l = self.bind_expr(left)?;
+        let r = self.bind_expr(right)?;
+        let node = match op {
+            Plus => Node::Add([l, r]),
+            Minus => Node::Sub([l, r]),
+            Multiply => Node::Mul([l, r]),
+            Divide => Node::Div([l, r]),
+            Modulo => Node::Mod([l, r]),
+            StringConcat => Node::StringConcat([l, r]),
+            Gt => Node::Gt([l, r]),
+            Lt => Node::Lt([l, r]),
+            GtEq => Node::GtEq([l, r]),
+            LtEq => Node::LtEq([l, r]),
+            Eq => Node::Eq([l, r]),
+            NotEq => Node::NotEq([l, r]),
+            And => Node::And([l, r]),
+            Or => Node::Or([l, r]),
+            Xor => Node::Xor([l, r]),
+            Like => Node::Like([l, r]),
+            _ => todo!("bind binary op: {:?}", op),
+        };
+        Ok(self.egraph.add(node))
+    }
+
+    fn bind_unary_op(&mut self, op: UnaryOperator, expr: Expr) -> Result {
+        use UnaryOperator::*;
+        let expr = self.bind_expr(expr)?;
+        Ok(match op {
+            Plus => expr,
+            Minus => self.egraph.add(Node::Neg(expr)),
+            Not => self.egraph.add(Node::Not(expr)),
+            _ => todo!("bind unary operator: {:?}", op),
+        })
+    }
+
+    fn bind_cast(&mut self, expr: Expr, mut ty: DataTypeKind) -> Result {
+        let expr = self.bind_expr(expr)?;
+        // workaround for 'BLOB'
+        if let DataTypeKind::Custom(name) = &ty {
+            if name.0.len() == 1 && name.0[0].value.to_lowercase() == "blob" {
+                ty = DataTypeKind::Blob(0);
+            }
+        }
+        let ty = self.egraph.add(Node::Type(ty.into()));
+        Ok(self.egraph.add(Node::Cast([ty, expr])))
+    }
+
+    fn bind_is_null(&mut self, expr: Expr) -> Result {
+        let expr = self.bind_expr(expr)?;
+        Ok(self.egraph.add(Node::IsNull(expr)))
+    }
+
+    fn bind_typed_string(&mut self, data_type: DataTypeKind, value: String) -> Result {
+        match data_type {
+            DataTypeKind::Date => {
+                let date = value.parse().map_err(|_| {
+                    BindError::CastError(DataValue::String(value), DataTypeKind::Date)
+                })?;
+                Ok(self.egraph.add(Node::Constant(DataValue::Date(date))))
+            }
+            t => todo!("support typed string: {:?}", t),
+        }
+    }
+
+    fn bind_between(&mut self, expr: Expr, negated: bool, low: Expr, high: Expr) -> Result {
+        let expr = self.bind_expr(expr)?;
+        let low = self.bind_expr(low)?;
+        let high = self.bind_expr(high)?;
+        let left = self.egraph.add(Node::GtEq([expr, low]));
+        let right = self.egraph.add(Node::LtEq([expr, high]));
+        let between = self.egraph.add(Node::And([left, right]));
+        if negated {
+            Ok(self.egraph.add(Node::Not(between)))
+        } else {
+            Ok(between)
+        }
+    }
+
+    fn bind_function(&mut self, func: Function) -> Result {
+        // TODO: Support scalar function
+        let mut args = vec![];
+        for arg in func.args {
+            // ignore argument name
+            let arg = match arg {
+                FunctionArg::Named { arg, .. } => arg,
+                FunctionArg::Unnamed(arg) => arg,
+            };
+            match arg {
+                FunctionArgExpr::Expr(expr) => args.push(self.bind_expr(expr)?),
+                FunctionArgExpr::Wildcard => {
+                    // No argument in row count
+                    args.clear();
+                    break;
+                }
+                FunctionArgExpr::QualifiedWildcard(_) => todo!("support qualified wildcard"),
+            }
+        }
+        let node = match func.name.to_string().to_lowercase().as_str() {
+            "count" if args.is_empty() => Node::RowCount,
+            "count" => Node::Count(args[0]),
+            "max" => Node::Max(args[0]),
+            "min" => Node::Min(args[0]),
+            "sum" => Node::Sum(args[0]),
+            "avg" => Node::Avg(args[0]),
+            "first" => Node::First(args[0]),
+            "last" => Node::Last(args[0]),
+            name => todo!("Unsupported function: {}", name),
+        };
+        Ok(self.egraph.add(node))
+    }
+}
+
+impl From<Value> for DataValue {
+    fn from(v: Value) -> Self {
+        match v {
+            Value::Number(n, _) => {
+                if let Ok(int) = n.parse::<i32>() {
+                    Self::Int32(int)
+                } else if let Ok(bigint) = n.parse::<i64>() {
+                    Self::Int64(bigint)
+                } else if let Ok(float) = n.parse::<F64>() {
+                    Self::Float64(float)
+                } else {
+                    panic!("invalid digit: {}", n);
+                }
+            }
+            Value::SingleQuotedString(s) => Self::String(s),
+            Value::DoubleQuotedString(s) => Self::String(s),
+            Value::Boolean(b) => Self::Bool(b),
+            Value::Null => Self::Null,
+            Value::Interval {
+                value,
+                leading_field,
+                ..
+            } => {
+                if let Expr::Value(Value::SingleQuotedString(value)) = *value {
+                    let num = value.parse().unwrap();
+                    Self::Interval(match leading_field {
+                        Some(DateTimeField::Day) => Interval::from_days(num),
+                        Some(DateTimeField::Month) => Interval::from_months(num),
+                        Some(DateTimeField::Year) => Interval::from_years(num),
+                        _ => todo!("Support interval with leading field: {:?}", leading_field),
+                    })
+                } else {
+                    todo!("unsupported value: {}", value)
+                }
+            }
+            _ => todo!("parse value: {:?}", v),
+        }
+    }
+}

--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 
 use crate::catalog::{RootCatalog, TableRefId, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME};
 use crate::parser::*;
-use crate::planner::{Expr as Node, RecExpr};
+use crate::planner::{Expr as Node, ExprAnalysis, RecExpr};
 use crate::types::{DataTypeKind, DataValue};
 
 mod expr;
@@ -62,7 +62,7 @@ pub enum BindError {
 /// The binder resolves all expressions referring to schema objects such as
 /// tables or views with their column names and types.
 pub struct Binder {
-    egraph: egg::EGraph<Node, ()>,
+    egraph: egg::EGraph<Node, ExprAnalysis>,
     catalog: Arc<RootCatalog>,
     contexts: Vec<Context>,
 }

--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -1,0 +1,168 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::vec::Vec;
+
+use egg::Id;
+use itertools::Itertools;
+
+use crate::catalog::{RootCatalog, TableRefId, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME};
+use crate::parser::*;
+use crate::planner::{Expr as Node, RecExpr};
+use crate::types::{DataTypeKind, DataValue};
+
+mod expr;
+mod select;
+mod table;
+
+pub use self::expr::*;
+pub use self::select::*;
+pub use self::table::*;
+
+pub type Result<T = Id> = std::result::Result<T, BindError>;
+
+/// The error type of bind operations.
+#[derive(thiserror::Error, Debug, PartialEq, Eq)]
+pub enum BindError {
+    #[error("invalid database {0}")]
+    InvalidDatabase(String),
+    #[error("invalid schema {0}")]
+    InvalidSchema(String),
+    #[error("invalid table {0}")]
+    InvalidTable(String),
+    #[error("invalid column {0}")]
+    InvalidColumn(String),
+    #[error("duplicated table {0}")]
+    DuplicatedTable(String),
+    #[error("duplicated column {0}")]
+    DuplicatedColumn(String),
+    #[error("duplicated alias {0}")]
+    DuplicatedAlias(String),
+    #[error("invalid expression: {0}")]
+    InvalidExpression(String),
+    #[error("not nullable column: {0}")]
+    NotNullableColumn(String),
+    #[error("binary operator types mismatch: {0} != {1}")]
+    BinaryOpTypeMismatch(String, String),
+    #[error("ambiguous column: {0}")]
+    AmbiguousColumn(String),
+    #[error("invalid table name: {0:?}")]
+    InvalidTableName(Vec<Ident>),
+    #[error("SQL not supported")]
+    NotSupportedTSQL,
+    #[error("invalid SQL")]
+    InvalidSQL,
+    #[error("cannot cast {0:?} to {1:?}")]
+    CastError(DataValue, DataTypeKind),
+    #[error("{0}")]
+    BindFunctionError(String),
+}
+
+/// The binder resolves all expressions referring to schema objects such as
+/// tables or views with their column names and types.
+pub struct Binder {
+    egraph: egg::EGraph<Node, ()>,
+    catalog: Arc<RootCatalog>,
+    contexts: Vec<Context>,
+}
+
+/// The context of binder execution.
+#[derive(Debug, Default)]
+struct Context {
+    /// Mapping table name to its ID.
+    tables: HashMap<String, TableRefId>,
+    /// Mapping alias name to expression.
+    aliases: HashMap<String, Id>,
+}
+
+impl Binder {
+    /// Create a new binder.
+    pub fn new(catalog: Arc<RootCatalog>) -> Self {
+        Binder {
+            egraph: egg::EGraph::default(),
+            catalog,
+            contexts: vec![],
+        }
+    }
+
+    /// Bind a statement.
+    pub fn bind(&mut self, stmt: Statement) -> Result<RecExpr> {
+        let id = self.bind_stmt(stmt)?;
+        let extractor = egg::Extractor::new(&self.egraph, egg::AstSize);
+        let (_, best) = extractor.find_best(id);
+        Ok(best)
+    }
+
+    fn bind_stmt(&mut self, stmt: Statement) -> Result {
+        match stmt {
+            Statement::CreateTable { .. } => todo!(),
+            Statement::Drop { .. } => todo!(),
+            Statement::Insert { .. } => todo!(),
+            Statement::Delete { .. } => todo!(),
+            Statement::Copy { .. } => todo!(),
+            Statement::Query(query) => self.bind_query(*query),
+            Statement::Explain { statement, .. } => todo!(),
+            Statement::ShowVariable { .. }
+            | Statement::ShowCreate { .. }
+            | Statement::ShowColumns { .. } => Err(BindError::NotSupportedTSQL),
+            _ => Err(BindError::InvalidSQL),
+        }
+    }
+
+    fn push_context(&mut self) {
+        self.contexts.push(Context::default());
+    }
+
+    fn pop_context(&mut self) {
+        self.contexts.pop();
+    }
+
+    fn current_ctx(&self) -> &Context {
+        self.contexts.last().unwrap()
+    }
+
+    fn current_ctx_mut(&mut self) -> &mut Context {
+        self.contexts.last_mut().unwrap()
+    }
+
+    /// Add an alias to the current context.
+    fn add_alias(&mut self, alias: Ident, expr: Id) -> Result<()> {
+        let context = self.contexts.last_mut().unwrap();
+        context.aliases.insert(alias.value.clone(), expr);
+        // may override the same name
+        Ok(())
+    }
+
+    /// Find a table by name.
+    fn find_table(&self, name: &str) -> Option<TableRefId> {
+        self.current_ctx().tables.get(name).cloned()
+        // TODO: support correlated subquery
+        // for context in self.contexts.iter().rev() {
+        //     if let Some(table) = context.tables.get(name) {
+        //         return Some(*table);
+        //     }
+        // }
+        // None
+    }
+}
+
+/// Split an object name into `(database name, schema name, table name)`.
+fn split_name(name: &ObjectName) -> Result<(&str, &str, &str)> {
+    Ok(match name.0.as_slice() {
+        [table] => (DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, &table.value),
+        [schema, table] => (DEFAULT_DATABASE_NAME, &schema.value, &table.value),
+        [db, schema, table] => (&db.value, &schema.value, &table.value),
+        _ => return Err(BindError::InvalidTableName(name.0.clone())),
+    })
+}
+
+/// Convert an object name into lower case
+fn lower_case_name(name: ObjectName) -> ObjectName {
+    ObjectName(
+        name.0
+            .iter()
+            .map(|ident| Ident::new(ident.value.to_lowercase()))
+            .collect::<Vec<_>>(),
+    )
+}

--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -102,7 +102,7 @@ impl Binder {
             Statement::Delete { .. } => todo!(),
             Statement::Copy { .. } => todo!(),
             Statement::Query(query) => self.bind_query(*query),
-            Statement::Explain { statement, .. } => todo!(),
+            Statement::Explain { .. } => todo!(),
             Statement::ShowVariable { .. }
             | Statement::ShowCreate { .. }
             | Statement::ShowColumns { .. } => Err(BindError::NotSupportedTSQL),
@@ -129,21 +129,9 @@ impl Binder {
     /// Add an alias to the current context.
     fn add_alias(&mut self, alias: Ident, expr: Id) -> Result<()> {
         let context = self.contexts.last_mut().unwrap();
-        context.aliases.insert(alias.value.clone(), expr);
+        context.aliases.insert(alias.value, expr);
         // may override the same name
         Ok(())
-    }
-
-    /// Find a table by name.
-    fn find_table(&self, name: &str) -> Option<TableRefId> {
-        self.current_ctx().tables.get(name).cloned()
-        // TODO: support correlated subquery
-        // for context in self.contexts.iter().rev() {
-        //     if let Some(table) = context.tables.get(name) {
-        //         return Some(*table);
-        //     }
-        // }
-        // None
     }
 }
 

--- a/src/binder_v2/select.rs
+++ b/src/binder_v2/select.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use super::*;
-use crate::catalog::ColumnRefId;
 use crate::parser::{Expr, Query, SelectItem, SetExpr};
 
 impl Binder {
@@ -22,11 +21,11 @@ impl Binder {
         let mut orderby = vec![];
         for e in query.order_by {
             let expr = self.bind_expr(e.expr)?;
-            let order = self.egraph.add(match e.asc {
-                Some(true) | None => Node::Asc,
-                Some(false) => Node::Desc,
+            let key = self.egraph.add(match e.asc {
+                Some(true) | None => Node::Asc(expr),
+                Some(false) => Node::Desc(expr),
             });
-            orderby.push(self.egraph.add(Node::OrderKey([expr, order])));
+            orderby.push(key);
         }
         let orderby = self.egraph.add(Node::List(orderby.into()));
 

--- a/src/binder_v2/select.rs
+++ b/src/binder_v2/select.rs
@@ -14,7 +14,7 @@ impl Binder {
     fn bind_query_internal(&mut self, query: Query) -> Result {
         let child = match *query.body {
             SetExpr::Select(select) => self.bind_select(*select)?,
-            SetExpr::Values(values) => todo!("bind values"),
+            SetExpr::Values(_values) => todo!("bind values"),
             _ => todo!("handle query ???"),
         };
 

--- a/src/binder_v2/select.rs
+++ b/src/binder_v2/select.rs
@@ -1,0 +1,91 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use super::*;
+use crate::catalog::ColumnRefId;
+use crate::parser::{Expr, Query, SelectItem, SetExpr};
+
+impl Binder {
+    pub(super) fn bind_query(&mut self, query: Query) -> Result {
+        self.push_context();
+        let ret = self.bind_query_internal(query);
+        self.pop_context();
+        ret
+    }
+
+    fn bind_query_internal(&mut self, query: Query) -> Result {
+        let child = match *query.body {
+            SetExpr::Select(select) => self.bind_select(*select)?,
+            SetExpr::Values(values) => todo!("bind values"),
+            _ => todo!("handle query ???"),
+        };
+
+        let mut orderby = vec![];
+        for e in query.order_by {
+            let expr = self.bind_expr(e.expr)?;
+            let order = self.egraph.add(match e.asc {
+                Some(true) | None => Node::Asc,
+                Some(false) => Node::Desc,
+            });
+            orderby.push(self.egraph.add(Node::OrderKey([expr, order])));
+        }
+        let orderby = self.egraph.add(Node::List(orderby.into()));
+
+        let limit = match query.limit {
+            Some(expr) => self.bind_expr(expr)?,
+            None => self.egraph.add(Node::null()),
+        };
+        let offset = match query.offset {
+            Some(offset) => self.bind_expr(offset.value)?,
+            None => self.egraph.add(Node::null()),
+        };
+        Ok(self.egraph.add(Node::TopN([orderby, limit, offset, child])))
+    }
+
+    pub fn bind_select(&mut self, select: Select) -> Result {
+        let from = self.bind_from(select.from)?;
+
+        let where_ = self.bind_condition(select.selection)?;
+
+        let projection = self.bind_projection(select.projection)?;
+
+        let group_list = (select.group_by.into_iter())
+            .map(|key| self.bind_expr(key))
+            .try_collect()?;
+        let groupby = self.egraph.add(Node::List(group_list));
+
+        let having = self.bind_condition(select.having)?;
+
+        Ok(self
+            .egraph
+            .add(Node::Select([projection, from, where_, groupby, having])))
+    }
+
+    fn bind_projection(&mut self, projection: Vec<SelectItem>) -> Result {
+        let mut select_list = vec![];
+        for item in projection {
+            match item {
+                SelectItem::UnnamedExpr(expr) => {
+                    let expr = self.bind_expr(expr)?;
+                    select_list.push(expr);
+                }
+                SelectItem::ExprWithAlias { expr, alias } => {
+                    let expr = self.bind_expr(expr)?;
+                    self.add_alias(alias, expr)?;
+                    select_list.push(expr);
+                }
+                SelectItem::Wildcard => {
+                    select_list.push(self.egraph.add(Node::Wildcard));
+                }
+                _ => todo!("bind select list"),
+            }
+        }
+        Ok(self.egraph.add(Node::List(select_list.into())))
+    }
+
+    pub(super) fn bind_condition(&mut self, selection: Option<Expr>) -> Result {
+        Ok(match selection {
+            Some(expr) => self.bind_expr(expr)?,
+            None => self.egraph.add(Node::true_()),
+        })
+    }
+}

--- a/src/binder_v2/table.rs
+++ b/src/binder_v2/table.rs
@@ -11,7 +11,7 @@ impl Binder {
         for table in tables {
             let table_node = self.bind_table_with_joins(table)?;
             node = Some(if let Some(node) = node {
-                let ty = self.egraph.add(Node::Inner);
+                let ty = self.egraph.add(Node::Cross);
                 let expr = self.egraph.add(Node::true_());
                 self.egraph.add(Node::Join([ty, expr, node, table_node]))
             } else {

--- a/src/binder_v2/table.rs
+++ b/src/binder_v2/table.rs
@@ -1,0 +1,115 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::vec::Vec;
+
+use super::*;
+use crate::catalog::ColumnRefId;
+
+impl Binder {
+    pub(super) fn bind_from(&mut self, tables: Vec<TableWithJoins>) -> Result {
+        let mut node = None;
+        for table in tables {
+            let table_node = self.bind_table_with_joins(table)?;
+            node = Some(if let Some(node) = node {
+                let ty = self.egraph.add(Node::Inner);
+                let expr = self.egraph.add(Node::true_());
+                self.egraph.add(Node::Join([ty, expr, node, table_node]))
+            } else {
+                table_node
+            });
+        }
+        Ok(node.expect("no table"))
+    }
+
+    fn bind_table_with_joins(&mut self, tables: TableWithJoins) -> Result {
+        let mut node = self.bind_table(tables.relation)?;
+        for join in tables.joins {
+            let table = self.bind_table(join.relation)?;
+            let (ty, condition) = self.bind_join_op(join.join_operator)?;
+            node = self.egraph.add(Node::Join([ty, condition, node, table]));
+        }
+        Ok(node)
+    }
+
+    pub(super) fn bind_table(&mut self, table: TableFactor) -> Result {
+        match table {
+            TableFactor::Table { name, alias, .. } => {
+                let name = lower_case_name(name);
+                let (database_name, schema_name, table_name) = split_name(&name)?;
+                let id = self.bind_table_name(database_name, schema_name, table_name)?;
+                if let Some(alias) = alias {
+                    self.add_alias(alias.name, id)?;
+                }
+                Ok(id)
+            }
+            _ => panic!("bind table ref"),
+        }
+    }
+
+    fn bind_join_op(&mut self, op: JoinOperator) -> Result<(Id, Id)> {
+        use JoinOperator::*;
+        match op {
+            Inner(constraint) => {
+                let ty = self.egraph.add(Node::Inner);
+                let condition = self.bind_join_constraint(constraint)?;
+                Ok((ty, condition))
+            }
+            LeftOuter(constraint) => {
+                let ty = self.egraph.add(Node::LeftOuter);
+                let condition = self.bind_join_constraint(constraint)?;
+                Ok((ty, condition))
+            }
+            RightOuter(constraint) => {
+                let ty = self.egraph.add(Node::RightOuter);
+                let condition = self.bind_join_constraint(constraint)?;
+                Ok((ty, condition))
+            }
+            FullOuter(constraint) => {
+                let ty = self.egraph.add(Node::FullOuter);
+                let condition = self.bind_join_constraint(constraint)?;
+                Ok((ty, condition))
+            }
+            CrossJoin => {
+                let ty = self.egraph.add(Node::Cross);
+                let condition = self.egraph.add(Node::true_());
+                Ok((ty, condition))
+            }
+            _ => todo!("Support more join types"),
+        }
+    }
+
+    fn bind_join_constraint(&mut self, constraint: JoinConstraint) -> Result {
+        match constraint {
+            JoinConstraint::On(expr) => self.bind_expr(expr),
+            _ => todo!("Support more join constraints"),
+        }
+    }
+
+    fn bind_table_name(
+        &mut self,
+        database_name: &str,
+        schema_name: &str,
+        table_name: &str,
+    ) -> Result {
+        if self.current_ctx().tables.contains_key(table_name) {
+            return Err(BindError::DuplicatedTable(table_name.into()));
+        }
+        let ref_id = self
+            .catalog
+            .get_table_id_by_name(database_name, schema_name, table_name)
+            .ok_or_else(|| BindError::InvalidTable(table_name.into()))?;
+        self.current_ctx_mut()
+            .tables
+            .insert(table_name.into(), ref_id);
+
+        let table = self.catalog.get_table(&ref_id).unwrap();
+        let mut ids = vec![];
+        for cid in table.all_columns().keys() {
+            let column_ref_id = ColumnRefId::from_table(ref_id, *cid);
+            ids.push(self.egraph.add(Node::Column(column_ref_id)));
+        }
+        let list = self.egraph.add(Node::List(ids.into()));
+        let scan = self.egraph.add(Node::Scan(list));
+        Ok(scan)
+    }
+}

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -22,10 +22,13 @@ mod root;
 mod schema;
 mod table;
 
+// TODO: move to this mod
+pub(crate) use crate::types::{ColumnId, DatabaseId, SchemaId, TableId};
+
 pub type RootCatalogRef = Arc<RootCatalog>;
 
 /// The reference ID of a table.
-#[derive(PartialEq, Eq, Hash, Copy, Clone, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Serialize, Deserialize)]
 pub struct TableRefId {
     pub database_id: DatabaseId,
     pub schema_id: SchemaId,

--- a/src/db.rs
+++ b/src/db.rs
@@ -155,6 +155,7 @@ impl Database {
             self.run_dt()
         } else if cmd == "v2" {
             USE_PLANNER_V2.store(true, Ordering::Relaxed);
+            println!("switched to planner v2");
             Ok(vec![])
         } else {
             Err(Error::InternalError("unsupported command".to_string()))

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -155,7 +155,7 @@ impl ArrayImpl {
 
                     (A::Decimal(a), A::Decimal(b)) => A::new_decimal(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Date(a), A::Interval(b)) => A::new_date(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op *b)),
-                    _ => todo!("Support more types for {}", stringify!($op)),
+                    _ => todo!("Support {} {} {}", self.type_string(), stringify!($op), right.type_string()),
                 }
             }
         }
@@ -169,7 +169,7 @@ impl ArrayImpl {
                     (A::Utf8(a), A::Utf8(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Date(a), A::Date(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Decimal(a), A::Decimal(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
-                    _ => todo!("Support more types for {}", stringify!($op)),
+                    _ => todo!("Support {} {} {}", self.type_string(), stringify!($op), right.type_string()),
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@ pub mod types;
 /// Utilities.
 pub mod utils;
 
+/// The new binder converting sqlparser AST to egg AST.
+mod binder_v2;
 /// Next-generation planner and optimizer based on egg.
 mod planner;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,8 +314,9 @@ async fn main() -> Result<()> {
     let args = Args::parse();
 
     let fmt_layer = tracing_subscriber::fmt::layer().compact();
-    let filter_layer =
-        tracing_subscriber::EnvFilter::from_default_env().add_directive(Level::INFO.into());
+    let filter_layer = tracing_subscriber::EnvFilter::from_default_env()
+        .add_directive(Level::INFO.into())
+        .add_directive("egg=warn".parse()?);
 
     tracing_subscriber::registry()
         .with(filter_layer)

--- a/src/planner/cost.rs
+++ b/src/planner/cost.rs
@@ -1,0 +1,24 @@
+use egg::Language;
+
+use super::*;
+
+pub struct CostFn<'a> {
+    pub egraph: &'a EGraph,
+}
+
+impl egg::CostFunction<Expr> for CostFn<'_> {
+    type Cost = u32;
+    fn cost<C>(&mut self, enode: &Expr, mut costs: C) -> Self::Cost
+    where
+        C: FnMut(Id) -> Self::Cost,
+    {
+        let op_cost = match enode {
+            // should no longer exists
+            Expr::Select(_) | Expr::Prune(_) => u32::MAX,
+            _ => 1,
+        };
+        enode.fold(op_cost, |sum, id| {
+            sum.checked_add(costs(id)).unwrap_or(u32::MAX)
+        })
+    }
+}

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -86,8 +86,8 @@ define_language! {
         "order" = Order([Id; 2]),               // (order [order_key..] child)
             "asc" = Asc(Id),                        // (asc key)
             "desc" = Desc(Id),                      // (desc key)
-        "limit" = Limit([Id; 3]),               // (limit offset limit child)
-        "topn" = TopN([Id; 4]),                 // (topn offset limit [order_key..] child)
+        "limit" = Limit([Id; 3]),               // (limit limit offset child)
+        "topn" = TopN([Id; 4]),                 // (topn limit offset [order_key..] child)
         "join" = Join([Id; 4]),                 // (join join_type expr left right)
         "hashjoin" = HashJoin([Id; 5]),         // (hashjoin join_type [left_expr..] [right_expr..] left right)
             "inner" = Inner,

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -8,7 +8,7 @@ use crate::types::{ColumnIndex, DataValue, PhysicalDataTypeKind};
 
 mod rules;
 
-pub use rules::optimize;
+pub use rules::{optimize, ExprAnalysis};
 
 pub type RecExpr = egg::RecExpr<Expr>;
 
@@ -20,7 +20,6 @@ define_language! {
         // Table(TableRefId),              // $1, $2, ...
         Column(ColumnRefId),            // $1.2, $2.1, ...
         ColumnIndex(ColumnIndex),       // #0, #1, ...
-        "*" = Wildcard,                 // *
 
         // binary operations
         "+" = Add([Id; 2]),

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -166,7 +166,7 @@ impl Expr {
 pub fn optimize(expr: &RecExpr) -> RecExpr {
     let mut runner = egg::Runner::default()
         // .with_explanations_enabled()
-        .with_expr(&expr)
+        .with_expr(expr)
         .with_time_limit(Duration::from_secs(1))
         .run(&rules::all_rules());
     // extract the best expression

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -53,19 +53,19 @@ pub struct ExprAnalysis;
 #[derive(Debug)]
 pub struct Data {
     /// Some if the expression is a constant.
-    constant: expr::ConstValue,
+    pub constant: expr::ConstValue,
 
     /// All columns involved in the node.
-    columns: plan::ColumnSet,
+    pub columns: plan::ColumnSet,
 
     /// All aggragations in the tree.
-    aggs: agg::AggSet,
+    pub aggs: agg::AggSet,
 
     /// The schema for plan node: a list of expressions.
     ///
     /// For non-plan node, it always be None.
     /// For plan node, it may be None if the schema is unknown due to unresolved `prune`.
-    schema: schema::Schema,
+    pub schema: schema::Schema,
 }
 
 impl Analysis<Expr> for ExprAnalysis {

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -23,16 +23,12 @@ use std::hash::Hash;
 
 use egg::{rewrite as rw, *};
 
-use super::{Expr, RecExpr};
+use super::{EGraph, Expr, RecExpr, Rewrite};
 
 mod agg;
 mod expr;
 mod plan;
 mod schema;
-
-// Alias types for our language.
-type EGraph = egg::EGraph<Expr, ExprAnalysis>;
-type Rewrite = egg::Rewrite<Expr, ExprAnalysis>;
 
 /// Returns all rules in the optimizer.
 pub fn all_rules() -> Vec<Rewrite> {
@@ -125,32 +121,4 @@ fn var(s: &str) -> Var {
 /// This is a helper function for submodules.
 fn pattern(s: &str) -> Pattern<Expr> {
     s.parse().expect("invalid pattern")
-}
-
-/// Optimize the given expression.
-pub fn optimize(expr: &RecExpr) -> RecExpr {
-    let runner = Runner::default().with_expr(&expr).run(&all_rules());
-    // define cost function
-    struct Trivial;
-    impl egg::CostFunction<Expr> for Trivial {
-        type Cost = u32;
-        fn cost<C>(&mut self, enode: &Expr, mut costs: C) -> Self::Cost
-        where
-            C: FnMut(Id) -> Self::Cost,
-        {
-            let op_cost = match enode {
-                // should no longer exists
-                Expr::Select(_) | Expr::Prune(_) => u32::MAX,
-                _ => 1,
-            };
-            enode.fold(op_cost, |sum, id| {
-                sum.checked_add(costs(id)).unwrap_or(u32::MAX)
-            })
-        }
-    }
-    // extract the best expression
-    let extractor = egg::Extractor::new(&runner.egraph, Trivial);
-    let root = runner.roots[0];
-    let (_, best) = extractor.find_best(root);
-    best
 }

--- a/src/planner/rules/plan.rs
+++ b/src/planner/rules/plan.rs
@@ -108,25 +108,27 @@ fn column_prune_rules() -> Vec<Rewrite> { vec![
         "(prune ?set (limit ?offset ?limit ?child))" =>
         "(limit ?offset ?limit (prune ?set ?child))"
     ),
-    // note that we use `+` to represent the union of two column sets.
-    // in fact, it doesn't matter what operator we use,
-    // because the set of a node is calculated by union all its children.
+    // note that we use `list` to represent the union of multiple column sets.
+    // because the column set of `list` is calculated by union all its children.
     // see `analyze_columns()`.
     rw!("prune-order";
         "(prune ?set (order ?keys ?child))" =>
-        "(order ?keys (prune (+ ?set ?keys) ?child))"
+        "(order ?keys (prune (list ?set ?keys) ?child))"
     ),
     rw!("prune-filter";
         "(prune ?set (filter ?cond ?child))" =>
-        "(filter ?cond (prune (+ ?set ?cond) ?child))"
+        "(filter ?cond (prune (list ?set ?cond) ?child))"
     ),
     rw!("prune-agg";
         "(prune ?set (agg ?aggs ?groupby ?child))" =>
-        "(agg ?aggs ?groupby (prune (+ (+ ?set ?aggs) ?groupby) ?child))"
+        "(agg ?aggs ?groupby (prune (list ?set ?aggs ?groupby) ?child))"
     ),
     rw!("prune-join";
         "(prune ?set (join ?type ?on ?left ?right))" =>
-        "(join ?type ?on (prune (+ ?set ?on) ?left) (prune (+ ?set ?on) ?right))"
+        "(join ?type ?on
+            (prune (list ?set ?on) ?left)
+            (prune (list ?set ?on) ?right)
+        )"
     ),
     // projection and scan is the sink of prune node
     rw!("prune-proj";

--- a/src/planner/rules/plan.rs
+++ b/src/planner/rules/plan.rs
@@ -17,7 +17,7 @@ pub fn rules() -> Vec<Rewrite> {
 #[rustfmt::skip]
 fn cancel_rules() -> Vec<Rewrite> { vec![
     rw!("limit-null";   "(limit null null ?child)" => "?child"),
-    rw!("limit-0";      "(limit ?offset 0 ?child)" => "(values)"),
+    rw!("limit-0";      "(limit 0 ?offset ?child)" => "(values)"),
     rw!("filter-true";  "(filter true ?child)" => "?child"),
     rw!("filter-false"; "(filter false ?child)" => "(values)"),
     rw!("join-false";   "(join ?type false ?left ?right)" => "(values)"),
@@ -27,12 +27,12 @@ fn cancel_rules() -> Vec<Rewrite> { vec![
 #[rustfmt::skip]
 fn merge_rules() -> Vec<Rewrite> { vec![
     rw!("topn-limit-order";
-        "(topn ?offset ?limit ?keys ?child)" =>
-        "(limit ?offset ?limit (order ?keys ?child))"
+        "(topn ?limit ?offset ?keys ?child)" =>
+        "(limit ?limit ?offset (order ?keys ?child))"
     ),
     rw!("limit-order-topn";
-        "(limit ?offset ?limit (order ?keys ?child))" =>
-        "(topn ?offset ?limit ?keys ?child)"
+        "(limit ?limit ?offset (order ?keys ?child))" =>
+        "(topn ?limit ?offset ?keys ?child)"
     ),
     rw!("filter-merge";
         "(filter ?cond1 (filter ?cond2 ?child))" =>
@@ -47,11 +47,11 @@ fn merge_rules() -> Vec<Rewrite> { vec![
 #[rustfmt::skip]
 fn pushdown_rules() -> Vec<Rewrite> { vec![
     pushdown("proj", "?exprs", "order", "?keys"),
-    pushdown("proj", "?exprs", "limit", "?offset ?limit"),
-    pushdown("proj", "?exprs", "topn", "?offset ?limit ?keys"),
+    pushdown("proj", "?exprs", "limit", "?limit ?offset"),
+    pushdown("proj", "?exprs", "topn", "?limit ?offset ?keys"),
     pushdown("filter", "?cond", "order", "?keys"),
-    pushdown("filter", "?cond", "limit", "?offset ?limit"),
-    pushdown("filter", "?cond", "topn", "?offset ?limit ?keys"),
+    pushdown("filter", "?cond", "limit", "?limit ?offset"),
+    pushdown("filter", "?cond", "topn", "?limit ?offset ?keys"),
     rw!("pushdown-filter-join";
         "(filter ?cond (join ?type ?on ?left ?right))" =>
         "(join ?type (and ?on ?cond) ?left ?right)"
@@ -115,8 +115,8 @@ fn column_prune_rules() -> Vec<Rewrite> { vec![
     // then it is pushed down through the plan node tree,
     // merging all used columns along the way
     rw!("prune-limit";
-        "(prune ?set (limit ?offset ?limit ?child))" =>
-        "(limit ?offset ?limit (prune ?set ?child))"
+        "(prune ?set (limit ?limit ?offset ?child))" =>
+        "(limit ?limit ?offset (prune ?set ?child))"
     ),
     // note that we use `list` to represent the union of multiple column sets.
     // because the column set of `list` is calculated by union all its children.

--- a/src/planner/rules/plan.rs
+++ b/src/planner/rules/plan.rs
@@ -26,7 +26,11 @@ fn cancel_rules() -> Vec<Rewrite> { vec![
 
 #[rustfmt::skip]
 fn merge_rules() -> Vec<Rewrite> { vec![
-    rw!("limit-order=topn";
+    rw!("topn-limit-order";
+        "(topn ?offset ?limit ?keys ?child)" =>
+        "(limit ?offset ?limit (order ?keys ?child))"
+    ),
+    rw!("limit-order-topn";
         "(limit ?offset ?limit (order ?keys ?child))" =>
         "(topn ?offset ?limit ?keys ?child)"
     ),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -67,7 +67,7 @@ impl std::fmt::Debug for DataType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.kind)?;
         if self.nullable {
-            write!(f, " (null)")?;
+            write!(f, " (nullable)")?;
         }
         Ok(())
     }
@@ -77,7 +77,7 @@ impl std::fmt::Display for DataType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.kind)?;
         if self.nullable {
-            write!(f, " (null)")?;
+            write!(f, " (nullable)")?;
         }
         Ok(())
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -67,7 +67,7 @@ impl std::fmt::Debug for DataType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.kind)?;
         if self.nullable {
-            write!(f, " (nullable)")?;
+            write!(f, " (null)")?;
         }
         Ok(())
     }
@@ -77,7 +77,7 @@ impl std::fmt::Display for DataType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.kind)?;
         if self.nullable {
-            write!(f, " (nullable)")?;
+            write!(f, " (null)")?;
         }
         Ok(())
     }


### PR DESCRIPTION
This PR forks the current binder and integrates it with the egg language introduced by #702.
(only queries for now, other statements are left to future PR)

Now the new planner is partially connected to the pipeline: 
SQL ==parser=> Parser AST ==binder=> Egg AST ==optimizer=> Optimized Egg AST.

You can try it by first typing `\v2` and then running queries in the interactive shell:
```sql
$ cargo run
> \v2
switched to planner v2
in 0.000s
# TPC-H Q3
> select
    l_orderkey,
    sum(l_extendedprice * (1 - l_discount)) as revenue,
    o_orderdate,
    o_shippriority
from
    customer,
    orders,
    lineitem
where
    c_mktsegment = 'BUILDING'
    and c_custkey = o_custkey
    and l_orderkey = o_orderkey
    and o_orderdate < date '1995-03-15'
    and l_shipdate > date '1995-03-15'
group by
    l_orderkey,
    o_orderdate,
    o_shippriority
order by
    revenue desc,
    o_orderdate
limit 10;
bind result:
(topn
  10
  null
  (list (desc (sum (* $7.5 (- 1 $7.6)))) (asc $6.4))
  (select
    (list $7.0 (sum (* $7.5 (- 1 $7.6))) $6.4 $6.7)
    (join
      cross
      true
      (join
        cross
        true
        (scan (list $5.0 $5.1 $5.2 $5.3 $5.4 $5.5 $5.6 $5.7))
        (scan (list $6.0 $6.1 $6.2 $6.3 $6.4 $6.5 $6.6 $6.7 $6.8)))
      (scan (list $7.0 $7.1 $7.2 $7.3 $7.4 $7.5 $7.6 $7.7 $7.8 $7.9 $7.10 $7.11 $7.12 $7.13 $7.14 $7.15)))
    (and
      (and
        (and (and (= $5.6 'BUILDING') (= $5.0 $6.1)) (= $7.0 $6.0))
        (< $6.4 1995-03-15))
      (> $7.10 1995-03-15))
    (list $7.0 $6.4 $6.7)
    true))
optimize result:
(topn
  10
  null
  (list (desc (sum (* $7.5 (- 1 $7.6)))) (asc $6.4))
  (proj
    (list $7.0 (sum (* $7.5 (- 1 $7.6))) $6.4 $6.7)
    (agg
      (list (sum (* $7.5 (- 1 $7.6))))
      (list $7.0 $6.4 $6.7)
      (join
        cross
        (= $7.0 $6.0)
        (filter
          (> 1995-03-15 $6.4)
          (join
            cross
            (and (= $6.1 $5.0) (= 'BUILDING' $5.6))
            (scan (list $5.0 $5.6))
            (scan (list $6.0 $6.1 $6.4 $6.7))))
        (filter
          (> $7.10 1995-03-15)
          (scan (list $7.0 $7.5 $7.6 $7.10)))))))
```

As you can see, the rewrite rules work but the output is not optimal, because we don't have a proper cost function. This will be the focus of the next step.