### PR TITLE
fix(type): add NULL type and fix type analysis

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -339,6 +339,7 @@ macro_rules! impl_array_builder {
             pub fn with_capacity(capacity: usize, ty: &DataType) -> Self {
                 use DataTypeKind::*;
                 match ty.kind() {
+                    Null => Self::Int32(I32ArrayBuilder::with_capacity(capacity)),
                     $(
                         $Type => Self::$Abc(<$AbcArrayBuilder>::with_capacity(capacity)),
                     )*

--- a/src/binder/expression/agg_call.rs
+++ b/src/binder/expression/agg_call.rs
@@ -99,18 +99,12 @@ impl Binder {
                 if args.is_empty() {
                     let first_index_column = BoundExpr::InputRef(BoundInputRef {
                         index: 0,
-                        return_type: DataType::new(DataTypeKind::Int32, false),
+                        return_type: DataTypeKind::Int32.not_null(),
                     });
                     args.push(first_index_column);
-                    (
-                        AggKind::RowCount,
-                        Some(DataType::new(DataTypeKind::Int32, false)),
-                    )
+                    (AggKind::RowCount, DataTypeKind::Int32.not_null())
                 } else {
-                    (
-                        AggKind::Count,
-                        Some(DataType::new(DataTypeKind::Int32, false)),
-                    )
+                    (AggKind::Count, DataTypeKind::Int32.not_null())
                 }
             }
             "max" => (AggKind::Max, args[0].return_type()),
@@ -128,14 +122,14 @@ impl Binder {
                 left_expr: Box::new(BoundExpr::AggCall(BoundAggCall {
                     kind: AggKind::Sum,
                     args: args.clone(),
-                    return_type: args[0].return_type().unwrap(),
+                    return_type: args[0].return_type(),
                 })),
                 right_expr: Box::new(BoundExpr::TypeCast(BoundTypeCast {
-                    ty: args[0].return_type().unwrap().kind(),
+                    ty: args[0].return_type().kind(),
                     expr: Box::new(BoundExpr::AggCall(BoundAggCall {
                         kind: AggKind::Count,
                         args,
-                        return_type: DataType::new(DataTypeKind::Int32, false),
+                        return_type: DataTypeKind::Int32.not_null(),
                     })),
                 })),
                 return_type,
@@ -143,7 +137,7 @@ impl Binder {
             _ => Ok(BoundExpr::AggCall(BoundAggCall {
                 kind,
                 args,
-                return_type: return_type.unwrap(),
+                return_type,
             })),
         }
     }

--- a/src/binder/expression/binary_op.rs
+++ b/src/binder/expression/binary_op.rs
@@ -12,7 +12,7 @@ pub struct BoundBinaryOp {
     pub op: BinaryOperator,
     pub left_expr: Box<BoundExpr>,
     pub right_expr: Box<BoundExpr>,
-    pub return_type: Option<DataType>,
+    pub return_type: DataType,
 }
 
 impl std::fmt::Debug for BoundBinaryOp {
@@ -45,60 +45,48 @@ impl Binder {
         let mut right_bound_expr = self.bind_expr(right)?;
 
         // Implicit type cast
-        let left_data_type_kind = match (
-            left_bound_expr.return_type(),
-            right_bound_expr.return_type(),
-        ) {
-            (Some(left_data_type), Some(right_data_type)) => {
-                let left_physical_kind = left_data_type.kind();
-                let right_physical_kind = right_data_type.kind();
-                let mut return_type_tmp = left_data_type.kind();
-                // Check if implicit type conversion is needed
-                if left_physical_kind != right_physical_kind {
-                    // Insert type cast expr
-                    match (left_physical_kind, right_physical_kind) {
-                        (Float64 | Decimal(_, _), Int32 | Int64)
-                        | (Int64, Int32)
-                        | (Date, String)
-                        | (Decimal(_, _), Float64) => {
-                            right_bound_expr = BoundExpr::TypeCast(BoundTypeCast {
-                                expr: Box::new(right_bound_expr),
-                                ty: left_data_type.kind(),
-                            });
-                        }
-                        (Int32 | Int64, Float64 | Decimal(_, _))
-                        | (Int32, Int64)
-                        | (String, Date)
-                        | (Float64, Decimal(_, _)) => {
-                            left_bound_expr = BoundExpr::TypeCast(BoundTypeCast {
-                                expr: Box::new(left_bound_expr),
-                                ty: right_data_type.kind(),
-                            });
-                            return_type_tmp = right_data_type.kind();
-                        }
-                        (Date, Interval) => {}
-                        (left_kind, right_kind) => todo!(
-                            "Support implicit conversion of {:?} and {:?}",
-                            left_kind,
-                            right_kind
-                        ),
+        let left_data_type_kind = {
+            let left_kind = left_bound_expr.return_type().kind();
+            let right_kind = right_bound_expr.return_type().kind();
+            let mut return_type_tmp = left_kind;
+            // Check if implicit type conversion is needed
+            if left_kind != right_kind {
+                // Insert type cast expr
+                match (left_kind, right_kind) {
+                    (Float64 | Decimal(_, _), Int32 | Int64)
+                    | (Int64, Int32)
+                    | (Date, String)
+                    | (Decimal(_, _), Float64) => {
+                        right_bound_expr = BoundExpr::TypeCast(BoundTypeCast {
+                            expr: Box::new(right_bound_expr),
+                            ty: left_kind,
+                        });
                     }
+                    (Int32 | Int64, Float64 | Decimal(_, _))
+                    | (Int32, Int64)
+                    | (String, Date)
+                    | (Float64, Decimal(_, _)) => {
+                        left_bound_expr = BoundExpr::TypeCast(BoundTypeCast {
+                            expr: Box::new(left_bound_expr),
+                            ty: right_kind,
+                        });
+                        return_type_tmp = right_kind;
+                    }
+                    (Date, Interval) => {}
+                    _ => todo!(
+                        "Support implicit conversion of {:?} and {:?}",
+                        left_kind,
+                        right_kind
+                    ),
                 }
-                Some(return_type_tmp.nullable())
             }
-            (None, None) => None,
-            (left, right) => {
-                return Err(BindError::BinaryOpTypeMismatch(
-                    format!("{:?}", left),
-                    format!("{:?}", right),
-                ))
-            }
+            return_type_tmp.nullable()
         };
 
         let return_type = match op {
             Op::Plus | Op::Minus | Op::Multiply | Op::Divide | Op::Modulo => left_data_type_kind,
             Op::Gt | Op::GtEq | Op::Lt | Op::LtEq | Op::Eq | Op::NotEq | Op::And | Op::Or => {
-                Some(DataTypeKind::Bool.nullable())
+                DataTypeKind::Bool.nullable()
             }
             _ => todo!("Support more binary operators"),
         };

--- a/src/binder/expression/mod.rs
+++ b/src/binder/expression/mod.rs
@@ -43,16 +43,16 @@ pub enum BoundExpr {
 }
 
 impl BoundExpr {
-    pub fn return_type(&self) -> Option<DataType> {
+    pub fn return_type(&self) -> DataType {
         match self {
             Self::Constant(v) => v.data_type(),
-            Self::ColumnRef(expr) => Some(*expr.desc.datatype()),
+            Self::ColumnRef(expr) => *expr.desc.datatype(),
             Self::BinaryOp(expr) => expr.return_type,
             Self::UnaryOp(expr) => expr.return_type,
-            Self::TypeCast(expr) => Some(expr.ty.nullable()),
-            Self::AggCall(expr) => Some(expr.return_type),
-            Self::InputRef(expr) => Some(expr.return_type),
-            Self::IsNull(_) => Some(DataTypeKind::Bool.not_null()),
+            Self::TypeCast(expr) => expr.ty.nullable(),
+            Self::AggCall(expr) => expr.return_type,
+            Self::InputRef(expr) => expr.return_type,
+            Self::IsNull(_) => DataTypeKind::Bool.not_null(),
             Self::ExprWithAlias(expr) => expr.expr.return_type(),
             Self::Alias(expr) => expr.expr.return_type(),
         }
@@ -207,7 +207,7 @@ impl Binder {
                 Ok(BoundExpr::UnaryOp(BoundUnaryOp {
                     op: UnaryOperator::Not,
                     expr: Box::new(expr),
-                    return_type: Some(DataTypeKind::Bool.not_null()),
+                    return_type: DataTypeKind::Bool.not_null(),
                 }))
             }
             Expr::TypedString { data_type, value } => self.bind_typed_string(data_type, value),
@@ -257,7 +257,7 @@ impl Binder {
             op: final_op,
             left_expr: Box::new(left_expr),
             right_expr: Box::new(right_expr),
-            return_type: Some(DataType::new(DataTypeKind::Bool, false)),
+            return_type: DataTypeKind::Bool.not_null(),
         }))
     }
 }
@@ -340,7 +340,7 @@ mod tests {
         let expr = BoundExpr::UnaryOp(BoundUnaryOp {
             op: UnaryOperator::Minus,
             expr: Box::new(expr),
-            return_type: Some(data_type),
+            return_type: data_type,
         });
         assert_eq!("-a", expr.format_name(&child_schema));
     }
@@ -361,7 +361,7 @@ mod tests {
                 op: BinaryOperator::Plus,
                 left_expr: Box::new(left_expr),
                 right_expr: Box::new(right_expr),
-                return_type: Some(DataType::new(DataTypeKind::Int32, true)),
+                return_type: DataTypeKind::Int32.nullable(),
             });
             assert_eq!("a+1", expr.format_name(&child_schema));
         }
@@ -385,7 +385,7 @@ mod tests {
                 op: BinaryOperator::Plus,
                 left_expr: Box::new(left_expr),
                 right_expr: Box::new(right_expr),
-                return_type: Some(data_type),
+                return_type: data_type,
             });
             assert_eq!("a+b", expr.format_name(&child_schema));
         }

--- a/src/binder/expression/unary_op.rs
+++ b/src/binder/expression/unary_op.rs
@@ -10,7 +10,7 @@ use crate::parser::UnaryOperator;
 pub struct BoundUnaryOp {
     pub op: UnaryOperator,
     pub expr: Box<BoundExpr>,
-    pub return_type: Option<DataType>,
+    pub return_type: DataType,
 }
 
 impl Binder {

--- a/src/binder/statement/insert.rs
+++ b/src/binder/statement/insert.rs
@@ -98,11 +98,11 @@ impl Binder {
                 // Bind expression
                 let mut expr = self.bind_expr(expr)?;
 
-                if let Some(data_type) = &expr.return_type() {
+                if !expr.return_type().kind().is_null() {
                     // table t1(a float, b float)
                     // for example: insert into values (1, 1);
                     // 1 should be casted to float.
-                    let left_kind = data_type.kind();
+                    let left_kind = expr.return_type().kind();
                     let right_kind = column_types[idx].kind();
                     if left_kind != right_kind {
                         expr = BoundExpr::TypeCast(BoundTypeCast {
@@ -143,11 +143,11 @@ impl Binder {
     ) -> Result<BoundInsert, BindError> {
         let mut bound_select_stmt = self.bind_select(select_stmt)?;
         for (idx, expr) in bound_select_stmt.select_list.iter_mut().enumerate() {
-            if let Some(data_type) = &expr.return_type() {
+            if !expr.return_type().kind().is_null() {
                 // table t1(a float, b float)
                 // for example: insert into values (1, 1);
                 // 1 should be casted to float.
-                let left_kind = data_type.kind();
+                let left_kind = expr.return_type().kind();
                 let right_kind = column_types[idx].kind();
                 if left_kind != right_kind {
                     *expr = BoundExpr::TypeCast(BoundTypeCast {

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -24,12 +24,8 @@ impl BoundExpr {
                 array.unary_op(&op.op)
             }
             BoundExpr::Constant(v) => {
-                let mut builder = ArrayBuilderImpl::with_capacity(
-                    chunk.cardinality(),
-                    &self
-                        .return_type()
-                        .unwrap_or_else(|| DataTypeKind::Int32.nullable()),
-                );
+                let mut builder =
+                    ArrayBuilderImpl::with_capacity(chunk.cardinality(), &self.return_type());
                 // TODO: optimize this
                 for _ in 0..chunk.cardinality() {
                     builder.push(v);
@@ -78,8 +74,7 @@ impl BoundExpr {
                 array.unary_op(&op.op)
             }
             BoundExpr::Constant(v) => {
-                let mut builder =
-                    ArrayBuilderImpl::with_capacity(cardinality, &self.return_type().unwrap());
+                let mut builder = ArrayBuilderImpl::with_capacity(cardinality, &self.return_type());
                 // TODO: optimize this
                 for _ in 0..cardinality {
                     builder.push(v);

--- a/src/executor/hash_agg.rs
+++ b/src/executor/hash_agg.rs
@@ -71,7 +71,7 @@ impl HashAggExecutor {
         while let Some(batch) = batches.next() {
             let mut key_builders = group_keys
                 .iter()
-                .map(|e| ArrayBuilderImpl::new(&e.return_type().unwrap()))
+                .map(|e| ArrayBuilderImpl::new(&e.return_type()))
                 .collect::<Vec<ArrayBuilderImpl>>();
             let mut res_builders = agg_calls
                 .iter()

--- a/src/executor/perfect_hash_agg.rs
+++ b/src/executor/perfect_hash_agg.rs
@@ -102,7 +102,7 @@ impl PerfectHashAggExecutor {
     ) -> DataChunk {
         let mut key_builders = group_keys
             .iter()
-            .map(|e| ArrayBuilderImpl::new(&e.return_type().unwrap()))
+            .map(|e| ArrayBuilderImpl::new(&e.return_type()))
             .collect::<Vec<ArrayBuilderImpl>>();
         let mut res_builders = agg_calls
             .iter()
@@ -113,7 +113,7 @@ impl PerfectHashAggExecutor {
             need_shift_bits_num -= bits[idx];
             let mask = (1usize << bits[idx]) - 1;
             let key_builder = &mut key_builders[idx];
-            match group_keys[idx].return_type().unwrap().kind {
+            match group_keys[idx].return_type().kind {
                 DataTypeKind::Bool => locations.iter().for_each(|location| {
                     let value = (location >> need_shift_bits_num) & mask;
                     if value == 0 {

--- a/src/executor/simple_agg.rs
+++ b/src/executor/simple_agg.rs
@@ -6,7 +6,7 @@ use smallvec::SmallVec;
 use super::*;
 use crate::array::{ArrayBuilderImpl, ArrayImpl};
 use crate::binder::{AggKind, BoundAggCall};
-use crate::types::{DataTypeKind, DataValue};
+use crate::types::DataValue;
 
 /// The executor of simple aggregation.
 pub struct SimpleAggExecutor {
@@ -38,18 +38,9 @@ impl SimpleAggExecutor {
             .iter()
             .map(|s| {
                 let result = &s.output();
-                match &result.data_type() {
-                    Some(r) => {
-                        let mut builder = ArrayBuilderImpl::with_capacity(1, r);
-                        builder.push(result);
-                        builder.finish()
-                    }
-                    None => {
-                        let mut builder = ArrayBuilderImpl::new(&DataTypeKind::Int32.nullable());
-                        builder.push(result);
-                        builder.finish()
-                    }
-                }
+                let mut builder = ArrayBuilderImpl::with_capacity(1, &result.data_type());
+                builder.push(result);
+                builder.finish()
             })
             .collect::<DataChunk>()
     }

--- a/src/executor/sort_agg.rs
+++ b/src/executor/sort_agg.rs
@@ -5,7 +5,6 @@ use smallvec::SmallVec;
 use super::*;
 use crate::array::{ArrayBuilderImpl, ArrayImpl};
 use crate::binder::BoundAggCall;
-use crate::types::DataTypeKind;
 
 pub struct SortAggExecutor {
     pub agg_calls: Vec<BoundAggCall>,
@@ -64,14 +63,9 @@ impl SortAggExecutor {
             .iter()
             .map(|s| {
                 let result = &s.output();
-                match &result.data_type() {
-                    Some(r) => {
-                        let mut builder = ArrayBuilderImpl::with_capacity(1, r);
-                        builder.push(result);
-                        builder.finish()
-                    }
-                    None => ArrayBuilderImpl::new(&DataTypeKind::Int32.nullable()).finish(),
-                }
+                let mut builder = ArrayBuilderImpl::with_capacity(1, &result.data_type());
+                builder.push(result);
+                builder.finish()
             })
             .collect::<DataChunk>();
     }

--- a/src/logical_planner/select.rs
+++ b/src/logical_planner/select.rs
@@ -55,7 +55,7 @@ impl LogicalPlaner {
             plan = Arc::new(LogicalValues::new(
                 stmt.select_list
                     .iter()
-                    .map(|expr| expr.return_type().unwrap())
+                    .map(|expr| expr.return_type())
                     .collect_vec(),
                 vec![stmt.select_list.clone()],
             ));
@@ -420,7 +420,7 @@ impl<'a> AliasExtractor<'a> {
                 let select_item = &self.select_list[index];
                 let input_ref = InputRef(BoundInputRef {
                     index,
-                    return_type: select_item.return_type().unwrap(),
+                    return_type: select_item.return_type(),
                 });
                 BoundOrderBy {
                     expr: input_ref,
@@ -451,7 +451,7 @@ mod tests {
             op: BinaryOperator::Plus,
             left_expr: v2.clone().into(),
             right_expr: BoundExpr::Constant(DataValue::Int32(1)).into(),
-            return_type: Some(DataTypeKind::Int32.not_null()),
+            return_type: DataTypeKind::Int32.not_null(),
         });
         assert!(
             validate_illegal_column(&mut [v2_plus_1.clone()], &mut [v2_plus_1.clone()], &[])
@@ -490,7 +490,7 @@ mod tests {
             op: BinaryOperator::Plus,
             left_expr: v2.clone().into(),
             right_expr: BoundExpr::Constant(DataValue::Int32(2)).into(),
-            return_type: Some(DataTypeKind::Int32.not_null()),
+            return_type: DataTypeKind::Int32.not_null(),
         });
         let count_wildcard = BoundExpr::AggCall(BoundAggCall {
             kind: AggKind::Count,
@@ -501,7 +501,7 @@ mod tests {
             op: BinaryOperator::Plus,
             left_expr: v2_plus_2.into(),
             right_expr: count_wildcard.clone().into(),
-            return_type: Some(DataTypeKind::Int32.not_null()),
+            return_type: DataTypeKind::Int32.not_null(),
         });
         assert!(
             validate_illegal_column(&mut [v2_puls_2_plus_count], &mut [v2_plus_1], &[]).is_err()
@@ -512,7 +512,7 @@ mod tests {
             op: BinaryOperator::Plus,
             left_expr: v2.clone().into(),
             right_expr: count_wildcard.into(),
-            return_type: Some(DataTypeKind::Int32.not_null()),
+            return_type: DataTypeKind::Int32.not_null(),
         });
         let order_by_v1 = BoundOrderBy {
             expr: v1,

--- a/src/optimizer/expr_utils.rs
+++ b/src/optimizer/expr_utils.rs
@@ -34,7 +34,7 @@ where
             op: And,
             left_expr: Box::new(ret),
             right_expr: Box::new(expr),
-            return_type: Some(DataTypeKind::Bool.nullable()),
+            return_type: DataTypeKind::Bool.nullable(),
         })
     }
     let rewriter = BoolExprSimplificationRule {};

--- a/src/optimizer/logical_plan_rewriter/input_ref_resolver.rs
+++ b/src/optimizer/logical_plan_rewriter/input_ref_resolver.rs
@@ -30,7 +30,7 @@ impl InputRefResolver {
         {
             *expr = InputRef(BoundInputRef {
                 index: idx,
-                return_type: expr.return_type().unwrap(),
+                return_type: expr.return_type(),
             });
             return;
         }
@@ -188,7 +188,7 @@ impl AggInputRefResolver {
         if let Some(i) = group_keys.iter().position(|e| e == expr) {
             *expr = InputRef(BoundInputRef {
                 index: i,
-                return_type: expr.return_type().unwrap(),
+                return_type: expr.return_type(),
             });
             return;
         }
@@ -251,7 +251,7 @@ mod tests {
             })
             .into(),
             right_expr: BoundExpr::Constant(DataValue::Int32(1)).into(),
-            return_type: Some(DataTypeKind::Int32.not_null()),
+            return_type: DataTypeKind::Int32.not_null(),
         });
         let group_keys = vec![v2_plus_1_expr.clone()];
         let mut select_list = vec![v2_plus_1_expr, sum_v1_call];
@@ -302,13 +302,13 @@ mod tests {
             op: BinaryOperator::Plus,
             left_expr: v2_expr.into(),
             right_expr: BoundExpr::Constant(DataValue::Int32(1)).into(),
-            return_type: Some(DataTypeKind::Int32.not_null()),
+            return_type: DataTypeKind::Int32.not_null(),
         });
         let v2_plus_1_plus_sum_expr = BoundExpr::BinaryOp(BoundBinaryOp {
             op: BinaryOperator::Plus,
             left_expr: v2_plus_1_expr.clone().into(),
             right_expr: sum_v1_call.into(),
-            return_type: Some(DataTypeKind::Int32.not_null()),
+            return_type: DataTypeKind::Int32.not_null(),
         });
         let group_keys = vec![v2_plus_1_expr];
         let mut select_list = vec![v2_plus_1_plus_sum_expr];
@@ -332,7 +332,7 @@ mod tests {
                     return_type: DataTypeKind::Int32.not_null(),
                 })
                 .into(),
-                return_type: Some(DataTypeKind::Int32.not_null()),
+                return_type: DataTypeKind::Int32.not_null(),
             })
         );
     }

--- a/src/optimizer/plan_nodes/join_predicate.rs
+++ b/src/optimizer/plan_nodes/join_predicate.rs
@@ -132,7 +132,7 @@ impl JoinPredicate {
                     op: BinaryOperator::Eq,
                     left_expr: Box::new(InputRef(l)),
                     right_expr: Box::new(InputRef(r)),
-                    return_type: Some(DataTypeKind::Bool.nullable()),
+                    return_type: DataTypeKind::Bool.nullable(),
                 })
             })
             .collect()

--- a/src/optimizer/plan_nodes/logical_aggregate.rs
+++ b/src/optimizer/plan_nodes/logical_aggregate.rs
@@ -71,13 +71,7 @@ impl PlanNode for LogicalAggregate {
         let child_schema = self.child.schema();
         self.group_keys
             .iter()
-            .map(|expr| {
-                ColumnDesc::new(
-                    expr.return_type().unwrap(),
-                    expr.format_name(&child_schema),
-                    false,
-                )
-            })
+            .map(|expr| ColumnDesc::new(expr.return_type(), expr.format_name(&child_schema), false))
             .chain(
                 self.agg_calls
                     .iter()
@@ -145,7 +139,7 @@ impl PlanNode for LogicalAggregate {
                 .map(|index| {
                     BoundExpr::InputRef(BoundInputRef {
                         index,
-                        return_type: self.group_keys[index].return_type().unwrap(),
+                        return_type: self.group_keys[index].return_type(),
                     })
                 })
                 .collect();

--- a/src/optimizer/plan_nodes/logical_filter.rs
+++ b/src/optimizer/plan_nodes/logical_filter.rs
@@ -140,7 +140,7 @@ mod tests {
                     return_type: ty,
                 })),
                 right_expr: Box::new(BoundExpr::Constant(DataValue::Int32(5))),
-                return_type: Some(ty),
+                return_type: ty,
             }),
             table_scan.into_plan_ref(),
         );
@@ -158,7 +158,7 @@ mod tests {
                     return_type: ty,
                 })),
                 right_expr: Box::new(BoundExpr::Constant(DataValue::Int32(5))),
-                return_type: Some(ty),
+                return_type: ty,
             })
         );
         let child = plan.child.as_logical_table_scan().unwrap();
@@ -206,7 +206,7 @@ mod tests {
                     return_type: ty,
                 })),
                 right_expr: Box::new(BoundExpr::Constant(DataValue::Int32(5))),
-                return_type: Some(ty),
+                return_type: ty,
             }),
             table_scan.into_plan_ref(),
         );

--- a/src/optimizer/plan_nodes/logical_projection.rs
+++ b/src/optimizer/plan_nodes/logical_projection.rs
@@ -24,7 +24,7 @@ impl ExprRewriter for Substitute {
     fn rewrite_input_ref(&self, input_ref: &mut BoundExpr) {
         match input_ref {
             BoundExpr::InputRef(i) => {
-                assert_eq!(self.mapping[i.index].return_type(), Some(i.return_type));
+                assert_eq!(self.mapping[i.index].return_type(), i.return_type);
                 *input_ref = self.mapping[i.index].clone();
             }
             _ => unreachable!(),
@@ -95,7 +95,7 @@ impl PlanNode for LogicalProjection {
                     }
                     _ => "?column?".to_string(),
                 };
-                expr.return_type().unwrap().to_column(name)
+                expr.return_type().to_column(name)
             })
             .collect()
     }

--- a/src/optimizer/plan_nodes/logical_values.rs
+++ b/src/optimizer/plan_nodes/logical_values.rs
@@ -53,7 +53,7 @@ impl PlanNode for LogicalValues {
             .iter()
             .map(|expr| {
                 let name = "?column?".to_string();
-                expr.return_type().unwrap().to_column(name)
+                expr.return_type().to_column(name)
             })
             .collect()
     }

--- a/src/optimizer/rules/filter_join_rule.rs
+++ b/src/optimizer/rules/filter_join_rule.rs
@@ -28,7 +28,7 @@ impl Rule for FilterJoinRule {
             op: And,
             left_expr: Box::new(filter_cond),
             right_expr: Box::new(join_on_clause),
-            return_type: Some(DataTypeKind::Bool.nullable()),
+            return_type: DataTypeKind::Bool.nullable(),
         });
         let left_col_num = join.left().out_types().len();
         let inner_join_predicate = JoinPredicate::create(left_col_num, new_inner_join_cond);

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -99,7 +99,7 @@ impl Analysis<Expr> for ExprAnalysis {
         let merge_columns = merge_small_set(&mut to.columns, from.columns);
         let merge_aggs = merge_small_set(&mut to.aggs, from.aggs);
         let merge_schema = egg::merge_max(&mut to.schema, from.schema);
-        let merge_type = type_::merge_types(&mut to.type_, from.type_);
+        let merge_type = egg::merge_max(&mut to.type_, from.type_);
         merge_const | merge_columns | merge_aggs | merge_schema | merge_type
     }
 

--- a/src/planner/rules/type_.rs
+++ b/src/planner/rules/type_.rs
@@ -27,38 +27,39 @@ pub fn analyze_type(egraph: &EGraph, enode: &Expr) -> Type {
         Column(_) | ColumnIndex(_) => Err(TypeError::Uninit), // binder should set the type
 
         // cast
-        Cast([ty, a]) => merge(enode, [x(ty)?, x(a)?], |_| true, |[ty, _]| ty),
+        Cast([ty, a]) => merge(enode, [x(ty)?, x(a)?], |[ty, _]| Some(ty)),
 
         // number ops
         Neg(a) => x(a),
         Add([a, b]) | Sub([a, b]) | Mul([a, b]) | Div([a, b]) | Mod([a, b]) => {
-            merge(enode, [x(a)?, x(b)?], |[a, b]| a == b, |[a, _]| a)
+            merge(enode, [x(a)?, x(b)?], |[a, b]| match (a.min(b), a.max(b)) {
+                _ if a == b && a.is_number() => Some(a),
+                (Kind::Int32 | Kind::Int64, b @ Kind::Decimal(_, _) | b @ Kind::Float64) => Some(b),
+                (Kind::Date, Kind::Interval) => Some(Kind::Date),
+                _ => None,
+            })
         }
 
         // string ops
-        StringConcat([a, b]) | Like([a, b]) => merge(
-            enode,
-            [x(a)?, x(b)?],
-            |[a, b]| a == Kind::String && b == Kind::String,
-            |_| Kind::String,
-        ),
+        StringConcat([a, b]) | Like([a, b]) => merge(enode, [x(a)?, x(b)?], |[a, b]| {
+            (a == Kind::String && b == Kind::String).then_some(Kind::String)
+        }),
 
         // bool ops
         Not(a) => check(enode, x(a)?, |a| a == Kind::Bool),
         Gt([a, b]) | Lt([a, b]) | GtEq([a, b]) | LtEq([a, b]) | Eq([a, b]) | NotEq([a, b]) => {
-            merge(enode, [x(a)?, x(b)?], |[a, b]| a == b, |_| Kind::Bool)
+            merge(enode, [x(a)?, x(b)?], |[a, b]| {
+                (a.is_number() && b.is_number() || a == b || a == Kind::String || b == Kind::String)
+                    .then_some(Kind::Bool)
+            })
         }
-        And([a, b]) | Or([a, b]) | Xor([a, b]) => merge(
-            enode,
-            [x(a)?, x(b)?],
-            |[a, b]| a == Kind::Bool && b == Kind::Bool,
-            |_| Kind::Bool,
-        ),
+        And([a, b]) | Or([a, b]) | Xor([a, b]) => merge(enode, [x(a)?, x(b)?], |[a, b]| {
+            (a == Kind::Bool && b == Kind::Bool).then_some(Kind::Bool)
+        }),
         If([cond, then, else_]) => merge(
             enode,
             [x(cond)?, x(then)?, x(else_)?],
-            |[cond, then, else_]| cond == Kind::Bool && then == else_,
-            |[_, then, _]| then,
+            |[cond, then, else_]| (cond == Kind::Bool && then == else_).then_some(then),
         ),
 
         // null ops
@@ -105,13 +106,12 @@ fn check(enode: &Expr, a: DataType, check: impl FnOnce(Kind) -> bool) -> Type {
 fn merge<const N: usize>(
     enode: &Expr,
     types: [DataType; N],
-    can_merge: impl FnOnce([Kind; N]) -> bool,
-    merge: impl FnOnce([Kind; N]) -> Kind,
+    merge: impl FnOnce([Kind; N]) -> Option<Kind>,
 ) -> Type {
     let kinds = types.map(|t| t.kind());
-    if can_merge(kinds) {
+    if let Some(kind) = merge(kinds) {
         Ok(DataType {
-            kind: merge(kinds),
+            kind,
             nullable: types.map(|t| t.nullable).iter().any(|b| *b),
         })
     } else {
@@ -132,7 +132,7 @@ mod tests {
         assert_type_eq("false", Ok(Kind::Bool.not_null()));
         assert_type_eq("true", Ok(Kind::Bool.not_null()));
         assert_type_eq("1", Ok(Kind::Int32.not_null()));
-        assert_type_eq("1.0", Ok(Kind::Float64.not_null()));
+        assert_type_eq("1.0", Ok(Kind::Decimal(None, None).not_null()));
         assert_type_eq("'hello'", Ok(Kind::String.not_null()));
         assert_type_eq("b'\\xAA'", Ok(Kind::Blob.not_null()));
         assert_type_eq("date'2022-10-14'", Ok(Kind::Date.not_null()));
@@ -150,29 +150,27 @@ mod tests {
     #[test]
     fn add() {
         assert_type_eq("(+ 1 2)", Ok(Kind::Int32.not_null()));
-        assert_type_eq("(+ 1.0 2.0)", Ok(Kind::Float64.not_null()));
+        assert_type_eq("(+ 1 1.0)", Ok(Kind::Decimal(None, None).not_null()));
+        assert_type_eq("(+ 1.0 2.0)", Ok(Kind::Decimal(None, None).not_null()));
         assert_type_eq("(+ null null)", Err(TypeError::Null));
         assert_type_eq(
             "(+ date'2022-10-14' interval'1_day')",
             Ok(Kind::Date.not_null()),
         );
+        assert_type_eq(
+            "(+ interval'1_day' date'2022-10-14')",
+            Ok(Kind::Date.not_null()),
+        );
         // FIXME: int + null => int
         // assert_type_eq("(+ 1 null)", Ok(Kind::Int32.nullable()));
 
-        // FIXME: interval + date => date
-        // assert_type_eq(
-        //     "(+ interval'1_day' date'2022-10-14')",
-        //     Ok(Kind::Date.not_null()),
-        // );
-
-        // FIXME: bool + bool => error
-        // assert_type_eq(
-        //     "(+ true false)",
-        //     Err(TypeError::NoFunction {
-        //         op: "+".into(),
-        //         operands: vec![Kind::Bool, Kind::Bool],
-        //     }),
-        // );
+        assert_type_eq(
+            "(+ true false)",
+            Err(TypeError::NoFunction {
+                op: "+".into(),
+                operands: vec![Kind::Bool, Kind::Bool],
+            }),
+        );
 
         assert_type_eq(
             "(+ 1 false)",
@@ -186,14 +184,13 @@ mod tests {
     #[test]
     fn cmp() {
         assert_type_eq("(= 1 1)", Ok(Kind::Bool.not_null()));
-        // FIXME: compare compatible types
-        // assert_type_eq("(= 1 1.0)", Ok(Kind::Bool.not_null()));
-        // assert_type_eq("(= 1 '1')", Ok(Kind::Bool.not_null()));
+        assert_type_eq("(= 1 1.0)", Ok(Kind::Bool.not_null()));
+        assert_type_eq("(= 1 '1')", Ok(Kind::Bool.not_null()));
         // assert_type_eq("(= 1 null)", Ok(Kind::Bool.nullable()));
-        // assert_type_eq(
-        //     "(= '2022-10-14' date'2022-10-14')",
-        //     Ok(Kind::Bool.not_null()),
-        // );
+        assert_type_eq(
+            "(= '2022-10-14' date'2022-10-14')",
+            Ok(Kind::Bool.not_null()),
+        );
         assert_type_eq(
             "(= date'2022-10-14' 1)",
             Err(TypeError::NoFunction {

--- a/src/storage/secondary/column/column_builder.rs
+++ b/src/storage/secondary/column/column_builder.rs
@@ -30,6 +30,7 @@ impl ColumnBuilderImpl {
     pub fn new_from_datatype(datatype: &DataType, options: ColumnBuilderOptions) -> Self {
         use DataTypeKind::*;
         match datatype.kind() {
+            Null => panic!("column type should not be null"),
             Int32 => Self::Int32(I32ColumnBuilder::new(datatype.nullable, options)),
             Int64 => Self::Int64(I64ColumnBuilder::new(datatype.nullable, options)),
             Bool => Self::Bool(BoolColumnBuilder::new(datatype.nullable, options)),

--- a/src/storage/secondary/column/column_iterator.rs
+++ b/src/storage/secondary/column/column_iterator.rs
@@ -33,6 +33,7 @@ impl ColumnIteratorImpl {
     ) -> StorageResult<Self> {
         use DataTypeKind::*;
         let iter = match column_info.datatype().kind() {
+            Null => panic!("column type should not be null"),
             Int32 => Self::Int32(
                 I32ColumnIterator::new(column, start_pos, PrimitiveBlockIteratorFactory::new())
                     .await?,

--- a/src/storage/secondary/rowset/rowset_iterator.rs
+++ b/src/storage/secondary/rowset/rowset_iterator.rs
@@ -397,7 +397,7 @@ mod tests {
         helper_build_rowset, helper_build_rowset_with_first_key_recorded,
     };
     use crate::storage::secondary::SecondaryRowHandler;
-    use crate::types::{DataType, DataTypeKind, DataValue};
+    use crate::types::{DataTypeKind, DataValue};
 
     #[tokio::test]
     async fn test_rowset_iterator() {
@@ -469,23 +469,16 @@ mod tests {
 
         let left_expr = Box::new(BoundExpr::InputRef(BoundInputRef {
             index: 2,
-            return_type: DataType {
-                kind: DataTypeKind::Int32,
-                nullable: true,
-            },
+            return_type: DataTypeKind::Int32.nullable(),
         }));
 
         let right_expr = Box::new(BoundExpr::Constant(DataValue::Int32(2)));
 
-        let return_type = Some(DataType {
-            kind: DataTypeKind::Bool,
-            nullable: true,
-        });
         let expr = BoundExpr::BinaryOp(BoundBinaryOp {
             op,
             left_expr,
             right_expr,
-            return_type,
+            return_type: DataTypeKind::Bool.nullable(),
         });
         let mut it = rowset
             .iter(

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -23,6 +23,7 @@ pub use self::native::*;
 /// Physical data type
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub enum DataTypeKind {
+    Null,
     Int32,
     Int64,
     // Float32,
@@ -37,6 +38,10 @@ pub enum DataTypeKind {
 }
 
 impl DataTypeKind {
+    pub const fn is_null(&self) -> bool {
+        matches!(self, Self::Null)
+    }
+
     pub const fn is_number(&self) -> bool {
         matches!(
             self,
@@ -67,6 +72,7 @@ impl From<&crate::parser::DataType> for DataTypeKind {
 impl std::fmt::Display for DataTypeKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Null => write!(f, "NULL"),
             Self::Int32 => write!(f, "INT"),
             Self::Int64 => write!(f, "BIGINT"),
             // Self::Float32 => write!(f, "REAL"),
@@ -288,19 +294,19 @@ impl DataValue {
         }
     }
 
-    /// Get the type of value. `None` means NULL.
-    pub fn data_type(&self) -> Option<DataType> {
+    /// Get the type of value.
+    pub fn data_type(&self) -> DataType {
         match self {
-            Self::Bool(_) => Some(DataTypeKind::Bool.not_null()),
-            Self::Int32(_) => Some(DataTypeKind::Int32.not_null()),
-            Self::Int64(_) => Some(DataTypeKind::Int64.not_null()),
-            Self::Float64(_) => Some(DataTypeKind::Float64.not_null()),
-            Self::String(_) => Some(DataTypeKind::String.not_null()),
-            Self::Blob(_) => Some(DataTypeKind::Blob.not_null()),
-            Self::Decimal(_) => Some(DataTypeKind::Decimal(None, None).not_null()),
-            Self::Date(_) => Some(DataTypeKind::Date.not_null()),
-            Self::Interval(_) => Some(DataTypeKind::Interval.not_null()),
-            Self::Null => None,
+            Self::Null => DataTypeKind::Null.nullable(),
+            Self::Bool(_) => DataTypeKind::Bool.not_null(),
+            Self::Int32(_) => DataTypeKind::Int32.not_null(),
+            Self::Int64(_) => DataTypeKind::Int64.not_null(),
+            Self::Float64(_) => DataTypeKind::Float64.not_null(),
+            Self::String(_) => DataTypeKind::String.not_null(),
+            Self::Blob(_) => DataTypeKind::Blob.not_null(),
+            Self::Decimal(_) => DataTypeKind::Decimal(None, None).not_null(),
+            Self::Date(_) => DataTypeKind::Date.not_null(),
+            Self::Interval(_) => DataTypeKind::Interval.not_null(),
         }
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -389,8 +389,8 @@ impl FromStr for DataValue {
             Ok(Self::Int32(int))
         } else if let Ok(bigint) = s.parse::<i64>() {
             Ok(Self::Int64(bigint))
-        } else if let Ok(float) = s.parse::<F64>() {
-            Ok(Self::Float64(float))
+        } else if let Ok(d) = s.parse::<Decimal>() {
+            Ok(Self::Decimal(d))
         } else if s.starts_with('\'') && s.ends_with('\'') {
             Ok(Self::String(s[1..s.len() - 1].to_string()))
         } else if s.starts_with("b\'") && s.ends_with('\'') {


### PR DESCRIPTION
This PR adds a NULL variant to the `DataTypeKind` enum, as the type of NULL value. And fixes the remaining failed tests in type analysis.