### PR TITLE
feat(planner_v2): support explain

### DIFF
--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -134,7 +134,7 @@ impl Binder {
                 ..
             } => self.bind_copy(table_name, &columns, to, target, &options),
             Statement::Query(query) => self.bind_query(*query),
-            Statement::Explain { .. } => todo!(),
+            Statement::Explain { statement, .. } => self.bind_explain(*statement),
             Statement::ShowVariable { .. }
             | Statement::ShowCreate { .. }
             | Statement::ShowColumns { .. } => Err(BindError::NotSupportedTSQL),
@@ -164,6 +164,12 @@ impl Binder {
         context.aliases.insert(alias.value, expr);
         // may override the same name
         Ok(())
+    }
+
+    fn bind_explain(&mut self, query: Statement) -> Result {
+        let id = self.bind_stmt(query)?;
+        let id = self.egraph.add(Node::Explain(id));
+        Ok(id)
     }
 }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -184,9 +184,9 @@ impl Database {
             for stmt in stmts {
                 let mut binder = crate::binder_v2::Binder::new(self.catalog.clone());
                 let bound = binder.bind(stmt)?;
-                println!("bind result:\n{}", bound.pretty(60));
+                println!("bind:\n{}", crate::planner::Explain::of(&bound));
                 let optimized = crate::planner::optimize(&bound);
-                println!("optimize result:\n{}", optimized.pretty(60));
+                println!("optimized:\n{}", crate::planner::Explain::of(&optimized));
             }
             return Ok(vec![]);
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -186,7 +186,11 @@ impl Database {
                 let bound = binder.bind(stmt)?;
                 println!("bind:\n{}", crate::planner::Explain::of(&bound));
                 let optimized = crate::planner::optimize(&bound);
-                println!("optimized:\n{}", crate::planner::Explain::of(&optimized));
+                let costs = crate::planner::costs(&optimized);
+                println!(
+                    "optimized:\n{}",
+                    crate::planner::Explain::with_costs(&optimized, &costs)
+                );
             }
             return Ok(vec![]);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub mod utils;
 /// The new binder converting sqlparser AST to egg AST.
 mod binder_v2;
 /// Next-generation planner and optimizer based on egg.
-mod planner;
+pub mod planner;
 
 #[cfg(feature = "jemalloc")]
 use tikv_jemallocator::Jemalloc;

--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -164,11 +164,11 @@ impl Display for Explain<'_> {
             ),
             Distinct(_) => todo!(),
 
-            Scan(list) => write!(f, "{tab}Scan: {}{cost}\n", self.expr(list)),
+            Scan(list) => writeln!(f, "{tab}Scan: {}{cost}", self.expr(list)),
             Values(values) => {
-                write!(f, "{tab}Values:{cost}\n")?;
+                writeln!(f, "{tab}Values:{cost}")?;
                 for v in values.iter() {
-                    write!(f, "  {tab}{}\n", self.expr(v))?;
+                    writeln!(f, "  {tab}{}", self.expr(v))?;
                 }
                 Ok(())
             }

--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -1,0 +1,208 @@
+use std::fmt::{Display, Formatter, Result};
+
+use egg::{Id, PatternAst};
+
+use super::{EGraph, Expr, RecExpr};
+
+/// A wrapper over [`RecExpr`] to explain it in [`Display`].
+///
+/// # Example
+/// ```
+/// use risinglight::planner::{Explain, RecExpr};
+/// let expr: RecExpr = "(+ 1 2)".parse().unwrap();
+/// println!("{}", Explain::of(&expr));
+/// ```
+pub struct Explain<'a> {
+    expr: &'a RecExpr,
+    id: Id,
+    depth: u8,
+}
+
+impl<'a> Explain<'a> {
+    /// Create a [`Explain`] over [`RecExpr`].
+    pub fn of(expr: &'a RecExpr) -> Self {
+        Self {
+            expr,
+            id: Id::from(expr.as_ref().len() - 1),
+            depth: 0,
+        }
+    }
+
+    #[inline]
+    const fn expr(&self, id: &Id) -> Self {
+        Explain {
+            expr: self.expr,
+            id: *id,
+            depth: self.depth,
+        }
+    }
+
+    #[inline]
+    const fn child(&self, id: &Id) -> Self {
+        Explain {
+            expr: self.expr,
+            id: *id,
+            depth: self.depth + 1,
+        }
+    }
+
+    #[inline]
+    const fn tab(&self) -> impl Display {
+        struct Tab(u8);
+        impl Display for Tab {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+                for _ in 0..self.0 {
+                    write!(f, "  ")?;
+                }
+                Ok(())
+            }
+        }
+        Tab(self.depth)
+    }
+
+    #[inline]
+    fn is_true(&self, id: &Id) -> bool {
+        self.expr[*id] == Expr::true_()
+    }
+}
+
+impl Display for Explain<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        use Expr::*;
+        let enode = &self.expr[self.id];
+        let tab = self.tab();
+        match enode {
+            Constant(v) => write!(f, "{v}"),
+            Type(t) => write!(f, "{t}"),
+            Column(i) => write!(f, "{i}"),
+            ColumnIndex(i) => write!(f, "{i}"),
+
+            List(list) => {
+                write!(f, "[")?;
+                for (i, v) in list.iter().enumerate() {
+                    if i != 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", self.expr(v))?;
+                }
+                write!(f, "]")
+            }
+
+            BoundDrop(_) => todo!(),
+            BoundExtSource(_) => todo!(),
+            BoundTable(_) => todo!(),
+
+            // binary operations
+            Add([a, b]) | Sub([a, b]) | Mul([a, b]) | Div([a, b]) | Mod([a, b])
+            | StringConcat([a, b]) | Gt([a, b]) | Lt([a, b]) | GtEq([a, b]) | LtEq([a, b])
+            | Eq([a, b]) | NotEq([a, b]) | And([a, b]) | Or([a, b]) | Xor([a, b])
+            | Like([a, b]) => write!(f, "({} {} {})", self.expr(a), enode, self.expr(b)),
+
+            // unary operations
+            Neg(a) | Not(a) | IsNull(a) => write!(f, "({} {})", enode, self.expr(a)),
+
+            If([cond, then, else_]) => write!(
+                f,
+                "(if {} {} {})",
+                self.expr(cond),
+                self.expr(then),
+                self.expr(else_)
+            ),
+
+            RowCount => write!(f, "rowcount"),
+            Max(a) | Min(a) | Sum(a) | Avg(a) | Count(a) | First(a) | Last(a) => {
+                write!(f, "{}({})", enode, self.expr(a))
+            }
+
+            Exists(a) => write!(f, "exists({})", self.expr(a)),
+            In([a, b]) => write!(f, "({} in {})", self.expr(a), self.expr(b)),
+            Cast([a, b]) => write!(f, "({} :: {})", self.expr(a), self.expr(b)),
+
+            Select([distinct, projection, from, where_, groupby, having]) => write!(
+                f,
+                "{tab}Select:\n  {tab}distinct={}\n  {tab}projection={}\n  {tab}where={}\n  {tab}groupby={}\n  {tab}having={}\n{}",
+                self.expr(distinct),
+                self.expr(projection),
+                self.expr(where_),
+                self.expr(groupby),
+                self.expr(having),
+                self.child(from),
+            ),
+            Distinct(_) => todo!(),
+
+            Scan(list) => write!(f, "{tab}Scan: {}\n", self.expr(list)),
+            Values(values) => {
+                write!(f, "{tab}Values:\n")?;
+                for v in values.iter() {
+                    write!(f, "  {tab}{}\n", self.expr(v))?;
+                }
+                Ok(())
+            }
+            Proj([exprs, child]) => write!(
+                f,
+                "{tab}Projection: {}\n{}",
+                self.expr(exprs),
+                self.child(child)
+            ),
+            Filter([cond, child]) => {
+                write!(f, "{tab}Filter: {}\n{}", self.expr(cond), self.child(child))
+            }
+            Order([orderby, child]) => {
+                write!(
+                    f,
+                    "{tab}Order: {}\n{}",
+                    self.expr(orderby),
+                    self.child(child)
+                )
+            }
+            Asc(a) | Desc(a) => write!(f, "{} {}", self.expr(a), enode),
+            Limit([limit, offset, child]) => write!(
+                f,
+                "{tab}Limit: limit={}, offset={}\n{}",
+                self.expr(limit),
+                self.expr(offset),
+                self.child(child)
+            ),
+            TopN([limit, offset, orderby, child]) => write!(
+                f,
+                "{tab}TopN: limit={}, offset={}, orderby={}\n{}",
+                self.expr(limit),
+                self.expr(offset),
+                self.expr(orderby),
+                self.child(child)
+            ),
+            Join([ty, cond, left, right]) => {
+                write!(f, "{tab}Join: {}", self.expr(ty))?;
+                if !self.is_true(cond) {
+                    write!(f, ", on={}", self.expr(cond))?;
+                }
+                write!(f, "\n{}{}", self.child(left), self.child(right))
+            }
+            HashJoin([ty, lkeys, rkeys, left, right]) => write!(
+                f,
+                "{tab}HashJoin: {}, lkey={}, rkey={}\n{}{}",
+                self.expr(ty),
+                self.expr(lkeys),
+                self.expr(rkeys),
+                self.child(left),
+                self.child(right)
+            ),
+            Inner | LeftOuter | RightOuter | FullOuter | Cross => write!(f, "{}", enode),
+            Agg([aggs, group_keys, child]) => write!(
+                f,
+                "{tab}Aggregate: {}, groupby={}\n{}",
+                self.expr(aggs),
+                self.expr(group_keys),
+                self.child(child)
+            ),
+            Create(_) => todo!(),
+            Insert(_) => todo!(),
+            Delete(_) => todo!(),
+            CopyFrom(_) => todo!(),
+            CopyTo(_) => todo!(),
+            Explain(child) => write!(f, "{tab}Explain:\n{}", self.child(child)),
+            Prune(_) => todo!(),
+            Symbol(s) => write!(f, "{s}"),
+        }
+    }
+}

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -10,8 +10,10 @@ use crate::parser::{BinaryOperator, UnaryOperator};
 use crate::types::{ColumnIndex, DataTypeKind, DataValue};
 
 mod cost;
+mod explain;
 mod rules;
 
+pub use explain::Explain;
 pub use rules::{ExprAnalysis, TypeError};
 
 // Alias types for our language.
@@ -31,6 +33,9 @@ define_language! {
         BoundDrop(BoundDrop),
         BoundExtSource(BoundExtSource),
         BoundTable(BoundTable),
+
+        // utilities
+        "list" = List(Box<[Id]>),       // (list ...)
 
         // binary operations
         "+" = Add([Id; 2]),
@@ -72,8 +77,6 @@ define_language! {
         "in" = In([Id; 2]),
 
         "cast" = Cast([Id; 2]),                 // (cast type expr)
-        "as" = Alias([Id; 2]),                  // (as name expr)
-        "fn" = Function(Box<[Id]>),             // (fn name args..)
 
         "select" = Select([Id; 6]),             // (select
                                                 //      distinct=[expr..]
@@ -112,9 +115,6 @@ define_language! {
         "copy_from" = CopyFrom(Id),             // (copy_from dest)
         "copy_to" = CopyTo([Id; 2]),            // (copy_to dest child)
         "explain" = Explain(Id),                // (explain child)
-
-        // utilities
-        "list" = List(Box<[Id]>),               // (list ...)
 
         // internal functions
         "prune" = Prune([Id; 2]),               // (prune node child)


### PR DESCRIPTION
@skyzh Sorry for racing with your #714. I was debugging the cost function and needed this feature to see what the hell was going on with my planner. 🤣

This PR adds the explain format to the new planner. It prints the plan in a prettier format than the original Lisp-style bracket expressions. In addition, it can print the cost of each plan if given.

```
> \v2
switched to planner v2
in 0.000s
> select
    l_orderkey,
    sum(l_extendedprice * (1 - l_discount)) as revenue,
    o_orderdate,
    o_shippriority
from
    customer,
    orders,
    lineitem
where
    c_mktsegment = 'BUILDING'
    and c_custkey = o_custkey
    and l_orderkey = o_orderkey
    and o_orderdate < date '1995-03-15'
    and l_shipdate > date '1995-03-15'
group by
    l_orderkey,
    o_orderdate,
    o_shippriority
order by
    revenue desc,
    o_orderdate
limit 10;
bind:
TopN: limit=10, offset=null, orderby=[sum(($7.5 * (1 - $7.6))) desc, $6.4 asc]
  Select:
    distinct=[]
    projection=[$7.0, sum(($7.5 * (1 - $7.6))), $6.4, $6.7]
    where=((((($5.6 = 'BUILDING') and ($5.0 = $6.1)) and ($7.0 = $6.0)) and ($6.4 < 1995-03-15)) and ($7.10 > 1995-03-15))
    groupby=[$7.0, $6.4, $6.7]
    having=true
    Join: cross
      Join: cross
        Scan: [$5.0, $5.1, $5.2, $5.3, $5.4, $5.5, $5.6, $5.7]
        Scan: [$6.0, $6.1, $6.2, $6.3, $6.4, $6.5, $6.6, $6.7, $6.8]
      Scan: [$7.0, $7.1, $7.2, $7.3, $7.4, $7.5, $7.6, $7.7, $7.8, $7.9, $7.10, $7.11, $7.12, $7.13, $7.14, $7.15]

optimized:
TopN: limit=10, offset=null, orderby=[sum(($7.5 * (1 - $7.6))) desc, $6.4 asc] (cost=74)
  Projection: [$7.0, sum(($7.5 * (1 - $7.6))), $6.4, $6.7] (cost=61)
    Aggregate: [sum(($7.5 * (1 - $7.6)))], groupby=[$7.0, $6.4, $6.7] (cost=50)
      Join: cross, on=(($7.0 = $6.0) and ('BUILDING' = $5.6)) (cost=38)
        Filter: ($6.1 = $5.0) (cost=19)
          Join: cross, on=(1995-03-15 > $6.4) (cost=15)
            Scan: [$5.0, $5.6] (cost=4)
            Scan: [$6.0, $6.1, $6.4, $6.7] (cost=6)
        Filter: ($7.10 > 1995-03-15) (cost=10)
          Scan: [$7.0, $7.5, $7.6, $7.10] (cost=6)
```

vs. the original format:
```
(topn
  10
  null
  (list (desc (sum (* $7.5 (- 1 $7.6)))) (asc $6.4))
  (proj
    (list $7.0 (sum (* $7.5 (- 1 $7.6))) $6.4 $6.7)
    (agg
      (list (sum (* $7.5 (- 1 $7.6))))
      (list $7.0 $6.4 $6.7)
      (join
        cross
        (and (= $7.0 $6.0) (= 'BUILDING' $5.6))
        (filter
          (= $6.1 $5.0)
          (join
            cross
            (> 1995-03-15 $6.4)
            (scan (list $5.0 $5.6))
            (scan (list $6.0 $6.1 $6.4 $6.7))))
        (filter
          (> $7.10 1995-03-15)
          (scan (list $7.0 $7.5 $7.6 $7.10)))))))
```