### PR TITLE
feat(planner): support `distinct on`

### DIFF
--- a/src/binder_v2/select.rs
+++ b/src/binder_v2/select.rs
@@ -47,6 +47,12 @@ impl Binder {
 
         let projection = self.bind_projection(select.projection, from)?;
 
+        let distinct = match select.distinct {
+            // TODO: distinct on
+            true => projection,
+            false => self.egraph.add(Node::List([].into())),
+        };
+
         let group_list = (select.group_by.into_iter())
             .map(|key| self.bind_expr(key))
             .try_collect()?;
@@ -54,9 +60,9 @@ impl Binder {
 
         let having = self.bind_condition(select.having)?;
 
-        Ok(self
-            .egraph
-            .add(Node::Select([projection, from, where_, groupby, having])))
+        Ok(self.egraph.add(Node::Select([
+            distinct, projection, from, where_, groupby, having,
+        ])))
     }
 
     fn bind_projection(&mut self, projection: Vec<SelectItem>, from: Id) -> Result {

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -16,6 +16,7 @@ pub use rules::ExprAnalysis;
 // Alias types for our language.
 type EGraph = egg::EGraph<Expr, ExprAnalysis>;
 type Rewrite = egg::Rewrite<Expr, ExprAnalysis>;
+type Pattern = egg::Pattern<Expr>;
 pub type RecExpr = egg::RecExpr<Expr>;
 
 define_language! {
@@ -70,13 +71,15 @@ define_language! {
         "as" = Alias([Id; 2]),                  // (as name expr)
         "fn" = Function(Box<[Id]>),             // (fn name args..)
 
-        "select" = Select([Id; 5]),             // (select
+        "select" = Select([Id; 6]),             // (select
+                                                //      distinct=[expr..]
                                                 //      select_list=[expr..]
                                                 //      from=join
                                                 //      where=expr
                                                 //      groupby=[expr..]
                                                 //      having=expr
                                                 // )
+        "distinct" = Distinct([Id; 2]),         // (distinct [expr..] child)
 
         // plans
         "scan" = Scan(Id),                      // (scan [column..])

--- a/src/planner/rules/agg.rs
+++ b/src/planner/rules/agg.rs
@@ -6,23 +6,34 @@ use super::*;
 #[rustfmt::skip]
 pub fn rules() -> Vec<Rewrite> { vec![
     rw!("extract-agg-from-select-list";
-        "(select ?exprs ?from ?where ?groupby ?having)" =>
+        "(select ?distinct ?exprs ?from ?where ?groupby ?having)" =>
         { ExtractAgg {
             has_agg: pattern("
             (proj ?exprs
-                (filter ?having
-                    (agg ?aggs ?groupby
-                        (filter ?where
-                            ?from
+                (distinct ?distinct
+                    (filter ?having
+                        (agg ?aggs ?groupby
+                            (filter ?where
+                                ?from
+                            )
                         )
                     )
                 )
             )"),
-            no_agg: pattern("(proj ?exprs (filter ?where ?from))"),
-            select_list: var("?exprs"),
+            no_agg: pattern("(proj ?exprs (distinct ?distinct (filter ?where ?from)))"),
+            sources: vec![var("?distinct"), var("?exprs"), var("?having")],
             groupby: var("?groupby"),
-            having: var("?having"),
             output: var("?aggs"),
+        }}
+    ),
+    rw!("proj-distinct-to-agg"; 
+        "(proj ?exprs (distinct ?on ?child))" =>
+        { DistinctToAgg {
+            no_distinct: pattern("(proj ?exprs ?child)"),
+            has_distinct: pattern("(proj ?exprs (agg ?aggs ?on ?child))"),
+            projection: var("?exprs"),
+            distinct_on: var("?on"),
+            aggs: var("?aggs"),
         }}
     ),
 ]}
@@ -38,7 +49,7 @@ pub fn analyze_aggs(egraph: &EGraph, enode: &Expr) -> AggSet {
         return [enode.clone()].into_iter().collect();
     }
     if let Max(c) | Min(c) | Sum(c) | Avg(c) | Count(c) | First(c) | Last(c) = enode {
-        assert!(x(c).is_empty(), "agg in agg");
+        assert!(x(c).is_empty(), "agg in agg"); // FIXME: report error instead of panic
         return [enode.clone()].into_iter().collect();
     }
     // TODO: ignore plan nodes
@@ -48,15 +59,15 @@ pub fn analyze_aggs(egraph: &EGraph, enode: &Expr) -> AggSet {
         .collect()
 }
 
-/// Extracts all agg expressions from `select_list` and `having`.
-/// If any, apply `has_agg` and put those aggs to `output`.
-/// Otherwise, apply `no_agg`.
+/// Extracts all agg expressions from `sources`.
+///
+/// If both agg and `groupby` are empty, apply `no_agg`.
+/// Otherwise, apply `has_agg` and put those aggs to `output`.
 struct ExtractAgg {
-    has_agg: Pattern<Expr>,
-    no_agg: Pattern<Expr>,
-    select_list: Var,
+    has_agg: Pattern,
+    no_agg: Pattern,
+    sources: Vec<Var>,
     groupby: Var,
-    having: Var,
     output: Var,
 }
 
@@ -69,9 +80,9 @@ impl Applier<Expr, ExprAnalysis> for ExtractAgg {
         searcher_ast: Option<&PatternAst<Expr>>,
         rule_name: Symbol,
     ) -> Vec<Id> {
-        let select_aggs = &egraph[subst[self.select_list]].data.aggs;
-        let having_aggs = &egraph[subst[self.having]].data.aggs;
-        let aggs = select_aggs.union(having_aggs).cloned().collect_vec();
+        let aggs = (self.sources.iter())
+            .flat_map(|var| egraph[subst[*var]].data.aggs.iter().cloned())
+            .collect::<HashSet<Expr>>();
         let groupby = match &egraph[subst[self.groupby]].nodes[0] {
             Expr::List(list) => list.as_slice(),
             _ => panic!("groupby is not a list"),
@@ -87,6 +98,54 @@ impl Applier<Expr, ExprAnalysis> for ExtractAgg {
         let mut subst = subst.clone();
         subst.insert(self.output, egraph.add(Expr::List(list)));
         self.has_agg
+            .apply_one(egraph, eclass, &subst, searcher_ast, rule_name)
+    }
+}
+
+/// Convert `distinct` to `agg`.
+///
+/// If `distinct_on` is empty, apply `no_distinct`.
+/// Otherwise, apply `has_distinct`. The expressions in the `projection` who are not in
+/// `distinct_on` will be aggregated by `first` and put to `aggs`.
+struct DistinctToAgg {
+    no_distinct: Pattern,
+    has_distinct: Pattern,
+    projection: Var,  // inout
+    distinct_on: Var, // in
+    aggs: Var,        // out
+}
+
+impl Applier<Expr, ExprAnalysis> for DistinctToAgg {
+    fn apply_one(
+        &self,
+        egraph: &mut EGraph,
+        eclass: Id,
+        subst: &Subst,
+        searcher_ast: Option<&PatternAst<Expr>>,
+        rule_name: Symbol,
+    ) -> Vec<Id> {
+        let get_list = |var: Var| match &egraph[subst[var]].nodes[0] {
+            Expr::List(list) => list.clone(),
+            _ => panic!("not a list"),
+        };
+        let distinct_on = get_list(self.distinct_on);
+        if distinct_on.is_empty() {
+            return self
+                .no_distinct
+                .apply_one(egraph, eclass, subst, searcher_ast, rule_name);
+        }
+        let mut aggs = vec![];
+        let mut projection = get_list(self.projection);
+        for id in projection.iter_mut() {
+            if !distinct_on.contains(id) {
+                *id = egraph.add(Expr::First(*id));
+                aggs.push(*id);
+            }
+        }
+        let mut subst = subst.clone();
+        subst.insert(self.aggs, egraph.add(Expr::List(aggs.into())));
+        subst.insert(self.projection, egraph.add(Expr::List(projection)));
+        self.has_distinct
             .apply_one(egraph, eclass, &subst, searcher_ast, rule_name)
     }
 }
@@ -109,6 +168,7 @@ mod tests {
         // WHERE b > 1 GROUP BY a HAVING count(a) > 1;
         "
         (select
+            (list)
             (list (+ (sum (+ $1.1 $1.2)) $1.1))
             (scan (list $1.1 $1.2 $1.3))
             (> $1.2 1)
@@ -134,6 +194,7 @@ mod tests {
         // SELECT a FROM t GROUP BY a;
         "
         (select
+            (list)
             (list $1.1)
             (scan (list $1.1 $1.2 $1.3))
             true (list $1.1) true
@@ -151,12 +212,32 @@ mod tests {
         // SELECT a FROM t;
         "
         (select
+            (list)
             (list $1.1)
             (scan (list $1.1 $1.2 $1.3))
             true (list) true
         )" => "
         (proj (list $1.1)
             (scan (list $1.1 $1.2 $1.3))
+        )"
+    }
+
+    egg::test_fn! {
+        distinct_on,
+        rules(),
+        // SELECT DISTINCT ON (a, b) a, c FROM t;
+        // => SELECT a, FIRST(c) FROM t GROUP BY a, b;
+        "
+        (select
+            (list $1.1 $1.2)
+            (list $1.1 $1.3)
+            (scan (list $1.1 $1.2 $1.3))
+            true (list) true
+        )" => "
+        (proj (list $1.1 (first $1.3))
+            (agg (list (first $1.3)) (list $1.1 $1.2)
+                (scan (list $1.1 $1.2 $1.3))
+            )
         )"
     }
 
@@ -168,6 +249,7 @@ mod tests {
         // WHERE s.sid = e.sid AND e.grade = 'A'
         "
         (select
+            (list)
             (list $1.2 $2.2)
             (join inner true
                 (scan (list $1.1 $1.2))

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -23,7 +23,7 @@ use std::hash::Hash;
 
 use egg::{rewrite as rw, *};
 
-use super::{EGraph, Expr, RecExpr, Rewrite};
+use super::{EGraph, Expr, Pattern, RecExpr, Rewrite};
 
 mod agg;
 mod expr;
@@ -119,6 +119,6 @@ fn var(s: &str) -> Var {
 /// Create a [`Pattern`] from string.
 ///
 /// This is a helper function for submodules.
-fn pattern(s: &str) -> Pattern<Expr> {
+fn pattern(s: &str) -> Pattern {
     s.parse().expect("invalid pattern")
 }

--- a/src/planner/rules/schema.rs
+++ b/src/planner/rules/schema.rs
@@ -54,7 +54,8 @@ pub fn analyze_schema(egraph: &EGraph, enode: &Expr) -> Schema {
     let concat = |v1: Vec<Id>, v2: Vec<Id>| v1.into_iter().chain(v2.into_iter()).collect();
     Some(match enode {
         // equal to child
-        Filter([_, c]) | Order([_, c]) | Limit([_, _, c]) | TopN([_, _, _, c]) => x(*c)?,
+        Filter([_, c]) | Order([_, c]) | Limit([_, _, c]) | TopN([_, _, _, c])
+        | Distinct([_, c]) => x(*c)?,
 
         // concat 2 children
         Join([_, _, l, r]) | HashJoin([_, _, _, l, r]) => concat(x(*l)?, x(*r)?),


### PR DESCRIPTION
This PR adds `SELECT DISTINCT (ON)` support to the new planner and fixes 2 bugs in aggregation planning.

It introduces a new plan `distinct` that uniquifies rows on the given expressions. This plan will be rewritten to `agg` by a rule. See https://github.com/risingwavelabs/risingwave/issues/4617 for details.
