### PR TITLE
feat(planner_v2): add type checker

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -503,7 +503,7 @@ macro_rules! impl_array {
             }
 
             /// Return a string describing the type of this array.
-            pub fn type_string(&self) -> &str {
+            pub fn type_string(&self) -> &'static str {
                 match self {
                     $(
                         Self::$Abc(_) => stringify!($Abc),

--- a/src/binder/expression/mod.rs
+++ b/src/binder/expression/mod.rs
@@ -46,12 +46,12 @@ impl BoundExpr {
     pub fn return_type(&self) -> Option<DataType> {
         match self {
             Self::Constant(v) => v.data_type(),
-            Self::ColumnRef(expr) => Some(expr.desc.datatype().clone()),
-            Self::BinaryOp(expr) => expr.return_type.clone(),
-            Self::UnaryOp(expr) => expr.return_type.clone(),
-            Self::TypeCast(expr) => Some(expr.ty.clone().nullable()),
-            Self::AggCall(expr) => Some(expr.return_type.clone()),
-            Self::InputRef(expr) => Some(expr.return_type.clone()),
+            Self::ColumnRef(expr) => Some(*expr.desc.datatype()),
+            Self::BinaryOp(expr) => expr.return_type,
+            Self::UnaryOp(expr) => expr.return_type,
+            Self::TypeCast(expr) => Some(expr.ty.nullable()),
+            Self::AggCall(expr) => Some(expr.return_type),
+            Self::InputRef(expr) => Some(expr.return_type),
             Self::IsNull(_) => Some(DataTypeKind::Bool.not_null()),
             Self::ExprWithAlias(expr) => expr.expr.return_type(),
             Self::Alias(expr) => expr.expr.return_type(),
@@ -334,9 +334,9 @@ mod tests {
         let data_type = DataType::new(DataTypeKind::Int32, true);
         let expr = BoundExpr::InputRef(BoundInputRef {
             index: 0,
-            return_type: data_type.clone(),
+            return_type: data_type,
         });
-        let child_schema = vec![ColumnDesc::new(data_type.clone(), "a".to_string(), false)];
+        let child_schema = vec![ColumnDesc::new(data_type, "a".to_string(), false)];
         let expr = BoundExpr::UnaryOp(BoundUnaryOp {
             op: UnaryOperator::Minus,
             expr: Box::new(expr),
@@ -353,7 +353,7 @@ mod tests {
             let left_data_type = DataType::new(DataTypeKind::Int32, true);
             let left_expr = BoundExpr::InputRef(BoundInputRef {
                 index: 0,
-                return_type: left_data_type.clone(),
+                return_type: left_data_type,
             });
             let right_expr = BoundExpr::Constant(DataValue::Int64(1));
             let child_schema = vec![ColumnDesc::new(left_data_type, "a".to_string(), false)];
@@ -370,15 +370,15 @@ mod tests {
             let data_type = DataType::new(DataTypeKind::Int32, true);
             let left_expr = BoundExpr::InputRef(BoundInputRef {
                 index: 0,
-                return_type: data_type.clone(),
+                return_type: data_type,
             });
             let right_expr = BoundExpr::InputRef(BoundInputRef {
                 index: 1,
-                return_type: data_type.clone(),
+                return_type: data_type,
             });
             let child_schema = vec![
-                ColumnDesc::new(data_type.clone(), "a".to_string(), false),
-                ColumnDesc::new(data_type.clone(), "b".to_string(), false),
+                ColumnDesc::new(data_type, "a".to_string(), false),
+                ColumnDesc::new(data_type, "b".to_string(), false),
             ];
 
             let expr = BoundExpr::BinaryOp(BoundBinaryOp {

--- a/src/binder_v2/expr.rs
+++ b/src/binder_v2/expr.rs
@@ -77,7 +77,10 @@ impl Binder {
             if column_ids.next().is_some() {
                 return Err(BindError::AmbiguousColumn(column_name.into()));
             }
-            return Ok(self.egraph.add(Node::Column(column_ref_id)));
+            let id = self.egraph.add(Node::Column(column_ref_id));
+            self.egraph[id].data.type_ =
+                Ok(self.catalog.get_column(&column_ref_id).unwrap().datatype());
+            return Ok(id);
         }
         if let Some(id) = self.current_ctx().aliases.get(column_name) {
             return Ok(*id);

--- a/src/binder_v2/expr.rs
+++ b/src/binder_v2/expr.rs
@@ -11,7 +11,7 @@ use crate::types::{DataTypeKind, DataValue, Interval, F64};
 impl Binder {
     /// Bind an expression.
     pub fn bind_expr(&mut self, expr: Expr) -> Result {
-        match expr {
+        let id = match expr {
             Expr::Value(v) => Ok(self.egraph.add(Node::Constant(v.into()))),
             Expr::Identifier(ident) => self.bind_ident([ident]),
             Expr::CompoundIdentifier(idents) => self.bind_ident(idents),
@@ -33,7 +33,11 @@ impl Binder {
                 high,
             } => self.bind_between(*expr, negated, *low, *high),
             _ => todo!("bind expression: {:?}", expr),
+        }?;
+        if let Err(e) = &self.egraph[id].data.type_ {
+            return Err(e.clone().into());
         }
+        Ok(id)
     }
 
     fn bind_ident(&mut self, idents: impl IntoIterator<Item = Ident>) -> Result {

--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 
 use crate::catalog::{RootCatalog, TableRefId, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME};
 use crate::parser::*;
-use crate::planner::{Expr as Node, ExprAnalysis, RecExpr};
+use crate::planner::{Expr as Node, ExprAnalysis, RecExpr, TypeError};
 use crate::types::{DataTypeKind, DataValue};
 
 mod expr;
@@ -57,6 +57,8 @@ pub enum BindError {
     CastError(DataValue, DataTypeKind),
     #[error("{0}")]
     BindFunctionError(String),
+    #[error("type error: {0}")]
+    TypeError(#[from] TypeError),
 }
 
 /// The binder resolves all expressions referring to schema objects such as

--- a/src/catalog/column.rs
+++ b/src/catalog/column.rs
@@ -85,7 +85,7 @@ impl ColumnCatalog {
     }
 
     pub fn datatype(&self) -> DataType {
-        self.desc.datatype.clone()
+        self.desc.datatype
     }
 
     pub fn set_primary(&mut self, is_primary: bool) {

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -87,6 +87,14 @@ impl ColumnRefId {
             column_id,
         }
     }
+
+    pub const fn table(&self) -> TableRefId {
+        TableRefId {
+            database_id: self.database_id,
+            schema_id: self.schema_id,
+            table_id: self.table_id,
+        }
+    }
 }
 
 impl std::fmt::Display for ColumnRefId {

--- a/src/catalog/root.rs
+++ b/src/catalog/root.rs
@@ -93,6 +93,11 @@ impl RootCatalog {
         schema.get_table_by_id(table_ref_id.table_id)
     }
 
+    pub fn get_column(&self, column_ref_id: &ColumnRefId) -> Option<ColumnCatalog> {
+        self.get_table(&column_ref_id.table())?
+            .get_column_by_id(column_ref_id.column_id)
+    }
+
     pub fn add_table(
         &self,
         table_ref_id: TableRefId,

--- a/src/executor/create.rs
+++ b/src/executor/create.rs
@@ -70,11 +70,11 @@ mod tests {
 
             let table_ref = catalog.get_table(&id).unwrap();
             assert_eq!(
-                table_ref.get_column_by_id(0).unwrap(),
+                table_ref.get_column_by_id(0).unwrap().clone(),
                 ColumnCatalog::new(0, DataTypeKind::Int32.not_null().to_column("v1".into()))
             );
             assert_eq!(
-                table_ref.get_column_by_id(1).unwrap(),
+                table_ref.get_column_by_id(1).unwrap().clone(),
                 ColumnCatalog::new(1, DataTypeKind::Int32.not_null().to_column("v2".into()))
             );
         }

--- a/src/executor/create.rs
+++ b/src/executor/create.rs
@@ -70,11 +70,11 @@ mod tests {
 
             let table_ref = catalog.get_table(&id).unwrap();
             assert_eq!(
-                table_ref.get_column_by_id(0).unwrap().clone(),
+                table_ref.get_column_by_id(0).unwrap(),
                 ColumnCatalog::new(0, DataTypeKind::Int32.not_null().to_column("v1".into()))
             );
             assert_eq!(
-                table_ref.get_column_by_id(1).unwrap().clone(),
+                table_ref.get_column_by_id(1).unwrap(),
                 ColumnCatalog::new(1, DataTypeKind::Int32.not_null().to_column("v2".into()))
             );
         }

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -41,7 +41,7 @@ impl BoundExpr {
                 if self.return_type() == cast.expr.return_type() {
                     return Ok(array);
                 }
-                array.try_cast(cast.ty.clone())
+                array.try_cast(cast.ty)
             }
             BoundExpr::IsNull(expr) => {
                 let array = expr.expr.eval(chunk)?;
@@ -91,7 +91,7 @@ impl BoundExpr {
                 if self.return_type() == cast.expr.return_type() {
                     return Ok(array);
                 }
-                array.try_cast(cast.ty.clone())
+                array.try_cast(cast.ty)
             }
             BoundExpr::IsNull(expr) => {
                 let array = expr.expr.eval_array_in_storage(chunk, cardinality)?;

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -17,11 +17,11 @@ impl BoundExpr {
             BoundExpr::BinaryOp(binary_op) => {
                 let left = binary_op.left_expr.eval(chunk)?;
                 let right = binary_op.right_expr.eval(chunk)?;
-                Ok(left.binary_op(&binary_op.op, &right))
+                left.binary_op(&binary_op.op, &right)
             }
             BoundExpr::UnaryOp(op) => {
                 let array = op.expr.eval(chunk)?;
-                Ok(array.unary_op(&op.op))
+                array.unary_op(&op.op)
             }
             BoundExpr::Constant(v) => {
                 let mut builder = ArrayBuilderImpl::with_capacity(
@@ -71,11 +71,11 @@ impl BoundExpr {
                 let right = binary_op
                     .right_expr
                     .eval_array_in_storage(chunk, cardinality)?;
-                Ok(left.binary_op(&binary_op.op, &right))
+                left.binary_op(&binary_op.op, &right)
             }
             BoundExpr::UnaryOp(op) => {
                 let array = op.expr.eval_array_in_storage(chunk, cardinality)?;
-                Ok(array.unary_op(&op.op))
+                array.unary_op(&op.op)
             }
             BoundExpr::Constant(v) => {
                 let mut builder =
@@ -108,34 +108,41 @@ impl BoundExpr {
 
 impl ArrayImpl {
     /// Perform unary operation.
-    pub fn unary_op(&self, op: &UnaryOperator) -> ArrayImpl {
+    pub fn unary_op(&self, op: &UnaryOperator) -> Result<ArrayImpl, ConvertError> {
         type A = ArrayImpl;
-        match op {
+        Ok(match op {
             UnaryOperator::Plus => match self {
                 A::Int32(_) => self.clone(),
                 A::Int64(_) => self.clone(),
                 A::Float64(_) => self.clone(),
                 A::Decimal(_) => self.clone(),
-                _ => panic!("+ can only be applied to Int, Float or Decimal array"),
+                _ => return Err(ConvertError::NoUnaryOp("+".into(), self.type_string())),
             },
             UnaryOperator::Minus => match self {
                 A::Int32(a) => A::new_int32(unary_op(a.as_ref(), |v| -v)),
                 A::Int64(a) => A::new_int64(unary_op(a.as_ref(), |v| -v)),
                 A::Float64(a) => A::new_float64(unary_op(a.as_ref(), |v| -v)),
                 A::Decimal(a) => A::new_decimal(unary_op(a.as_ref(), |v| -v)),
-                _ => panic!("- can only be applied to Int, Float or Decimal array"),
+                _ => return Err(ConvertError::NoUnaryOp("-".into(), self.type_string())),
             },
             UnaryOperator::Not => match self {
                 A::Bool(a) => A::new_bool(unary_op(a.as_ref(), |b| !b)),
-                _ => panic!("Not can only be applied to BOOL array"),
+                _ => return Err(ConvertError::NoUnaryOp("not".into(), self.type_string())),
             },
-            _ => todo!("evaluate operator: {:?}", op),
-        }
+            _ => return Err(ConvertError::NoUnaryOp(op.to_string(), self.type_string())),
+        })
     }
 
     /// Perform binary operation.
-    pub fn binary_op(&self, op: &BinaryOperator, right: &ArrayImpl) -> ArrayImpl {
+    pub fn binary_op(
+        &self,
+        op: &BinaryOperator,
+        right: &ArrayImpl,
+    ) -> Result<ArrayImpl, ConvertError> {
+        use BinaryOperator::*;
         type A = ArrayImpl;
+        let no_op =
+            || ConvertError::NoBinaryOp(op.to_string(), self.type_string(), right.type_string());
         macro_rules! arith {
             ($op:tt) => {
                 match (self, right) {
@@ -155,7 +162,8 @@ impl ArrayImpl {
 
                     (A::Decimal(a), A::Decimal(b)) => A::new_decimal(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Date(a), A::Interval(b)) => A::new_date(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op *b)),
-                    _ => todo!("Support {} {} {}", self.type_string(), stringify!($op), right.type_string()),
+
+                    _ => return Err(no_op()),
                 }
             }
         }
@@ -169,23 +177,23 @@ impl ArrayImpl {
                     (A::Utf8(a), A::Utf8(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Date(a), A::Date(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Decimal(a), A::Decimal(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
-                    _ => todo!("Support {} {} {}", self.type_string(), stringify!($op), right.type_string()),
+                    _ => return Err(no_op()),
                 }
             }
         }
-        match op {
-            BinaryOperator::Plus => arith!(+),
-            BinaryOperator::Minus => arith!(-),
-            BinaryOperator::Multiply => arith!(*),
-            BinaryOperator::Divide => arith!(/),
-            BinaryOperator::Modulo => arith!(%),
-            BinaryOperator::Eq => cmp!(==),
-            BinaryOperator::NotEq => cmp!(!=),
-            BinaryOperator::Gt => cmp!(>),
-            BinaryOperator::Lt => cmp!(<),
-            BinaryOperator::GtEq => cmp!(>=),
-            BinaryOperator::LtEq => cmp!(<=),
-            BinaryOperator::And => match (self, right) {
+        Ok(match op {
+            Plus => arith!(+),
+            Minus => arith!(-),
+            Multiply => arith!(*),
+            Divide => arith!(/),
+            Modulo => arith!(%),
+            Eq => cmp!(==),
+            NotEq => cmp!(!=),
+            Gt => cmp!(>),
+            Lt => cmp!(<),
+            GtEq => cmp!(>=),
+            LtEq => cmp!(<=),
+            And => match (self, right) {
                 (A::Bool(a), A::Bool(b)) => {
                     A::new_bool(binary_op_with_null(a.as_ref(), b.as_ref(), |a, b| {
                         match (a, b) {
@@ -195,9 +203,9 @@ impl ArrayImpl {
                         }
                     }))
                 }
-                _ => panic!("And can only be applied to BOOL arrays"),
+                _ => return Err(no_op()),
             },
-            BinaryOperator::Or => match (self, right) {
+            Or => match (self, right) {
                 (A::Bool(a), A::Bool(b)) => {
                     A::new_bool(binary_op_with_null(a.as_ref(), b.as_ref(), |a, b| {
                         match (a, b) {
@@ -207,10 +215,10 @@ impl ArrayImpl {
                         }
                     }))
                 }
-                _ => panic!("Or can only be applied to BOOL arrays"),
+                _ => return Err(no_op()),
             },
-            _ => todo!("evaluate operator: {:?}", op),
-        }
+            _ => return Err(no_op()),
+        })
     }
 
     /// Cast the array to another type.

--- a/src/function/abs.rs
+++ b/src/function/abs.rs
@@ -18,7 +18,7 @@ impl AbsFunction {
         }
 
         Ok(Box::new(AbsFunction {
-            return_type: input_types[0].clone(),
+            return_type: input_types[0],
         }))
     }
 }
@@ -32,7 +32,7 @@ impl Function for AbsFunction {
         // TODO: When unsigned types are supported,
         // we can convert signed type to unsigned type
         // this makes abs(i32::MIN) can represent by u32
-        self.return_type.clone()
+        self.return_type
     }
 
     fn execute(&self, input: &[&ArrayImpl]) -> Result<ArrayImpl, FunctionError> {

--- a/src/function/add.rs
+++ b/src/function/add.rs
@@ -27,7 +27,7 @@ impl AddFunction {
         }
 
         Ok(Box::new(AddFunction {
-            return_type: input_types[0].clone(),
+            return_type: input_types[0],
         }))
     }
 }
@@ -38,7 +38,7 @@ impl Function for AddFunction {
     }
 
     fn return_types(&self) -> DataType {
-        self.return_type.clone()
+        self.return_type
     }
 
     fn execute(&self, input: &[&ArrayImpl]) -> Result<ArrayImpl, FunctionError> {

--- a/src/function/repeat.rs
+++ b/src/function/repeat.rs
@@ -37,7 +37,7 @@ impl RepeatFunction {
         }
 
         Ok(Box::new(RepeatFunction {
-            return_type: input_types[0].clone(),
+            return_type: input_types[0],
         }))
     }
 }
@@ -48,7 +48,7 @@ impl Function for RepeatFunction {
     }
 
     fn return_types(&self) -> DataType {
-        self.return_type.clone()
+        self.return_type
     }
 
     fn execute(&self, input: &[&ArrayImpl]) -> Result<ArrayImpl, FunctionError> {

--- a/src/optimizer/logical_plan_rewriter/constant_folding.rs
+++ b/src/optimizer/logical_plan_rewriter/constant_folding.rs
@@ -22,10 +22,9 @@ impl ExprRewriter for ConstantFoldingRule {
                 self.rewrite_expr(&mut op.left_expr);
                 self.rewrite_expr(&mut op.right_expr);
                 if let (Constant(v1), Constant(v2)) = (&*op.left_expr, &*op.right_expr) {
-                    let res = ArrayImpl::from(v1)
-                        .binary_op(&op.op, &ArrayImpl::from(v2))
-                        .get(0);
-                    *expr = Constant(res);
+                    if let Ok(res) = ArrayImpl::from(v1).binary_op(&op.op, &ArrayImpl::from(v2)) {
+                        *expr = Constant(res.get(0));
+                    }
                 }
             }
             _ => unreachable!(),
@@ -37,8 +36,9 @@ impl ExprRewriter for ConstantFoldingRule {
             UnaryOp(op) => {
                 self.rewrite_expr(&mut op.expr);
                 if let Constant(v) = &*op.expr {
-                    let res = ArrayImpl::from(v).unary_op(&op.op).get(0);
-                    *expr = Constant(res);
+                    if let Ok(res) = ArrayImpl::from(v).unary_op(&op.op) {
+                        *expr = Constant(res.get(0));
+                    }
                 }
             }
             _ => unreachable!(),

--- a/src/optimizer/logical_plan_rewriter/constant_folding.rs
+++ b/src/optimizer/logical_plan_rewriter/constant_folding.rs
@@ -50,7 +50,7 @@ impl ExprRewriter for ConstantFoldingRule {
             TypeCast(cast) => {
                 self.rewrite_expr(&mut cast.expr);
                 if let Constant(v) = &*cast.expr {
-                    if let Ok(array) = ArrayImpl::from(v).try_cast(cast.ty.clone()) {
+                    if let Ok(array) = ArrayImpl::from(v).try_cast(cast.ty) {
                         let res = array.get(0);
                         *expr = Constant(res);
                     }

--- a/src/optimizer/logical_plan_rewriter/constant_moving.rs
+++ b/src/optimizer/logical_plan_rewriter/constant_moving.rs
@@ -27,20 +27,20 @@ impl ExprRewriter for ConstantMovingRule {
                                 op: op.op.clone(),
                                 left_expr: Box::new(other.clone()),
                                 right_expr: Box::new(Constant(rval - lval)),
-                                return_type: op.return_type.clone(),
+                                return_type: op.return_type,
                             })
                         }
                         (Minus, other, Constant(lval)) => BinaryOp(BoundBinaryOp {
                             op: op.op.clone(),
                             left_expr: Box::new(other.clone()),
                             right_expr: Box::new(Constant(rval + lval)),
-                            return_type: op.return_type.clone(),
+                            return_type: op.return_type,
                         }),
                         (Minus, Constant(lval), other) => BinaryOp(BoundBinaryOp {
                             op: op.op.clone(),
                             left_expr: Box::new(Constant(lval - rval)),
                             right_expr: Box::new(other.clone()),
-                            return_type: op.return_type.clone(),
+                            return_type: op.return_type,
                         }),
                         (Multiply, other, Constant(lval)) | (Multiply, Constant(lval), other)
                             if lval.is_positive() && rval.is_divisible_by(lval) =>
@@ -49,7 +49,7 @@ impl ExprRewriter for ConstantMovingRule {
                                 op: op.op.clone(),
                                 left_expr: Box::new(other.clone()),
                                 right_expr: Box::new(Constant(rval / lval)),
-                                return_type: op.return_type.clone(),
+                                return_type: op.return_type,
                             })
                         }
                         // TODO: support negative number moving

--- a/src/optimizer/logical_plan_rewriter/input_ref_resolver.rs
+++ b/src/optimizer/logical_plan_rewriter/input_ref_resolver.rs
@@ -199,7 +199,7 @@ impl AggInputRefResolver {
             AggCall(agg) => {
                 *expr = InputRef(BoundInputRef {
                     index: self.agg_start_index,
-                    return_type: agg.return_type.clone(),
+                    return_type: agg.return_type,
                 });
                 self.agg_start_index += 1;
             }

--- a/src/optimizer/plan_nodes/logical_aggregate.rs
+++ b/src/optimizer/plan_nodes/logical_aggregate.rs
@@ -78,11 +78,11 @@ impl PlanNode for LogicalAggregate {
                     false,
                 )
             })
-            .chain(self.agg_calls.iter().map(|agg_call| {
-                agg_call
-                    .return_type
-                    .to_column(format!("{}", agg_call.kind))
-            }))
+            .chain(
+                self.agg_calls
+                    .iter()
+                    .map(|agg_call| agg_call.return_type.to_column(format!("{}", agg_call.kind))),
+            )
             .collect()
     }
 

--- a/src/optimizer/plan_nodes/logical_aggregate.rs
+++ b/src/optimizer/plan_nodes/logical_aggregate.rs
@@ -81,7 +81,6 @@ impl PlanNode for LogicalAggregate {
             .chain(self.agg_calls.iter().map(|agg_call| {
                 agg_call
                     .return_type
-                    .clone()
                     .to_column(format!("{}", agg_call.kind))
             }))
             .collect()
@@ -154,7 +153,7 @@ impl PlanNode for LogicalAggregate {
             for (index, item) in new_agg_calls.iter().enumerate() {
                 new_projection.push(BoundExpr::InputRef(BoundInputRef {
                     index: group_keys_len + index,
-                    return_type: item.return_type.clone(),
+                    return_type: item.return_type,
                 }))
             }
             LogicalProjection::new(new_projection, new_agg.into_plan_ref()).into_plan_ref()
@@ -224,9 +223,9 @@ mod tests {
     fn test_prune_aggregate() {
         let ty = DataTypeKind::Int32.not_null();
         let col_descs = vec![
-            ty.clone().to_column("v1".into()),
-            ty.clone().to_column("v2".into()),
-            ty.clone().to_column("v3".into()),
+            ty.to_column("v1".into()),
+            ty.to_column("v2".into()),
+            ty.to_column("v3".into()),
         ];
 
         let table_scan = LogicalTableScan::new(
@@ -245,11 +244,11 @@ mod tests {
         let input_refs = vec![
             BoundExpr::InputRef(BoundInputRef {
                 index: 0,
-                return_type: ty.clone(),
+                return_type: ty,
             }),
             BoundExpr::InputRef(BoundInputRef {
                 index: 1,
-                return_type: ty.clone(),
+                return_type: ty,
             }),
             BoundExpr::InputRef(BoundInputRef {
                 index: 2,

--- a/src/optimizer/plan_nodes/logical_filter.rs
+++ b/src/optimizer/plan_nodes/logical_filter.rs
@@ -80,7 +80,7 @@ impl PlanNode for LogicalFilter {
             .map(|old_idx| {
                 BoundExpr::InputRef(BoundInputRef {
                     index: mapper[old_idx],
-                    return_type: input_types[old_idx].clone(),
+                    return_type: input_types[old_idx],
                 })
             })
             .collect();
@@ -116,9 +116,9 @@ mod tests {
     fn test_prune_filter() {
         let ty = DataTypeKind::Int32.not_null();
         let col_descs = vec![
-            ty.clone().to_column("v1".into()),
-            ty.clone().to_column("v2".into()),
-            ty.clone().to_column("v3".into()),
+            ty.to_column("v1".into()),
+            ty.to_column("v2".into()),
+            ty.to_column("v3".into()),
         ];
         let table_scan = LogicalTableScan::new(
             crate::catalog::TableRefId {
@@ -137,10 +137,10 @@ mod tests {
                 op: BinaryOperator::Lt,
                 left_expr: Box::new(BoundExpr::InputRef(BoundInputRef {
                     index: 1,
-                    return_type: ty.clone(),
+                    return_type: ty,
                 })),
                 right_expr: Box::new(BoundExpr::Constant(DataValue::Int32(5))),
-                return_type: Some(ty.clone()),
+                return_type: Some(ty),
             }),
             table_scan.into_plan_ref(),
         );
@@ -155,7 +155,7 @@ mod tests {
                 op: BinaryOperator::Lt,
                 left_expr: Box::new(BoundExpr::InputRef(BoundInputRef {
                     index: 0,
-                    return_type: ty.clone(),
+                    return_type: ty,
                 })),
                 right_expr: Box::new(BoundExpr::Constant(DataValue::Int32(5))),
                 return_type: Some(ty),
@@ -181,10 +181,10 @@ mod tests {
     fn test_prune_filter_with_project() {
         let ty = DataTypeKind::Int32.not_null();
         let col_descs = vec![
-            ty.clone().to_column("v1".into()),
-            ty.clone().to_column("v2".into()),
-            ty.clone().to_column("v3".into()),
-            ty.clone().to_column("v4".into()),
+            ty.to_column("v1".into()),
+            ty.to_column("v2".into()),
+            ty.to_column("v3".into()),
+            ty.to_column("v4".into()),
         ];
         let table_scan = LogicalTableScan::new(
             crate::catalog::TableRefId {
@@ -203,7 +203,7 @@ mod tests {
                 op: BinaryOperator::Lt,
                 left_expr: Box::new(BoundExpr::InputRef(BoundInputRef {
                     index: 1,
-                    return_type: ty.clone(),
+                    return_type: ty,
                 })),
                 right_expr: Box::new(BoundExpr::Constant(DataValue::Int32(5))),
                 return_type: Some(ty),
@@ -223,7 +223,7 @@ mod tests {
             plan.project_expressions()[0],
             BoundExpr::InputRef(BoundInputRef {
                 index: 1,
-                return_type: input_types[1].clone(),
+                return_type: input_types[1],
             })
         );
         let table_scan = child.child.as_logical_table_scan().unwrap();

--- a/src/optimizer/plan_nodes/logical_join.rs
+++ b/src/optimizer/plan_nodes/logical_join.rs
@@ -137,7 +137,7 @@ impl PlanNode for LogicalJoin {
                 .map(|col_idx| {
                     BoundExpr::InputRef(BoundInputRef {
                         index: mapper[col_idx],
-                        return_type: out_types[col_idx].clone(),
+                        return_type: out_types[col_idx],
                     })
                 })
                 .collect();

--- a/src/optimizer/plan_nodes/logical_order.rs
+++ b/src/optimizer/plan_nodes/logical_order.rs
@@ -91,9 +91,9 @@ mod tests {
     fn test_prune_order() {
         let ty = DataTypeKind::Int32.not_null();
         let col_descs = vec![
-            ty.clone().to_column("v1".into()),
-            ty.clone().to_column("v2".into()),
-            ty.clone().to_column("v3".into()),
+            ty.to_column("v1".into()),
+            ty.to_column("v2".into()),
+            ty.to_column("v3".into()),
         ];
         let table_scan = LogicalTableScan::new(
             crate::catalog::TableRefId {
@@ -111,15 +111,15 @@ mod tests {
         let project_expressions = vec![
             BoundExpr::InputRef(BoundInputRef {
                 index: 0,
-                return_type: ty.clone(),
+                return_type: ty,
             }),
             BoundExpr::InputRef(BoundInputRef {
                 index: 1,
-                return_type: ty.clone(),
+                return_type: ty,
             }),
             BoundExpr::InputRef(BoundInputRef {
                 index: 2,
-                return_type: ty.clone(),
+                return_type: ty,
             }),
         ];
 
@@ -128,7 +128,7 @@ mod tests {
         let node = vec![BoundOrderBy {
             expr: BoundExpr::InputRef(BoundInputRef {
                 index: 1,
-                return_type: ty.clone(),
+                return_type: ty,
             }),
             descending: false,
         }];

--- a/src/optimizer/plan_nodes/logical_projection.rs
+++ b/src/optimizer/plan_nodes/logical_projection.rs
@@ -24,10 +24,7 @@ impl ExprRewriter for Substitute {
     fn rewrite_input_ref(&self, input_ref: &mut BoundExpr) {
         match input_ref {
             BoundExpr::InputRef(i) => {
-                assert_eq!(
-                    self.mapping[i.index].return_type(),
-                    Some(i.return_type)
-                );
+                assert_eq!(self.mapping[i.index].return_type(), Some(i.return_type));
                 *input_ref = self.mapping[i.index].clone();
             }
             _ => unreachable!(),

--- a/src/optimizer/plan_nodes/logical_projection.rs
+++ b/src/optimizer/plan_nodes/logical_projection.rs
@@ -26,7 +26,7 @@ impl ExprRewriter for Substitute {
             BoundExpr::InputRef(i) => {
                 assert_eq!(
                     self.mapping[i.index].return_type(),
-                    Some(i.return_type.clone())
+                    Some(i.return_type)
                 );
                 *input_ref = self.mapping[i.index].clone();
             }
@@ -226,9 +226,9 @@ mod tests {
     fn test_prune_projection() {
         let ty = DataTypeKind::Int32.not_null();
         let col_descs = vec![
-            ty.clone().to_column("v1".into()),
-            ty.clone().to_column("v2".into()),
-            ty.clone().to_column("v3".into()),
+            ty.to_column("v1".into()),
+            ty.to_column("v2".into()),
+            ty.to_column("v3".into()),
         ];
         let table_scan = LogicalTableScan::new(
             crate::catalog::TableRefId {
@@ -245,15 +245,15 @@ mod tests {
         let project_expressions = vec![
             BoundExpr::InputRef(BoundInputRef {
                 index: 0,
-                return_type: ty.clone(),
+                return_type: ty,
             }),
             BoundExpr::InputRef(BoundInputRef {
                 index: 1,
-                return_type: ty.clone(),
+                return_type: ty,
             }),
             BoundExpr::InputRef(BoundInputRef {
                 index: 2,
-                return_type: ty.clone(),
+                return_type: ty,
             }),
         ];
         let projection = LogicalProjection::new(project_expressions, table_scan.into_plan_ref());

--- a/src/optimizer/plan_nodes/logical_table_scan.rs
+++ b/src/optimizer/plan_nodes/logical_table_scan.rs
@@ -160,7 +160,7 @@ impl PlanNode for LogicalTableScan {
                 .map(|index| {
                     BoundExpr::InputRef(BoundInputRef {
                         index,
-                        return_type: column_descs[index].datatype().clone(),
+                        return_type: *column_descs[index].datatype(),
                     })
                 })
                 .collect();

--- a/src/optimizer/plan_nodes/logical_top_n.rs
+++ b/src/optimizer/plan_nodes/logical_top_n.rs
@@ -107,7 +107,7 @@ impl PlanNode for LogicalTopN {
                 .map(|col_idx| {
                     BoundExpr::InputRef(BoundInputRef {
                         index: mapper[col_idx],
-                        return_type: out_types[col_idx].clone(),
+                        return_type: out_types[col_idx],
                     })
                 })
                 .collect();

--- a/src/optimizer/plan_nodes/logical_values.rs
+++ b/src/optimizer/plan_nodes/logical_values.rs
@@ -61,7 +61,7 @@ impl PlanNode for LogicalValues {
     fn prune_col(&self, required_cols: BitSet) -> PlanRef {
         let types: Vec<_> = required_cols
             .iter()
-            .map(|index| self.column_types[index].clone())
+            .map(|index| self.column_types[index])
             .collect();
 
         let new_values: Vec<_> = self

--- a/src/optimizer/plan_nodes/mod.rs
+++ b/src/optimizer/plan_nodes/mod.rs
@@ -134,10 +134,7 @@ pub trait PlanNode:
 
     /// Output column types
     fn out_types(&self) -> Vec<DataType> {
-        self.schema()
-            .iter()
-            .map(|desc| *desc.datatype())
-            .collect()
+        self.schema().iter().map(|desc| *desc.datatype()).collect()
     }
 
     /// Output column names

--- a/src/optimizer/plan_nodes/mod.rs
+++ b/src/optimizer/plan_nodes/mod.rs
@@ -136,7 +136,7 @@ pub trait PlanNode:
     fn out_types(&self) -> Vec<DataType> {
         self.schema()
             .iter()
-            .map(|desc| desc.datatype().clone())
+            .map(|desc| *desc.datatype())
             .collect()
     }
 
@@ -170,7 +170,7 @@ pub trait PlanNode:
             .map(|index| {
                 BoundExpr::InputRef(BoundInputRef {
                     index,
-                    return_type: input_types[index].clone(),
+                    return_type: input_types[index],
                 })
             })
             .collect();

--- a/src/optimizer/plan_nodes/physical_simple_agg.rs
+++ b/src/optimizer/plan_nodes/physical_simple_agg.rs
@@ -38,11 +38,7 @@ impl PlanNode for PhysicalSimpleAgg {
     fn schema(&self) -> Vec<ColumnDesc> {
         self.agg_calls
             .iter()
-            .map(|agg_call| {
-                agg_call
-                    .return_type
-                    .to_column(format!("{}", agg_call.kind))
-            })
+            .map(|agg_call| agg_call.return_type.to_column(format!("{}", agg_call.kind)))
             .collect()
     }
 

--- a/src/optimizer/plan_nodes/physical_simple_agg.rs
+++ b/src/optimizer/plan_nodes/physical_simple_agg.rs
@@ -41,7 +41,6 @@ impl PlanNode for PhysicalSimpleAgg {
             .map(|agg_call| {
                 agg_call
                     .return_type
-                    .clone()
                     .to_column(format!("{}", agg_call.kind))
             })
             .collect()

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -11,7 +11,7 @@ use crate::types::{ColumnIndex, DataTypeKind, DataValue};
 mod cost;
 mod rules;
 
-pub use rules::ExprAnalysis;
+pub use rules::{ExprAnalysis, TypeError};
 
 // Alias types for our language.
 type EGraph = egg::EGraph<Expr, ExprAnalysis>;

--- a/src/planner/rules/expr.rs
+++ b/src/planner/rules/expr.rs
@@ -120,7 +120,7 @@ pub fn eval_constant(egraph: &EGraph, enode: &Expr) -> ConstValue {
         }
         let array_a = ArrayImpl::from(a);
         let ty = match &egraph[ty].nodes[0] {
-            Expr::Type(ty) => ty.clone(),
+            Expr::Type(ty) => *ty,
             _ => panic!("expect data type"),
         };
         // TODO: handle cast error

--- a/src/planner/rules/expr.rs
+++ b/src/planner/rules/expr.rs
@@ -97,16 +97,28 @@ pub fn eval_constant(egraph: &EGraph, enode: &Expr) -> ConstValue {
     if let Constant(v) = enode {
         Some(v.clone())
     } else if let Some((op, a, b)) = enode.binary_op() {
-        let array_a = ArrayImpl::from(x(a)?);
-        let array_b = ArrayImpl::from(x(b)?);
-        Some(array_a.binary_op(&op, &array_b).get(0))
+        let (a, b) = (x(a)?, x(b)?);
+        if a.is_null() || b.is_null() {
+            return Some(DataValue::Null);
+        }
+        let array_a = ArrayImpl::from(a);
+        let array_b = ArrayImpl::from(b);
+        Some(array_a.binary_op(&op, &array_b).ok()?.get(0))
     } else if let Some((op, a)) = enode.unary_op() {
-        let array_a = ArrayImpl::from(x(a)?);
-        Some(array_a.unary_op(&op).get(0))
+        let a = x(a)?;
+        if a.is_null() {
+            return Some(DataValue::Null);
+        }
+        let array_a = ArrayImpl::from(a);
+        Some(array_a.unary_op(&op).ok()?.get(0))
     } else if let &IsNull(a) = enode {
         Some(DataValue::Bool(x(a)?.is_null()))
     } else if let &Cast([ty, a]) = enode {
-        let array_a = ArrayImpl::from(x(a)?);
+        let a = x(a)?;
+        if a.is_null() {
+            return Some(DataValue::Null);
+        }
+        let array_a = ArrayImpl::from(a);
         let ty = match &egraph[ty].nodes[0] {
             Expr::Type(ty) => ty.clone(),
             _ => panic!("expect data type"),

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -9,6 +9,7 @@
 //! | [`plan`]   | plan optimization     | use and defination of columns | [`ColumnSet`]  |
 //! | [`agg`]    | agg extraction        | aggregations in an expr       | [`AggSet`]     |
 //! | [`schema`] | column id to index    | output schema of a plan       | [`Schema`]     |
+//! | [`type_`]  |                       | data type                     | [`Type`]       |
 //!
 //! It would be best if you have a background in program analysis.
 //! Here is a recommended course: <https://pascal-group.bitbucket.io/teaching.html>.
@@ -17,6 +18,7 @@
 //! [`ColumnSet`]: plan::ColumnSet
 //! [`AggSet`]: agg::AggSet
 //! [`Schema`]: schema::Schema
+//! [`Type`]: type_::Type
 
 use std::collections::HashSet;
 use std::hash::Hash;
@@ -29,6 +31,7 @@ mod agg;
 mod expr;
 mod plan;
 mod schema;
+mod type_;
 
 /// Returns all rules in the optimizer.
 pub fn all_rules() -> Vec<Rewrite> {
@@ -62,6 +65,9 @@ pub struct Data {
     /// For non-plan node, it always be None.
     /// For plan node, it may be None if the schema is unknown due to unresolved `prune`.
     pub schema: schema::Schema,
+
+    /// Data type of the expression.
+    pub type_: type_::Type,
 }
 
 impl Analysis<Expr> for ExprAnalysis {
@@ -74,6 +80,7 @@ impl Analysis<Expr> for ExprAnalysis {
             columns: plan::analyze_columns(egraph, enode),
             aggs: agg::analyze_aggs(egraph, enode),
             schema: schema::analyze_schema(egraph, enode),
+            type_: type_::analyze_type(egraph, enode),
         }
     }
 
@@ -90,7 +97,8 @@ impl Analysis<Expr> for ExprAnalysis {
         let merge_columns = merge_small_set(&mut to.columns, from.columns);
         let merge_aggs = merge_small_set(&mut to.aggs, from.aggs);
         let merge_schema = egg::merge_max(&mut to.schema, from.schema);
-        merge_const | merge_columns | merge_aggs | merge_schema
+        let merge_type = type_::merge_types(&mut to.type_, from.type_);
+        merge_const | merge_columns | merge_aggs | merge_schema | merge_type
     }
 
     /// Modify the graph after analyzing a node.

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -33,6 +33,8 @@ mod plan;
 mod schema;
 mod type_;
 
+pub use self::type_::TypeError;
+
 /// Returns all rules in the optimizer.
 pub fn all_rules() -> Vec<Rewrite> {
     let mut rules = vec![];

--- a/src/planner/rules/type_.rs
+++ b/src/planner/rules/type_.rs
@@ -1,0 +1,121 @@
+use super::*;
+use crate::types::{DataType, DataTypeKind as Kind};
+
+/// The data type of type analysis.
+pub type Type = Result<DataType, TypeError>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TypeError {
+    /// NULL expression can be any type.
+    Null,
+    /// The type should be set manually.
+    Uninit,
+    /// Type is not available for node.
+    Unavailable,
+    /// Invalid type for function.
+    NoFunction { op: String, operands: Vec<Kind> },
+}
+
+/// Returns data type of the expression.
+pub fn analyze_type(egraph: &EGraph, enode: &Expr) -> Type {
+    use Expr::*;
+    let x = |i: &Id| egraph[*i].data.type_.clone();
+    match enode {
+        // values
+        Constant(v) => Ok(v.data_type().ok_or(TypeError::Null)?),
+        Type(t) => Ok(t.clone().nullable()),
+        Column(_) | ColumnIndex(_) => Err(TypeError::Uninit), // binder should set the type
+
+        // number ops
+        Neg(a) => x(a),
+        Add([a, b]) | Sub([a, b]) | Mul([a, b]) | Div([a, b]) | Mod([a, b]) => {
+            merge(enode, [x(a)?, x(b)?], |[a, b]| a == b, |[a, _]| a)
+        }
+
+        // string ops
+        StringConcat([a, b]) | Like([a, b]) => merge(
+            enode,
+            [x(a)?, x(b)?],
+            |[a, b]| a == Kind::String && b == Kind::String,
+            |_| Kind::String,
+        ),
+
+        // bool ops
+        Not(a) => check(enode, x(a)?, |a| a == Kind::Bool),
+        Gt([a, b]) | Lt([a, b]) | GtEq([a, b]) | LtEq([a, b]) | Eq([a, b]) | NotEq([a, b])
+        | And([a, b]) | Or([a, b]) | Xor([a, b]) => merge(
+            enode,
+            [x(a)?, x(b)?],
+            |[a, b]| a == Kind::Bool && b == Kind::Bool,
+            |_| Kind::Bool,
+        ),
+        If([cond, then, else_]) => merge(
+            enode,
+            [x(cond)?, x(then)?, x(else_)?],
+            |[cond, then, else_]| cond == Kind::Bool && then == else_,
+            |[_, then, _]| then,
+        ),
+
+        // null ops
+        IsNull(_) => Ok(Kind::Bool.not_null()),
+
+        // number agg
+        Max(a) | Min(a) => x(a),
+        Sum(a) => check(enode, x(a)?, |a| a.is_number()),
+        Avg(a) => check(enode, x(a)?, |a| a.is_number()),
+
+        // agg
+        RowCount | Count(_) => Ok(Kind::Int32.not_null()),
+        First(a) | Last(a) => x(a),
+
+        // other plan nodes
+        _ => Err(TypeError::Unavailable),
+    }
+}
+
+/// Merge two type analysis results.
+pub fn merge_types(to: &mut Type, from: Type) -> DidMerge {
+    match (to, from) {
+        (Err(_), Err(_)) => DidMerge(false, true),
+        (to @ Err(_), from @ Ok(_)) => {
+            *to = from;
+            DidMerge(true, false)
+        }
+        (Ok(_), Err(_)) => DidMerge(false, true),
+        (Ok(a), Ok(b)) => {
+            assert_eq!(*a, b);
+            DidMerge(false, true)
+        }
+    }
+}
+
+fn check(enode: &Expr, a: DataType, check: impl FnOnce(Kind) -> bool) -> Type {
+    if check(a.kind()) {
+        Ok(a)
+    } else {
+        Err(TypeError::NoFunction {
+            op: enode.to_string(),
+            operands: vec![a.kind()],
+        })
+    }
+}
+
+fn merge<const N: usize>(
+    enode: &Expr,
+    types: [DataType; N],
+    can_merge: impl FnOnce([Kind; N]) -> bool,
+    merge: impl FnOnce([Kind; N]) -> Kind,
+) -> Type {
+    let kinds = types.map(|t| t.kind());
+    if can_merge(kinds) {
+        Ok(DataType {
+            kind: merge(kinds),
+            nullable: types.map(|t| t.nullable).iter().any(|b| *b),
+        })
+    } else {
+        Err(TypeError::NoFunction {
+            op: enode.to_string(),
+            operands: kinds.into(),
+        })
+    }
+}

--- a/src/planner/rules/type_.rs
+++ b/src/planner/rules/type_.rs
@@ -4,15 +4,15 @@ use crate::types::{DataType, DataTypeKind as Kind};
 /// The data type of type analysis.
 pub type Type = Result<DataType, TypeError>;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum TypeError {
-    /// NULL expression can be any type.
+    #[error("unknown type from null")]
     Null,
-    /// The type should be set manually.
+    #[error("the type should be set manually")]
     Uninit,
-    /// Type is not available for node.
+    #[error("type is not available for node")]
     Unavailable,
-    /// Invalid type for function.
+    #[error("no function for {op}{operands:?}")]
     NoFunction { op: String, operands: Vec<Kind> },
 }
 

--- a/src/planner/rules/type_.rs
+++ b/src/planner/rules/type_.rs
@@ -23,7 +23,7 @@ pub fn analyze_type(egraph: &EGraph, enode: &Expr) -> Type {
     match enode {
         // values
         Constant(v) => Ok(v.data_type().ok_or(TypeError::Null)?),
-        Type(t) => Ok(t.clone().not_null()),
+        Type(t) => Ok((*t).not_null()),
         Column(_) | ColumnIndex(_) => Err(TypeError::Uninit), // binder should set the type
 
         // cast

--- a/src/types/interval.rs
+++ b/src/types/interval.rs
@@ -154,6 +154,7 @@ impl FromStr for Interval {
         let mut seconds = 0;
 
         let mut last_val: Option<i32> = None;
+        let s = s.replace('_', " "); // allow '_' as alias for space
         for token in s.trim().split_ascii_whitespace() {
             if let Some(val) = last_val {
                 match token {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -356,6 +356,10 @@ pub enum ConvertError {
     Cast(String, &'static str),
     #[error("constant {0:?} overflows {1:?}")]
     Overflow(DataValue, DataTypeKind),
+    #[error("no function {0}({1})")]
+    NoUnaryOp(String, &'static str),
+    #[error("no function {0}({1}, {2})")]
+    NoBinaryOp(String, &'static str, &'static str),
 }
 
 /// memory table row type

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -21,7 +21,7 @@ pub use self::interval::*;
 pub use self::native::*;
 
 /// Physical data type
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum DataTypeKind {
     Int32,
     Int64,
@@ -34,6 +34,15 @@ pub enum DataTypeKind {
     Decimal(Option<u8>, Option<u8>),
     Date,
     Interval,
+}
+
+impl DataTypeKind {
+    pub const fn is_number(&self) -> bool {
+        matches!(
+            self,
+            Self::Int32 | Self::Int64 | Self::Float64 | Self::Decimal(_, _)
+        )
+    }
 }
 
 impl From<&crate::parser::DataType> for DataTypeKind {
@@ -117,7 +126,7 @@ impl FromStr for DataTypeKind {
 }
 
 /// Data type with nullable.
-#[derive(Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct DataType {
     pub kind: DataTypeKind,
     pub nullable: bool,
@@ -125,7 +134,7 @@ pub struct DataType {
 
 impl std::fmt::Debug for DataType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.kind)?;
+        write!(f, "{}", self.kind)?;
         if self.nullable {
             write!(f, " (nullable)")?;
         }
@@ -135,11 +144,7 @@ impl std::fmt::Debug for DataType {
 
 impl std::fmt::Display for DataType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.kind)?;
-        if self.nullable {
-            write!(f, " (nullable)")?;
-        }
-        Ok(())
+        write!(f, "{:?}", self)
     }
 }
 
@@ -153,7 +158,7 @@ impl DataType {
     }
 
     pub fn kind(&self) -> DataTypeKind {
-        self.kind.clone()
+        self.kind
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -371,6 +371,8 @@ pub enum ParseValueError {
     ParseIntervalError(#[from] ParseIntervalError),
     #[error("invalid date: {0}")]
     ParseDateError(#[from] ParseDateError),
+    #[error("invalid blob: {0}")]
+    ParseBlobError(#[from] ParseBlobError),
     #[error("invalid value: {0}")]
     Invalid(String),
 }
@@ -391,6 +393,8 @@ impl FromStr for DataValue {
             Ok(Self::Float64(float))
         } else if s.starts_with('\'') && s.ends_with('\'') {
             Ok(Self::String(s[1..s.len() - 1].to_string()))
+        } else if s.starts_with("b\'") && s.ends_with('\'') {
+            Ok(Self::Blob(s[2..s.len() - 1].parse()?))
         } else if let Some(s) = s.strip_prefix("interval") {
             Ok(Self::Interval(s.trim().trim_matches('\'').parse()?))
         } else if let Some(s) = s.strip_prefix("date") {


### PR DESCRIPTION
This PR adds a type checker to the new planner. It is implemented as an egg analysis. Each `Expr` node will be associated with a type analysis result, which can be either a type or an error. If a type error is found after constructing a node, the binder will return the error:

```
> create table t (a int, b boolean);
created
in 0.004s
> \v2
switched to planner v2
in 0.000s
> select a + b from t;
bind error: type error: no function for +[Int32, Bool]
```

Note that the type checker in this PR is far from complete. For example, it only allows binary operations on values of the same type (INT + INT ✅), and doesn't support implicit type cast yet (INT + DOUBLE ❌). I've added some failing tests to show these limits. They will be fixed in the future.