### PR TITLE
feat: introduce executor v2 for the new planner

### DIFF
--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 
 use crate::catalog::{RootCatalog, TableRefId, DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME};
 use crate::parser::*;
-use crate::planner::{Expr as Node, ExprAnalysis, RecExpr, TypeError};
+use crate::planner::{Expr as Node, RecExpr, TypeError, TypeSchemaAnalysis};
 use crate::types::{DataTypeKind, DataValue};
 
 mod copy;
@@ -72,7 +72,7 @@ pub enum BindError {
 /// The binder resolves all expressions referring to schema objects such as
 /// tables or views with their column names and types.
 pub struct Binder {
-    egraph: egg::EGraph<Node, ExprAnalysis>,
+    egraph: egg::EGraph<Node, TypeSchemaAnalysis>,
     catalog: Arc<RootCatalog>,
     contexts: Vec<Context>,
 }

--- a/src/executor_v2/evaluator.rs
+++ b/src/executor_v2/evaluator.rs
@@ -1,0 +1,86 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+//! Apply expressions on data chunks.
+
+use std::borrow::Borrow;
+use std::fmt;
+
+use egg::{Id, Language};
+
+use crate::array::*;
+use crate::parser::{BinaryOperator, UnaryOperator};
+use crate::planner::{Expr, RecExpr};
+use crate::types::{Blob, ConvertError, DataType, DataTypeKind, DataValue, Date, F64};
+
+pub struct ExprRef<'a> {
+    expr: &'a RecExpr,
+    id: Id,
+}
+
+impl fmt::Display for ExprRef<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let recexpr = self.node().build_recexpr(|id| self.expr[id].clone());
+        write!(f, "{recexpr}")
+    }
+}
+
+impl<'a> ExprRef<'a> {
+    pub fn new(expr: &'a RecExpr) -> Self {
+        Self {
+            expr,
+            id: Id::from(expr.as_ref().len() - 1),
+        }
+    }
+
+    fn node(&self) -> &Expr {
+        &self.expr[self.id]
+    }
+
+    fn next(&self, id: Id) -> Self {
+        Self {
+            expr: self.expr,
+            id,
+        }
+    }
+
+    /// Evaluate the given expression as an array.
+    pub fn eval(&self, chunk: &DataChunk) -> Result<ArrayImpl, ConvertError> {
+        use Expr::*;
+        match self.node() {
+            ColumnIndex(idx) => Ok(chunk.array_at(idx.0 as _).clone()),
+            Constant(v) => {
+                let mut builder =
+                    ArrayBuilderImpl::with_capacity(chunk.cardinality(), &v.data_type());
+                // TODO: optimize this
+                for _ in 0..chunk.cardinality() {
+                    builder.push(v);
+                }
+                Ok(builder.finish())
+            }
+            Cast([ty, a]) => {
+                let array = self.next(*a).eval(chunk)?;
+                array.try_cast(self.next(*ty).node().as_type())
+            }
+            IsNull(a) => {
+                let array = self.next(*a).eval(chunk)?;
+                Ok(ArrayImpl::new_bool(
+                    (0..array.len())
+                        .map(|i| array.get(i) == DataValue::Null)
+                        .collect(),
+                ))
+            }
+            e => {
+                if let Some((op, a, b)) = e.binary_op() {
+                    let left = self.next(a).eval(chunk)?;
+                    let right = self.next(b).eval(chunk)?;
+                    left.binary_op(&op, &right)
+                } else if let Some((op, a)) = e.unary_op() {
+                    let array = self.next(a).eval(chunk)?;
+                    array.unary_op(&op)
+                } else {
+                    panic!("can not evaluate expression: {self}");
+                }
+            }
+        }
+    }
+}

--- a/src/executor_v2/explain.rs
+++ b/src/executor_v2/explain.rs
@@ -1,0 +1,22 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use futures::{future, stream};
+
+use super::*;
+use crate::array::{ArrayImpl, Utf8Array};
+use crate::planner::{costs, Explain};
+
+/// The executor of `explain` statement.
+pub struct ExplainExecutor {
+    pub plan: RecExpr,
+}
+
+impl ExplainExecutor {
+    pub fn execute(self) -> BoxedExecutor {
+        let explain = format!("{}", Explain::with_costs(&self.plan, &costs(&self.plan)));
+        let chunk =
+            DataChunk::from_iter([ArrayImpl::new_utf8(Utf8Array::from_iter([Some(explain)]))]);
+
+        stream::once(future::ok(chunk)).boxed()
+    }
+}

--- a/src/executor_v2/filter.rs
+++ b/src/executor_v2/filter.rs
@@ -1,0 +1,24 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use super::*;
+use crate::array::{Array, ArrayImpl, DataChunk};
+
+/// The executor of a filter operation.
+pub struct FilterExecutor {
+    pub condition: RecExpr,
+}
+
+impl FilterExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, child: BoxedExecutor) {
+        #[for_await]
+        for batch in child {
+            let batch = batch?;
+            let vis = match ExprRef::new(&self.condition).eval(&batch)? {
+                ArrayImpl::Bool(a) => a,
+                _ => panic!("filters can only accept bool array"),
+            };
+            yield batch.filter(vis.iter().map(|b| matches!(b, Some(true))));
+        }
+    }
+}

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -53,7 +53,7 @@ use self::table_scan::*;
 use crate::array::DataChunk;
 use crate::binder::BoundExpr;
 use crate::function::FunctionError;
-use crate::planner::{resolve_column_index, Expr, RecExpr, TypeSchemaAnalysis};
+use crate::planner::{ColumnIndexResolver, Expr, RecExpr, TypeSchemaAnalysis};
 use crate::storage::{Storage, StorageImpl, TracedStorageError};
 use crate::types::{ConvertError, DataValue};
 
@@ -175,7 +175,7 @@ impl<S: Storage> Builder<S> {
             .iter()
             .map(|id| self.recexpr(*id))
             .collect_vec();
-        resolve_column_index(&self.recexpr(expr), &schema)
+        ColumnIndexResolver::new(&schema).resolve(&self.recexpr(expr))
     }
 
     fn build(self) -> BoxedExecutor {

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -1,0 +1,234 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+#![allow(unused)]
+
+//! # Execution Model
+//!
+//! The execution engine executes the query in a Vectorized Volcano model.
+//!
+//! # Async Stream
+//!
+//! Each executor is an async-stream that produces a stream of values asynchronously.
+//!
+//! To write async-stream in Rust, we use the [`try_stream`] macro from [`async_stream`] crate.
+//!
+//! [`try_stream`]: async_stream::try_stream
+
+use std::sync::Arc;
+
+use egg::{Id, Language};
+use futures::stream::{BoxStream, StreamExt};
+use futures_async_stream::try_stream;
+use itertools::Itertools;
+use minitrace::prelude::*;
+
+use self::evaluator::*;
+// pub use self::aggregation::*;
+// use self::copy_from_file::*;
+// use self::copy_to_file::*;
+// use self::create::*;
+// use self::delete::*;
+// use self::drop::*;
+// use self::dummy_scan::*;
+use self::explain::*;
+use self::filter::*;
+// use self::hash_agg::*;
+// use self::hash_join::*;
+// use self::insert::*;
+// use self::internal::*;
+// use self::limit::*;
+// use self::nested_loop_join::*;
+// use self::order::*;
+// #[allow(unused_imports)]
+// use self::perfect_hash_agg::*;
+use self::projection::*;
+// use self::simple_agg::*;
+// #[allow(unused_imports)]
+// use self::sort_agg::*;
+// #[allow(unused_imports)]
+// use self::sort_merge_join::*;
+use self::table_scan::*;
+// use self::top_n::TopNExecutor;
+// use self::values::*;
+use crate::array::DataChunk;
+use crate::binder::BoundExpr;
+use crate::function::FunctionError;
+use crate::planner::{resolve_column_index, Expr, RecExpr, TypeSchemaAnalysis};
+use crate::storage::{Storage, StorageImpl, TracedStorageError};
+use crate::types::{ConvertError, DataValue};
+
+// mod aggregation;
+// mod copy_from_file;
+// mod copy_to_file;
+// mod create;
+// mod delete;
+// mod drop;
+// mod dummy_scan;
+mod evaluator;
+mod explain;
+mod filter;
+// mod hash_agg;
+// mod hash_join;
+// mod insert;
+// mod internal;
+// mod limit;
+// mod nested_loop_join;
+// mod order;
+// mod perfect_hash_agg;
+mod projection;
+// mod simple_agg;
+// mod sort_agg;
+// mod sort_merge_join;
+mod table_scan;
+// mod top_n;
+// mod values;
+
+/// The error type of execution.
+#[derive(thiserror::Error, Debug)]
+pub enum ExecutorError {
+    #[error("function error: {0}")]
+    Function(
+        #[from]
+        #[backtrace]
+        #[source]
+        FunctionError,
+    ),
+    #[error("failed to build executors from the physical plan")]
+    BuildingPlanError,
+    #[error("storage error: {0}")]
+    Storage(
+        #[from]
+        #[backtrace]
+        #[source]
+        TracedStorageError,
+    ),
+    #[error("conversion error: {0}")]
+    Convert(#[from] ConvertError),
+    #[error("tuple length mismatch: expected {expected} but got {actual}")]
+    LengthMismatch { expected: usize, actual: usize },
+    #[error("io error")]
+    Io(
+        #[from]
+        #[source]
+        std::io::Error,
+    ),
+    #[error("csv error")]
+    Csv(
+        #[from]
+        #[source]
+        csv::Error,
+    ),
+    #[error("value can not be null")]
+    NotNullable,
+    #[error("exceed char/varchar length limit: item length {length} > char/varchar width {width}")]
+    ExceedLengthLimit { length: u64, width: u64 },
+    #[error("abort")]
+    Abort,
+}
+
+/// The maximum chunk length produced by executor at a time.
+const PROCESSING_WINDOW_SIZE: usize = 1024;
+
+/// A type-erased executor object.
+///
+/// Logically an executor is a stream of data chunks.
+///
+/// It consumes one or more streams from its child executors,
+/// and produces a stream to its parent.
+pub type BoxedExecutor = BoxStream<'static, Result<DataChunk, ExecutorError>>;
+
+pub fn build(storage: Arc<impl Storage>, plan: &RecExpr) -> BoxedExecutor {
+    Builder::new(storage, plan).build()
+}
+
+/// The builder of executor.
+struct Builder<S: Storage> {
+    storage: Arc<S>,
+    egraph: egg::EGraph<Expr, TypeSchemaAnalysis>,
+    root: Id,
+}
+
+impl<S: Storage> Builder<S> {
+    /// Create a new executor builder.
+    fn new(storage: Arc<S>, plan: &RecExpr) -> Self {
+        let mut egraph = egg::EGraph::default();
+        let root = egraph.add_expr(plan);
+        Builder {
+            storage,
+            egraph,
+            root,
+        }
+    }
+
+    fn node(&self, id: Id) -> &Expr {
+        &self.egraph[id].nodes[0]
+    }
+
+    /// Extract a `RecExpr` from id.
+    fn recexpr(&self, id: Id) -> RecExpr {
+        self.node(id).build_recexpr(|id| self.node(id).clone())
+    }
+
+    /// Resolve the column index of `expr` in `plan`.
+    fn resolve_column_index(&self, expr: Id, plan: Id) -> RecExpr {
+        let schema = (self.egraph[plan].data.schema.as_ref().expect("no schema"))
+            .iter()
+            .map(|id| self.recexpr(*id))
+            .collect_vec();
+        resolve_column_index(&self.recexpr(expr), &schema)
+    }
+
+    fn build(self) -> BoxedExecutor {
+        self.build_id(self.root)
+    }
+
+    fn build_id(&self, id: Id) -> BoxedExecutor {
+        use Expr::*;
+        match self.node(id).clone() {
+            Scan(list) => TableScanExecutor {
+                columns: (self.node(list).as_list().iter())
+                    .map(|id| self.node(*id).as_column())
+                    .collect(),
+                storage: self.storage.clone(),
+            }
+            .execute(),
+
+            Values(_) => todo!(),
+
+            Proj([projs, child]) => ProjectionExecutor {
+                projs: {
+                    let expr = self.resolve_column_index(projs, child);
+                    (expr.as_ref().last().unwrap().as_list())
+                        .iter()
+                        .map(|id| expr[*id].build_recexpr(|id| expr[id].clone()))
+                        .collect()
+                },
+            }
+            .execute(self.build_id(child)),
+
+            Filter([cond, child]) => FilterExecutor {
+                condition: self.resolve_column_index(cond, child),
+            }
+            .execute(self.build_id(child)),
+
+            Order(_) => todo!(),
+            Limit(_) => todo!(),
+            TopN(_) => todo!(),
+            Join(_) => todo!(),
+            HashJoin(_) => todo!(),
+            Agg(_) => todo!(),
+            Create(_) => todo!(),
+            Insert(_) => todo!(),
+            Delete(_) => todo!(),
+            CopyFrom(_) => todo!(),
+            CopyTo(_) => todo!(),
+
+            Explain(plan) => ExplainExecutor {
+                plan: self.recexpr(plan),
+            }
+            .execute(),
+
+            node => panic!("not a plan: {node:?}"),
+        }
+    }
+}

--- a/src/executor_v2/projection.rs
+++ b/src/executor_v2/projection.rs
@@ -1,0 +1,25 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use super::*;
+use crate::array::DataChunk;
+
+/// The executor of project operation.
+pub struct ProjectionExecutor {
+    pub projs: Vec<RecExpr>,
+}
+
+impl ProjectionExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, child: BoxedExecutor) {
+        #[for_await]
+        for batch in child {
+            let batch = batch?;
+            let chunk: Vec<_> = self
+                .projs
+                .iter()
+                .map(|expr| ExprRef::new(expr).eval(&batch))
+                .try_collect()?;
+            yield chunk.into_iter().collect();
+        }
+    }
+}

--- a/src/executor_v2/table_scan.rs
+++ b/src/executor_v2/table_scan.rs
@@ -1,0 +1,46 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use super::*;
+use crate::array::DataChunk;
+use crate::catalog::ColumnRefId;
+use crate::storage::{Storage, StorageColumnRef, Table, Transaction, TxnIterator};
+
+/// The executor of table scan operation.
+pub struct TableScanExecutor<S: Storage> {
+    pub columns: Vec<ColumnRefId>,
+    pub storage: Arc<S>,
+}
+
+impl<S: Storage> TableScanExecutor<S> {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self) {
+        let table = self.storage.get_table(self.columns[0].table())?;
+
+        let mut col_idx = self
+            .columns
+            .iter()
+            .map(|x| StorageColumnRef::Idx(x.column_id)) // FIXME: use index, not id
+            .collect_vec();
+
+        // TODO: append row handler?
+
+        let txn = table.read().await?;
+
+        let mut it = txn
+            .scan(
+                &[],
+                &[],
+                &col_idx,
+                false, // TODO: is_sorted
+                false,
+                None, // TODO: support filter scan
+            )
+            .await?;
+
+        while let Some(x) = it.next_batch(None).await? {
+            yield x;
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod utils;
 
 /// The new binder converting sqlparser AST to egg AST.
 mod binder_v2;
+mod executor_v2;
 /// Next-generation planner and optimizer based on egg.
 pub mod planner;
 

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -10,7 +10,7 @@ mod explain;
 mod rules;
 
 pub use explain::Explain;
-pub use rules::{ExprAnalysis, TypeError};
+pub use rules::{resolve_column_index, ExprAnalysis, TypeError, TypeSchemaAnalysis};
 
 // Alias types for our language.
 type EGraph = egg::EGraph<Expr, ExprAnalysis>;

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -10,7 +10,7 @@ mod explain;
 mod rules;
 
 pub use explain::Explain;
-pub use rules::{resolve_column_index, ExprAnalysis, TypeError, TypeSchemaAnalysis};
+pub use rules::{ColumnIndexResolver, ExprAnalysis, TypeError, TypeSchemaAnalysis};
 
 // Alias types for our language.
 type EGraph = egg::EGraph<Expr, ExprAnalysis>;

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -130,7 +130,28 @@ impl Expr {
         Self::Constant(DataValue::Null)
     }
 
-    const fn binary_op(&self) -> Option<(BinaryOperator, Id, Id)> {
+    pub fn as_list(&self) -> &[Id] {
+        match self {
+            Self::List(list) => list,
+            _ => panic!("not a list"),
+        }
+    }
+
+    pub fn as_column(&self) -> ColumnRefId {
+        match self {
+            Self::Column(c) => *c,
+            _ => panic!("not a column"),
+        }
+    }
+
+    pub fn as_type(&self) -> DataTypeKind {
+        match self {
+            Self::Type(t) => *t,
+            _ => panic!("not a type"),
+        }
+    }
+
+    pub const fn binary_op(&self) -> Option<(BinaryOperator, Id, Id)> {
         use BinaryOperator as Op;
         #[allow(clippy::match_ref_pats)]
         Some(match self {
@@ -154,7 +175,7 @@ impl Expr {
         })
     }
 
-    const fn unary_op(&self) -> Option<(UnaryOperator, Id)> {
+    pub const fn unary_op(&self) -> Option<(UnaryOperator, Id)> {
         use UnaryOperator as Op;
         #[allow(clippy::match_ref_pats)]
         Some(match self {

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -36,7 +36,7 @@ mod rows;
 mod schema;
 mod type_;
 
-pub use self::schema::resolve_column_index;
+pub use self::schema::ColumnIndexResolver;
 pub use self::type_::TypeError;
 
 /// Stage1 rules in the optimizer.

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -36,7 +36,7 @@ mod rows;
 mod schema;
 mod type_;
 
-pub use self::rows::analyze_rows;
+pub use self::schema::resolve_column_index;
 pub use self::type_::TypeError;
 
 /// Stage1 rules in the optimizer.
@@ -86,10 +86,6 @@ pub struct Data {
     /// For non-plan node, it always be None.
     /// For plan node, it may be None if the schema is unknown due to unresolved `prune`.
     pub schema: schema::Schema,
-
-    /// Data type of the expression.
-    pub type_: type_::Type,
-
     /// Estimate rows.
     pub rows: rows::Rows,
 }
@@ -103,8 +99,7 @@ impl Analysis<Expr> for ExprAnalysis {
             constant: expr::eval_constant(egraph, enode),
             columns: plan::analyze_columns(egraph, enode),
             aggs: agg::analyze_aggs(egraph, enode),
-            schema: schema::analyze_schema(egraph, enode),
-            type_: type_::analyze_type(egraph, enode),
+            schema: schema::analyze_schema(enode, |i| egraph[*i].data.schema.clone()),
             rows: rows::analyze_rows(egraph, enode),
         }
     }
@@ -122,17 +117,49 @@ impl Analysis<Expr> for ExprAnalysis {
         let merge_columns = merge_small_set(&mut to.columns, from.columns);
         let merge_aggs = merge_small_set(&mut to.aggs, from.aggs);
         let merge_schema = egg::merge_max(&mut to.schema, from.schema);
-        let merge_type = egg::merge_max(&mut to.type_, from.type_);
         let merge_rows = egg::merge_min(
             unsafe { std::mem::transmute(&mut to.rows) },
             F32::from(from.rows),
         );
-        merge_const | merge_columns | merge_aggs | merge_schema | merge_type | merge_rows
+        merge_const | merge_columns | merge_aggs | merge_schema | merge_rows
     }
 
     /// Modify the graph after analyzing a node.
     fn modify(egraph: &mut EGraph, id: Id) {
         expr::union_constant(egraph, id);
+    }
+}
+
+/// Analysis used in binding and building executor.
+#[derive(Default)]
+pub struct TypeSchemaAnalysis;
+
+#[derive(Debug)]
+pub struct TypeSchema {
+    /// Data type of the expression.
+    pub type_: type_::Type,
+
+    /// The schema for plan node: a list of expressions.
+    ///
+    /// For non-plan node, it always be None.
+    /// For plan node, it may be None if the schema is unknown due to unresolved `prune`.
+    pub schema: schema::Schema,
+}
+
+impl Analysis<Expr> for TypeSchemaAnalysis {
+    type Data = TypeSchema;
+
+    fn make(egraph: &egg::EGraph<Expr, Self>, enode: &Expr) -> Self::Data {
+        TypeSchema {
+            type_: type_::analyze_type(enode, |i| egraph[*i].data.type_.clone()),
+            schema: schema::analyze_schema(enode, |i| egraph[*i].data.schema.clone()),
+        }
+    }
+
+    fn merge(&mut self, to: &mut Self::Data, from: Self::Data) -> DidMerge {
+        let merge_type = egg::merge_max(&mut to.type_, from.type_);
+        let merge_schema = egg::merge_max(&mut to.schema, from.schema);
+        merge_type | merge_schema
     }
 }
 

--- a/src/planner/rules/schema.rs
+++ b/src/planner/rules/schema.rs
@@ -12,14 +12,13 @@ use crate::types::ColumnIndex;
 /// - given schema:           `sum(v1), v2`
 /// - the expressions:        `v2 + 1, sum(v1) + v2`
 /// - should be rewritten to: `#1 + 1, #0 + #1`
-#[allow(unused)]
-pub fn resolve_column_index(expr: RecExpr, schema: &[RecExpr]) -> RecExpr {
+pub fn resolve_column_index(expr: &RecExpr, schema: &[RecExpr]) -> RecExpr {
     let mut egraph = egg::EGraph::<Expr, ()>::default();
     // add expressions from schema and union them with index
     for (i, expr) in schema.iter().enumerate() {
         let id1 = egraph.add_expr(expr);
         let id2 = egraph.add(Expr::ColumnIndex(ColumnIndex(i as u32)));
-        egraph.union(id1, id2);
+        egraph.union(id2, id1);
     }
     // define cost function
     struct PreferColumnIndex;
@@ -39,7 +38,7 @@ pub fn resolve_column_index(expr: RecExpr, schema: &[RecExpr]) -> RecExpr {
         }
     }
     // extract the best expression
-    let id = egraph.add_expr(&expr);
+    let id = egraph.add_expr(expr);
     let extractor = egg::Extractor::new(&egraph, PreferColumnIndex);
     let (_, best) = extractor.find_best(id);
     best
@@ -49,26 +48,25 @@ pub fn resolve_column_index(expr: RecExpr, schema: &[RecExpr]) -> RecExpr {
 pub type Schema = Option<Vec<Id>>;
 
 /// Returns the output expressions for plan node.
-pub fn analyze_schema(egraph: &EGraph, enode: &Expr) -> Schema {
+pub fn analyze_schema(enode: &Expr, x: impl Fn(&Id) -> Schema) -> Schema {
     use Expr::*;
-    let x = |i: Id| egraph[i].data.schema.clone();
     let concat = |v1: Vec<Id>, v2: Vec<Id>| v1.into_iter().chain(v2.into_iter()).collect();
     Some(match enode {
         // equal to child
         Filter([_, c]) | Order([_, c]) | Limit([_, _, c]) | TopN([_, _, _, c])
-        | Distinct([_, c]) => x(*c)?,
+        | Distinct([_, c]) => x(c)?,
 
         // concat 2 children
-        Join([_, _, l, r]) | HashJoin([_, _, _, l, r]) => concat(x(*l)?, x(*r)?),
+        Join([_, _, l, r]) | HashJoin([_, _, _, l, r]) => concat(x(l)?, x(r)?),
 
         // list is the source for the following nodes
         List(ids) => ids.to_vec(),
 
         // plans that change schema
-        Scan(columns) => x(*columns)?,
+        Scan(columns) => x(columns)?,
         Values(_) => todo!("add schema for values plan"),
-        Proj([exprs, _]) | Select([exprs, ..]) => x(*exprs)?,
-        Agg([exprs, group_keys, _]) => concat(x(*exprs)?, x(*group_keys)?),
+        Proj([exprs, _]) | Select([exprs, ..]) => x(exprs)?,
+        Agg([exprs, group_keys, _]) => concat(x(exprs)?, x(group_keys)?),
 
         // prune node may changes the schema, but we don't know the exact result for now
         // so just return `None` to indicate "unknown"
@@ -91,7 +89,7 @@ mod tests {
             fn $name() {
                 let input = $input.parse().unwrap();
                 let schema = $schema.iter().map(|s| s.parse().unwrap()).collect_vec();
-                let actual = resolve_column_index(input, &schema);
+                let actual = resolve_column_index(&input, &schema);
                 assert_eq!(actual.to_string(), $expected);
             }
         };

--- a/src/planner/rules/schema.rs
+++ b/src/planner/rules/schema.rs
@@ -12,36 +12,60 @@ use crate::types::ColumnIndex;
 /// - given schema:           `sum(v1), v2`
 /// - the expressions:        `v2 + 1, sum(v1) + v2`
 /// - should be rewritten to: `#1 + 1, #0 + #1`
-pub fn resolve_column_index(expr: &RecExpr, schema: &[RecExpr]) -> RecExpr {
-    let mut egraph = egg::EGraph::<Expr, ()>::default();
-    // add expressions from schema and union them with index
-    for (i, expr) in schema.iter().enumerate() {
-        let id1 = egraph.add_expr(expr);
-        let id2 = egraph.add(Expr::ColumnIndex(ColumnIndex(i as u32)));
-        egraph.union(id2, id1);
-    }
-    // define cost function
-    struct PreferColumnIndex;
-    impl CostFunction<Expr> for PreferColumnIndex {
-        type Cost = u32;
-        fn cost<C>(&mut self, enode: &Expr, mut costs: C) -> Self::Cost
-        where
-            C: FnMut(Id) -> Self::Cost,
-        {
-            let op_cost = match enode {
-                Expr::Column(_) => u32::MAX, // column ref should no longer exists
-                _ => 1,
-            };
-            enode.fold(op_cost, |sum, id| {
-                sum.checked_add(costs(id)).unwrap_or(u32::MAX)
-            })
+///
+/// ```
+/// # use risinglight::planner::{RecExpr, ColumnIndexResolver};
+/// let s0 = "(sum v1)".parse().unwrap();
+/// let s1 = "v2".parse().unwrap();
+/// let mut resolver = ColumnIndexResolver::new(&[s0, s1]);
+/// let expr = "(list (+ v2 1) (+ (sum v1) v2))".parse().unwrap();
+/// assert_eq!(
+///     resolver.resolve(&expr).to_string(),
+///     "(list (+ #1 1) (+ #0 #1))"
+/// );
+/// ```
+pub struct ColumnIndexResolver {
+    egraph: egg::EGraph<Expr, ()>,
+}
+
+impl ColumnIndexResolver {
+    pub fn new(schema: &[RecExpr]) -> Self {
+        let mut egraph = egg::EGraph::<Expr, ()>::default();
+        // add expressions from schema and union them with index
+        for (i, expr) in schema.iter().enumerate() {
+            let id1 = egraph.add_expr(expr);
+            let id2 = egraph.add(Expr::ColumnIndex(ColumnIndex(i as u32)));
+            egraph.union(id2, id1);
         }
+        egraph.rebuild();
+        ColumnIndexResolver { egraph }
     }
-    // extract the best expression
-    let id = egraph.add_expr(expr);
-    let extractor = egg::Extractor::new(&egraph, PreferColumnIndex);
-    let (_, best) = extractor.find_best(id);
-    best
+
+    /// Replaces all column references (`ColumnRefId`) with
+    /// physical indices ([`ColumnIndex`]) in the expr.
+    pub fn resolve(&mut self, expr: &RecExpr) -> RecExpr {
+        struct PreferColumnIndex;
+        impl CostFunction<Expr> for PreferColumnIndex {
+            type Cost = u32;
+            fn cost<C>(&mut self, enode: &Expr, mut costs: C) -> Self::Cost
+            where
+                C: FnMut(Id) -> Self::Cost,
+            {
+                let op_cost = match enode {
+                    Expr::Column(_) => u32::MAX, // column ref should no longer exists
+                    _ => 1,
+                };
+                enode.fold(op_cost, |sum, id| {
+                    sum.checked_add(costs(id)).unwrap_or(u32::MAX)
+                })
+            }
+        }
+        // extract the best expression
+        let id = self.egraph.add_expr(expr);
+        let extractor = egg::Extractor::new(&self.egraph, PreferColumnIndex);
+        let (_, best) = extractor.find_best(id);
+        best
+    }
 }
 
 /// The data type of schema analysis.
@@ -81,7 +105,7 @@ pub fn analyze_schema(enode: &Expr, x: impl Fn(&Id) -> Schema) -> Schema {
 mod tests {
     use itertools::Itertools;
 
-    use super::resolve_column_index;
+    use super::ColumnIndexResolver;
 
     macro_rules! test_resolve_column_index {
         ($name:ident,rewrite: $input:expr,schema: $schema:expr,expect: $expected:expr,) => {
@@ -89,7 +113,7 @@ mod tests {
             fn $name() {
                 let input = $input.parse().unwrap();
                 let schema = $schema.iter().map(|s| s.parse().unwrap()).collect_vec();
-                let actual = resolve_column_index(&input, &schema);
+                let actual = ColumnIndexResolver::new(&schema).resolve(&input);
                 assert_eq!(actual.to_string(), $expected);
             }
         };

--- a/src/planner/rules/type_.rs
+++ b/src/planner/rules/type_.rs
@@ -15,9 +15,8 @@ pub enum TypeError {
 }
 
 /// Returns data type of the expression.
-pub fn analyze_type(egraph: &EGraph, enode: &Expr) -> Type {
+pub fn analyze_type(enode: &Expr, x: impl Fn(&Id) -> Type) -> Type {
     use Expr::*;
-    let x = |i: &Id| egraph[*i].data.type_.clone();
     match enode {
         // values
         Constant(v) => Ok(v.data_type()),
@@ -194,7 +193,7 @@ mod tests {
     }
 
     fn type_of(expr: &str) -> Type {
-        let mut egraph = EGraph::default();
+        let mut egraph = egg::EGraph::<Expr, TypeSchemaAnalysis>::default();
         let id = egraph.add_expr(&expr.parse().unwrap());
         egraph[id].data.type_.clone()
     }


### PR DESCRIPTION
This PR starts migrating executors to the new planner. The new version is put into a new module `executor_v2`. This PR finishes the migration of **scan, projection, filter, and explain** executor. Now the new planner is able to work from end to end!

```sql
> \v2
switched to planner v2
in 0.000s
> select * from nation where N_NATIONKEY = 24;
+----+---------------+---+----------------------------------------------------------------------------------------------------------------+
| 24 | UNITED STATES | 1 | y final packages. slow foxes cajole quickly. quickly silent platelets breach ironic accounts. unusual pinto be |
+----+---------------+---+----------------------------------------------------------------------------------------------------------------+
in 0.067s
> explain select * from nation where N_NATIONKEY = 24;
+--------------------------------------------------+
| Projection: [$0.0, $0.1, $0.2, $0.3] (cost=6000) |
|   Filter: ($0.0 = 24) (cost=5100)                |
|     Scan: [$0.0, $0.1, $0.2, $0.3] (cost=4000)   |
|                                                  |
+--------------------------------------------------+
in 0.036s
```