### PR TITLE
feat(executor_v2): migrate executors to run TPCH

### DIFF
--- a/src/array/data_chunk.rs
+++ b/src/array/data_chunk.rs
@@ -5,7 +5,7 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use super::*;
-use crate::types::DataValue;
+use crate::types::{DataValue, Row};
 
 /// A collection of arrays.
 ///
@@ -260,5 +260,9 @@ impl RowRef<'_> {
     /// Get an iterator over the values of the row.
     pub fn values(&self) -> impl Iterator<Item = DataValue> + '_ {
         self.chunk.arrays().iter().map(|a| a.get(self.row_idx))
+    }
+
+    pub fn to_owned(&self) -> Row {
+        self.values().collect()
     }
 }

--- a/src/array/data_chunk.rs
+++ b/src/array/data_chunk.rs
@@ -108,6 +108,16 @@ impl DataChunk {
         }
         arrays.into_iter().collect()
     }
+
+    /// Concatenate two chunks in rows.
+    pub fn row_concat(self, other: Self) -> Self {
+        assert_eq!(self.cardinality(), other.cardinality());
+        self.arrays
+            .iter()
+            .chain(other.arrays.iter())
+            .cloned()
+            .collect()
+    }
 }
 
 /// Print the data chunk as a pretty table.

--- a/src/array/internal_ext.rs
+++ b/src/array/internal_ext.rs
@@ -36,7 +36,7 @@ pub trait ArrayFromDataExt: Array {
 
 /// Implement dispatch functions for `ArrayImplValidExt` and `ArrayImplEstimateExt`
 macro_rules! impl_array_impl_internal_ext {
-    ([], $( { $Abc:ident, $abc:ident, $AbcArray:ty, $AbcArrayBuilder:ty, $Value:ident, $Type:pat } ),*) => {
+    ([], $( { $Abc:ident, $Type:ty, $abc:ident, $AbcArray:ty, $AbcArrayBuilder:ty, $Value:ident, $Pattern:pat } ),*) => {
         impl ArrayImplValidExt for ArrayImpl {
             fn get_valid_bitmap(&self) -> &BitVec {
                 match self {

--- a/src/array/iterator.rs
+++ b/src/array/iterator.rs
@@ -9,16 +9,16 @@ use super::Array;
 #[derive(Clone)]
 pub struct ArrayIter<'a, A: Array> {
     data: &'a A,
-    pos: usize,
-    _phantom: PhantomData<&'a usize>,
+    begin: usize,
+    end: usize,
 }
 
 impl<'a, A: Array> ArrayIter<'a, A> {
     pub fn new(data: &'a A) -> Self {
         Self {
             data,
-            pos: 0,
-            _phantom: PhantomData,
+            begin: 0,
+            end: data.len(),
         }
     }
 }
@@ -27,18 +27,29 @@ impl<'a, A: Array> Iterator for ArrayIter<'a, A> {
     type Item = Option<&'a A::Item>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.pos >= self.data.len() {
+        if self.begin >= self.end {
             None
         } else {
-            let item = self.data.get(self.pos);
-            self.pos += 1;
+            let item = self.data.get(self.begin);
+            self.begin += 1;
             Some(item)
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let exact = self.data.len() - self.pos;
+        let exact = self.end - self.begin;
         (exact, Some(exact))
+    }
+}
+
+impl<'a, A: Array> DoubleEndedIterator for ArrayIter<'a, A> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.begin >= self.end {
+            None
+        } else {
+            self.end -= 1;
+            Some(self.data.get(self.end))
+        }
     }
 }
 

--- a/src/array/shuffle_ext.rs
+++ b/src/array/shuffle_ext.rs
@@ -122,7 +122,7 @@ pub trait ArrayImplSortExt {
 
 /// Implement dispatch functions for `ArrayImplBuilderPickExt` and `ArrayImplSortExt`
 macro_rules! impl_array_impl_shuffle_ext {
-    ([], $( { $Abc:ident, $abc:ident, $AbcArray:ty, $AbcArrayBuilder:ty, $Value:ident, $Type:pat } ),*) => {
+    ([], $( { $Abc:ident, $Type:ty, $abc:ident, $AbcArray:ty, $AbcArrayBuilder:ty, $Value:ident, $Pattern:pat } ),*) => {
         impl ArrayImplBuilderPickExt for ArrayBuilderImpl {
             fn pick_from(&mut self, array: &ArrayImpl, logical_rows: &[usize]) {
                 match (self, array) {

--- a/src/binder_v2/copy.rs
+++ b/src/binder_v2/copy.rs
@@ -55,7 +55,7 @@ impl Binder {
         target: CopyTarget,
         options: &[CopyOption],
     ) -> Result {
-        let cols = self.bind_table_columns(table_name, columns)?;
+        let cols = self.bind_table_columns(&table_name, columns)?;
 
         let ext_source = self.egraph.add(Node::ExtSource(ExtSource {
             path: match target {
@@ -71,8 +71,9 @@ impl Binder {
             self.egraph.add(Node::CopyTo([ext_source, scan]))
         } else {
             // COPY <dest_table> FROM <source_file>
+            let table = self.bind_table_id(&table_name)?;
             let copy = self.egraph.add(Node::CopyFrom(ext_source));
-            self.egraph.add(Node::Insert([cols, copy]))
+            self.egraph.add(Node::Insert([table, cols, copy]))
         };
 
         Ok(copy)

--- a/src/binder_v2/create_table.rs
+++ b/src/binder_v2/create_table.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 
 use super::*;
-use crate::catalog::{ColumnCatalog, ColumnDesc};
+use crate::catalog::ColumnCatalog;
 use crate::types::{ColumnId, DatabaseId, SchemaId};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
@@ -13,7 +13,7 @@ pub struct CreateTable {
     pub database_id: DatabaseId,
     pub schema_id: SchemaId,
     pub table_name: String,
-    pub columns_desc: Vec<ColumnDesc>,
+    pub columns: Vec<ColumnCatalog>,
     pub ordered_pk_ids: Vec<ColumnId>,
 }
 
@@ -21,12 +21,8 @@ impl std::fmt::Display for CreateTable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "databaseId: {}, schemaId: {}, tableName: {}, columnDesc: {:?}, orderedIds: {:?}",
-            self.database_id,
-            self.schema_id,
-            self.table_name,
-            self.columns_desc,
-            self.ordered_pk_ids
+            "databaseId: {}, schemaId: {}, tableName: {}, columns: {:?}, orderedIds: {:?}",
+            self.database_id, self.schema_id, self.table_name, self.columns, self.ordered_pk_ids
         )
     }
 }
@@ -109,11 +105,7 @@ impl Binder {
             database_id: db.id(),
             schema_id: schema.id(),
             table_name: table_name.into(),
-            columns_desc: columns
-                .iter()
-                .map(|col| col.desc())
-                .cloned()
-                .collect::<Vec<ColumnDesc>>(),
+            columns,
             ordered_pk_ids,
         }));
         Ok(create)

--- a/src/binder_v2/create_table.rs
+++ b/src/binder_v2/create_table.rs
@@ -46,7 +46,7 @@ impl Binder {
         columns: &[ColumnDef],
         constraints: &[TableConstraint],
     ) -> Result {
-        let name = lower_case_name(name);
+        let name = lower_case_name(&name);
         let (database_name, schema_name, table_name) = split_name(&name)?;
         let db = self
             .catalog

--- a/src/binder_v2/delete.rs
+++ b/src/binder_v2/delete.rs
@@ -6,7 +6,10 @@ impl Binder {
         table_name: TableFactor,
         selection: Option<Expr>,
     ) -> Result {
-        let table_id = self.bind_table_id(table_name.clone())?;
+        let TableFactor::Table { name, .. } = &table_name else {
+            todo!("unsupported delete target: {:?}", table_name);
+        };
+        let table_id = self.bind_table_id(name)?;
         let scan = self.bind_table(table_name)?;
         let cond = self.bind_condition(selection)?;
         let filter = self.egraph.add(Node::Filter([cond, scan]));

--- a/src/binder_v2/drop.rs
+++ b/src/binder_v2/drop.rs
@@ -53,7 +53,7 @@ impl Binder {
     ) -> Result {
         match object_type {
             ObjectType::Table => {
-                let name = lower_case_name(names[0].clone());
+                let name = lower_case_name(&names[0]);
                 let (database_name, schema_name, table_name) = split_name(&name)?;
                 let table_ref_id = self
                     .catalog

--- a/src/binder_v2/expr.rs
+++ b/src/binder_v2/expr.rs
@@ -190,7 +190,11 @@ impl Binder {
             "max" => Node::Max(args[0]),
             "min" => Node::Min(args[0]),
             "sum" => Node::Sum(args[0]),
-            "avg" => Node::Avg(args[0]),
+            "avg" => {
+                let sum = self.egraph.add(Node::Sum(args[0]));
+                let count = self.egraph.add(Node::Count(args[0]));
+                Node::Div([sum, count])
+            }
             "first" => Node::First(args[0]),
             "last" => Node::Last(args[0]),
             name => todo!("Unsupported function: {}", name),

--- a/src/binder_v2/expr.rs
+++ b/src/binder_v2/expr.rs
@@ -76,8 +76,6 @@ impl Binder {
                 return Err(BindError::AmbiguousColumn(column_name.into()));
             }
             let id = self.egraph.add(Node::Column(column_ref_id));
-            self.egraph[id].data.type_ =
-                Ok(self.catalog.get_column(&column_ref_id).unwrap().datatype());
             return Ok(id);
         }
         if let Some(id) = self.current_ctx().aliases.get(column_name) {

--- a/src/binder_v2/insert.rs
+++ b/src/binder_v2/insert.rs
@@ -10,9 +10,10 @@ impl Binder {
         columns: Vec<Ident>,
         source: Box<Query>,
     ) -> Result {
-        let cols = self.bind_table_columns(table_name, &columns)?;
+        let table = self.bind_table_id(&table_name)?;
+        let cols = self.bind_table_columns(&table_name, &columns)?;
         let source = self.bind_query(*source)?;
-        let id = self.egraph.add(Node::Insert([cols, source]));
+        let id = self.egraph.add(Node::Insert([table, cols, source]));
         Ok(id)
     }
 }

--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -12,7 +12,7 @@ use crate::parser::*;
 use crate::planner::{Expr as Node, RecExpr, TypeError, TypeSchemaAnalysis};
 use crate::types::{DataTypeKind, DataValue};
 
-mod copy;
+pub mod copy;
 mod create_table;
 mod delete;
 mod drop;
@@ -21,7 +21,6 @@ mod insert;
 mod select;
 mod table;
 
-pub use self::copy::*;
 pub use self::create_table::*;
 pub use self::delete::*;
 pub use self::drop::*;
@@ -173,9 +172,8 @@ impl Binder {
         Ok(())
     }
 
-    fn check_type(&self, id: Id) -> Result<()> {
-        self.egraph[id].data.type_.clone()?;
-        Ok(())
+    fn check_type(&self, id: Id) -> Result<crate::types::DataType> {
+        Ok(self.egraph[id].data.type_.clone()?)
     }
 
     fn bind_explain(&mut self, query: Statement) -> Result {

--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -92,8 +92,8 @@ impl Binder {
     /// Create a new binder.
     pub fn new(catalog: Arc<RootCatalog>) -> Self {
         Binder {
-            egraph: egg::EGraph::default(),
-            catalog,
+            catalog: catalog.clone(),
+            egraph: egg::EGraph::new(TypeSchemaAnalysis { catalog }),
             contexts: vec![Context::default()],
         }
     }

--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -196,7 +196,7 @@ fn split_name(name: &ObjectName) -> Result<(&str, &str, &str)> {
 }
 
 /// Convert an object name into lower case
-fn lower_case_name(name: ObjectName) -> ObjectName {
+fn lower_case_name(name: &ObjectName) -> ObjectName {
     ObjectName(
         name.0
             .iter()

--- a/src/binder_v2/select.rs
+++ b/src/binder_v2/select.rs
@@ -13,22 +13,10 @@ impl Binder {
 
     fn bind_query_internal(&mut self, query: Query) -> Result {
         let child = match *query.body {
-            SetExpr::Select(select) => self.bind_select(*select)?,
+            SetExpr::Select(select) => self.bind_select(*select, query.order_by)?,
             SetExpr::Values(values) => self.bind_values(values)?,
             _ => todo!("handle query ???"),
         };
-
-        let mut orderby = vec![];
-        for e in query.order_by {
-            let expr = self.bind_expr(e.expr)?;
-            let key = self.egraph.add(match e.asc {
-                Some(true) | None => Node::Asc(expr),
-                Some(false) => Node::Desc(expr),
-            });
-            orderby.push(key);
-        }
-        let orderby = self.egraph.add(Node::List(orderby.into()));
-
         let limit = match query.limit {
             Some(expr) => self.bind_expr(expr)?,
             None => self.egraph.add(Node::null()),
@@ -37,10 +25,10 @@ impl Binder {
             Some(offset) => self.bind_expr(offset.value)?,
             None => self.egraph.add(Node::null()),
         };
-        Ok(self.egraph.add(Node::TopN([limit, offset, orderby, child])))
+        Ok(self.egraph.add(Node::Limit([limit, offset, child])))
     }
 
-    fn bind_select(&mut self, select: Select) -> Result {
+    fn bind_select(&mut self, select: Select, order_by: Vec<OrderByExpr>) -> Result {
         let from = self.bind_from(select.from)?;
 
         let where_ = self.bind_condition(select.selection)?;
@@ -60,8 +48,19 @@ impl Binder {
 
         let having = self.bind_condition(select.having)?;
 
+        let mut orderby = vec![];
+        for e in order_by {
+            let expr = self.bind_expr(e.expr)?;
+            let key = self.egraph.add(match e.asc {
+                Some(true) | None => Node::Asc(expr),
+                Some(false) => Node::Desc(expr),
+            });
+            orderby.push(key);
+        }
+        let orderby = self.egraph.add(Node::List(orderby.into()));
+
         Ok(self.egraph.add(Node::Select([
-            distinct, projection, from, where_, groupby, having,
+            distinct, projection, from, where_, groupby, having, orderby,
         ])))
     }
 

--- a/src/binder_v2/select.rs
+++ b/src/binder_v2/select.rs
@@ -23,7 +23,7 @@ impl Binder {
         };
         let offset = match query.offset {
             Some(offset) => self.bind_expr(offset.value)?,
-            None => self.egraph.add(Node::null()),
+            None => self.egraph.add(Node::zero()),
         };
         Ok(self.egraph.add(Node::Limit([limit, offset, child])))
     }

--- a/src/binder_v2/table.rs
+++ b/src/binder_v2/table.rs
@@ -94,7 +94,7 @@ impl Binder {
     }
 
     fn bind_table_name(&mut self, name: ObjectName) -> Result {
-        let name = lower_case_name(name);
+        let name = lower_case_name(&name);
         let (database_name, schema_name, table_name) = split_name(&name)?;
         if self.current_ctx().tables.contains_key(table_name) {
             return Err(BindError::DuplicatedTable(table_name.into()));
@@ -120,7 +120,7 @@ impl Binder {
     /// Returns the Id of a list of columns.
     pub(super) fn bind_table_columns(
         &mut self,
-        table_name: ObjectName,
+        table_name: &ObjectName,
         columns: &[Ident],
     ) -> Result {
         let name = lower_case_name(table_name);
@@ -158,20 +158,15 @@ impl Binder {
     }
 
     /// Returns the Id of a node `TableRefId`.
-    pub(super) fn bind_table_id(&mut self, table: TableFactor) -> Result {
-        match table {
-            TableFactor::Table { name, .. } => {
-                let name = lower_case_name(name);
-                let (database_name, schema_name, table_name) = split_name(&name)?;
+    pub(super) fn bind_table_id(&mut self, table_name: &ObjectName) -> Result {
+        let name = lower_case_name(table_name);
+        let (database_name, schema_name, table_name) = split_name(&name)?;
 
-                let table_ref_id = self
-                    .catalog
-                    .get_table_id_by_name(database_name, schema_name, table_name)
-                    .ok_or_else(|| BindError::InvalidTable(table_name.into()))?;
-                let id = self.egraph.add(Node::Table(table_ref_id));
-                Ok(id)
-            }
-            _ => panic!("bind table id"),
-        }
+        let table_ref_id = self
+            .catalog
+            .get_table_id_by_name(database_name, schema_name, table_name)
+            .ok_or_else(|| BindError::InvalidTable(table_name.into()))?;
+        let id = self.egraph.add(Node::Table(table_ref_id));
+        Ok(id)
     }
 }

--- a/src/binder_v2/table.rs
+++ b/src/binder_v2/table.rs
@@ -11,7 +11,7 @@ impl Binder {
         for table in tables {
             let table_node = self.bind_table_with_joins(table)?;
             node = Some(if let Some(node) = node {
-                let ty = self.egraph.add(Node::Cross);
+                let ty = self.egraph.add(Node::Inner);
                 let expr = self.egraph.add(Node::true_());
                 self.egraph.add(Node::Join([ty, expr, node, table_node]))
             } else {
@@ -78,7 +78,7 @@ impl Binder {
                 Ok((ty, condition))
             }
             CrossJoin => {
-                let ty = self.egraph.add(Node::Cross);
+                let ty = self.egraph.add(Node::Inner);
                 let condition = self.egraph.add(Node::true_());
                 Ok((ty, condition))
             }

--- a/src/catalog/column.rs
+++ b/src/catalog/column.rs
@@ -57,7 +57,7 @@ impl DataType {
 }
 
 /// The catalog of a column.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct ColumnCatalog {
     id: ColumnId,
     desc: ColumnDesc,

--- a/src/db.rs
+++ b/src/db.rs
@@ -178,8 +178,12 @@ impl Database {
                 let bound = binder.bind(stmt)?;
                 let optimized = crate::planner::optimize(&bound);
                 let executor = match self.storage.clone() {
-                    StorageImpl::InMemoryStorage(s) => crate::executor_v2::build(s, &optimized),
-                    StorageImpl::SecondaryStorage(s) => crate::executor_v2::build(s, &optimized),
+                    StorageImpl::InMemoryStorage(s) => {
+                        crate::executor_v2::build(self.catalog.clone(), s, &optimized)
+                    }
+                    StorageImpl::SecondaryStorage(s) => {
+                        crate::executor_v2::build(self.catalog.clone(), s, &optimized)
+                    }
                 };
                 let output = executor.try_collect().await?;
                 let chunk = Chunk::new(output);

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -156,6 +156,13 @@ impl ArrayImpl {
                     #[cfg(not(feature = "simd"))]
                     (A::Float64(a), A::Float64(b)) => A::new_float64(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op *b)),
 
+                    (A::Int32(a), A::Decimal(b)) => A::new_decimal(binary_op(a.as_ref(), b.as_ref(), |a, b| Decimal::from(*a) $op *b)),
+                    (A::Int64(a), A::Decimal(b)) => A::new_decimal(binary_op(a.as_ref(), b.as_ref(), |a, b| Decimal::from(*a) $op *b)),
+                    (A::Float64(a), A::Decimal(b)) => A::new_decimal(binary_op(a.as_ref(), b.as_ref(), |a, b| Decimal::from_f64_retain(a.0).unwrap() $op *b)),
+                    (A::Decimal(a), A::Int32(b)) => A::new_decimal(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op Decimal::from(*b))),
+                    (A::Decimal(a), A::Int64(b)) => A::new_decimal(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op Decimal::from(*b))),
+                    (A::Decimal(a), A::Float64(b)) => A::new_decimal(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op Decimal::from_f64_retain(b.0).unwrap())),
+
                     (A::Decimal(a), A::Decimal(b)) => A::new_decimal(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Date(a), A::Interval(b)) => A::new_date(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op *b)),
 
@@ -173,6 +180,12 @@ impl ArrayImpl {
                     (A::Utf8(a), A::Utf8(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Date(a), A::Date(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
                     (A::Decimal(a), A::Decimal(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| a $op b)),
+                    (A::Int32(a), A::Decimal(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| Decimal::from(*a) $op *b)),
+                    (A::Int64(a), A::Decimal(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| Decimal::from(*a) $op *b)),
+                    (A::Float64(a), A::Decimal(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| Decimal::from_f64_retain(a.0).unwrap() $op *b)),
+                    (A::Decimal(a), A::Int32(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op Decimal::from(*b))),
+                    (A::Decimal(a), A::Int64(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op Decimal::from(*b))),
+                    (A::Decimal(a), A::Float64(b)) => A::new_bool(binary_op(a.as_ref(), b.as_ref(), |a, b| *a $op Decimal::from_f64_retain(b.0).unwrap())),
                     _ => return Err(no_op()),
                 }
             }

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -361,11 +361,11 @@ impl ArrayImpl {
     /// Returns the sum of values.
     pub fn sum(&self) -> DataValue {
         match self {
-            Self::Int32(a) => DataValue::Int64(a.iter().filter_map(|x| x).map(|x| *x as i64).sum()),
-            Self::Int64(a) => DataValue::Int64(a.iter().filter_map(|x| x).sum()),
-            Self::Float64(a) => DataValue::Float64(a.iter().filter_map(|x| x).sum()),
-            Self::Decimal(a) => DataValue::Decimal(a.iter().filter_map(|x| x).sum()),
-            Self::Interval(a) => DataValue::Interval(a.iter().filter_map(|x| x).sum()),
+            Self::Int32(a) => DataValue::Int32(a.iter().flatten().sum()),
+            Self::Int64(a) => DataValue::Int64(a.iter().flatten().sum()),
+            Self::Float64(a) => DataValue::Float64(a.iter().flatten().sum()),
+            Self::Decimal(a) => DataValue::Decimal(a.iter().flatten().sum()),
+            Self::Interval(a) => DataValue::Interval(a.iter().flatten().sum()),
             _ => panic!("can not sum array"),
         }
     }
@@ -378,28 +378,28 @@ macro_rules! impl_agg {
             /// Returns the minimum of values.
             pub fn min_(&self) -> DataValue {
                 match self {
-                    $(Self::$Abc(a) => a.iter().filter_map(|x| x).min().into(),)*
+                    $(Self::$Abc(a) => a.iter().flatten().min().into(),)*
                 }
             }
 
             /// Returns the maximum of values.
             pub fn max_(&self) -> DataValue {
                 match self {
-                    $(Self::$Abc(a) => a.iter().filter_map(|x| x).max().into(),)*
+                    $(Self::$Abc(a) => a.iter().flatten().max().into(),)*
                 }
             }
 
             /// Returns the first non-null value.
             pub fn first(&self) -> DataValue {
                 match self {
-                    $(Self::$Abc(a) => a.iter().filter_map(|x| x).next().into(),)*
+                    $(Self::$Abc(a) => a.iter().flatten().next().into(),)*
                 }
             }
 
             /// Returns the last non-null value.
             pub fn last(&self) -> DataValue {
                 match self {
-                    $(Self::$Abc(a) => a.iter().rev().filter_map(|x| x).next().into(),)*
+                    $(Self::$Abc(a) => a.iter().rev().flatten().next().into(),)*
                 }
             }
         }

--- a/src/executor_v2/copy_from_file.rs
+++ b/src/executor_v2/copy_from_file.rs
@@ -41,7 +41,7 @@ impl CopyFromFileExecutor {
         let file = File::open(self.source.path)?;
         let file_size = file.metadata()?.len();
         let mut buf_reader = BufReader::new(file);
-        let mut reader = match self.source.format.clone() {
+        let mut reader = match self.source.format {
             FileFormat::Csv {
                 delimiter,
                 quote,

--- a/src/executor_v2/copy_from_file.rs
+++ b/src/executor_v2/copy_from_file.rs
@@ -1,0 +1,157 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::fs::File;
+use std::io::BufReader;
+
+use indicatif::{ProgressBar, ProgressStyle};
+use itertools::izip;
+use tokio::sync::mpsc::Sender;
+
+use super::*;
+use crate::array::DataChunkBuilder;
+use crate::binder_v2::copy::{ExtSource, FileFormat};
+
+/// The executor of loading file data.
+pub struct CopyFromFileExecutor {
+    pub source: ExtSource,
+    pub types: Vec<DataType>,
+}
+
+/// When the source file size is above the limit, we show a progress bar on the screen.
+const IMPORT_PROGRESS_BAR_LIMIT: u64 = 1024 * 1024;
+
+impl CopyFromFileExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self) {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        // # Cancellation
+        // When this stream is dropped, the `rx` is dropped, the spawned task will fail to send to
+        // `tx`, then the task will finish.
+        let handle = tokio::task::spawn_blocking(|| self.read_file_blocking(tx));
+        while let Some(chunk) = rx.recv().await {
+            yield chunk;
+        }
+        handle.await.unwrap()?;
+    }
+
+    /// Read records from file using blocking IO.
+    ///
+    /// The read data chunks will be sent through `tx`.
+    fn read_file_blocking(self, tx: Sender<DataChunk>) -> Result<(), ExecutorError> {
+        let file = File::open(self.source.path)?;
+        let file_size = file.metadata()?.len();
+        let mut buf_reader = BufReader::new(file);
+        let mut reader = match self.source.format.clone() {
+            FileFormat::Csv {
+                delimiter,
+                quote,
+                escape,
+                header,
+            } => csv::ReaderBuilder::new()
+                .delimiter(delimiter as u8)
+                .quote(quote as u8)
+                .escape(escape.map(|c| c as u8))
+                .has_headers(header)
+                .from_reader(&mut buf_reader),
+        };
+
+        let bar = if file_size < IMPORT_PROGRESS_BAR_LIMIT {
+            // disable progress bar if file size is < 1MB
+            ProgressBar::hidden()
+        } else {
+            let bar = ProgressBar::new(file_size);
+            bar.set_style(
+                ProgressStyle::default_bar()
+                    .template("[{elapsed_precise}] {bar:40.cyan/blue} {bytes}/{total_bytes}")
+                    .progress_chars("=>-"),
+            );
+            bar
+        };
+
+        let column_count = self.types.len();
+
+        // create chunk builder
+        let mut chunk_builder = DataChunkBuilder::new(&self.types, PROCESSING_WINDOW_SIZE);
+        let mut size_count = 0;
+
+        for record in reader.records() {
+            // read records and push raw str rows into data chunk builder
+            let record = record?;
+
+            if !(record.len() == column_count
+                || record.len() == column_count + 1 && record.get(column_count) == Some(""))
+            {
+                return Err(ExecutorError::LengthMismatch {
+                    expected: column_count,
+                    actual: record.len(),
+                });
+            }
+
+            let str_row_data: Result<Vec<&str>, _> = izip!(record.iter(), &self.types)
+                .map(|(v, ty)| {
+                    if !ty.nullable && v.is_empty() {
+                        return Err(ExecutorError::NotNullable);
+                    }
+                    Ok(v)
+                })
+                .collect();
+            size_count += record.as_slice().as_bytes().len();
+
+            // push a raw str row and send it if necessary
+            if let Some(chunk) = chunk_builder.push_str_row(str_row_data?)? {
+                bar.set_position(size_count as u64);
+                tx.blocking_send(chunk).map_err(|_| ExecutorError::Abort)?;
+            }
+        }
+        // send left chunk
+        if let Some(chunk) = chunk_builder.take() {
+            tx.blocking_send(chunk).map_err(|_| ExecutorError::Abort)?;
+        }
+        bar.finish();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+    use crate::array::ArrayImpl;
+    use crate::types::DataTypeKind;
+
+    #[tokio::test]
+    async fn read_csv() {
+        let csv = "1,1.5,one\n2,2.5,two\n";
+
+        let mut file = tempfile::NamedTempFile::new().expect("failed to create temp file");
+        write!(file, "{}", csv).expect("failed to write file");
+
+        let executor = CopyFromFileExecutor {
+            source: ExtSource {
+                path: file.path().into(),
+                format: FileFormat::Csv {
+                    delimiter: ',',
+                    quote: '"',
+                    escape: None,
+                    header: false,
+                },
+            },
+            types: vec![
+                DataTypeKind::Int32.not_null(),
+                DataTypeKind::Float64.not_null(),
+                DataTypeKind::String.not_null(),
+            ],
+        };
+        let actual = executor.execute().next().await.unwrap().unwrap();
+
+        let expected: DataChunk = [
+            ArrayImpl::new_int32([1, 2].into_iter().collect()),
+            ArrayImpl::new_float64([1.5, 2.5].into_iter().collect()),
+            ArrayImpl::new_utf8(["one", "two"].iter().map(Some).collect()),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/executor_v2/copy_to_file.rs
+++ b/src/executor_v2/copy_to_file.rs
@@ -1,0 +1,113 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::fs::File;
+use std::path::PathBuf;
+
+use tokio::sync::mpsc;
+
+use super::*;
+use crate::binder_v2::copy::{ExtSource, FileFormat};
+
+/// The executor of saving data to file.
+pub struct CopyToFileExecutor {
+    pub source: ExtSource,
+}
+
+impl CopyToFileExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, child: BoxedExecutor) {
+        let (sender, recver) = mpsc::channel(1);
+        // # Cancellation
+        // When this stream is dropped, the `sender` is dropped, the `recver` will return
+        // `None` in the spawned task, then the task will finish.
+        let writer = tokio::task::spawn_blocking(move || {
+            Self::write_file_blocking(self.source.path, self.source.format, recver)
+        });
+        #[for_await]
+        for batch in child {
+            let res = sender.send(batch?).await;
+            if res.is_err() {
+                // send error means the background IO task returns error.
+                break;
+            }
+        }
+        drop(sender);
+        let rows = writer.await.unwrap()?;
+        yield DataChunk::single(rows as _);
+    }
+
+    fn write_file_blocking(
+        path: PathBuf,
+        format: FileFormat,
+        mut recver: mpsc::Receiver<DataChunk>,
+    ) -> Result<usize, ExecutorError> {
+        let file = File::create(&path)?;
+        let mut writer = match format {
+            FileFormat::Csv {
+                delimiter,
+                quote,
+                escape,
+                header,
+            } => csv::WriterBuilder::new()
+                .delimiter(delimiter as u8)
+                .quote(quote as u8)
+                .escape(escape.unwrap_or(quote) as u8)
+                .has_headers(header)
+                .from_writer(file),
+        };
+
+        let mut rows = 0;
+
+        while let Some(chunk) = recver.blocking_recv() {
+            for i in 0..chunk.cardinality() {
+                // TODO(wrj): avoid dynamic memory allocation (String)
+                let row = chunk.arrays().iter().map(|a| a.get_to_string(i));
+                writer.write_record(row)?;
+            }
+            writer.flush()?;
+            rows += chunk.cardinality();
+        }
+        // the task maybe completed or cancelled.
+        // if cancelled, just leave the file as it is.
+
+        Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::array::ArrayImpl;
+
+    #[tokio::test]
+    async fn write_csv() {
+        let file = tempfile::NamedTempFile::new().expect("failed to create temp file");
+
+        let executor = CopyToFileExecutor {
+            source: ExtSource {
+                path: file.path().into(),
+                format: FileFormat::Csv {
+                    delimiter: ',',
+                    quote: '"',
+                    escape: None,
+                    header: false,
+                },
+            },
+        };
+        let child = async_stream::try_stream! {
+            yield [
+                ArrayImpl::new_int32([1, 2].into_iter().collect()),
+                ArrayImpl::new_float64([1.5, 2.5].into_iter().collect()),
+                ArrayImpl::new_utf8(["one", "two"].iter().map(Some).collect()),
+            ]
+            .into_iter()
+            .collect();
+        }
+        .boxed();
+        executor.execute(child).next().await.unwrap().unwrap();
+
+        let actual = std::fs::read_to_string(file.path()).unwrap();
+        let expected = "1,1.5,one\n2,2.5,two\n";
+        assert_eq!(actual, expected);
+    }
+}

--- a/src/executor_v2/create.rs
+++ b/src/executor_v2/create.rs
@@ -1,0 +1,31 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use super::*;
+use crate::binder_v2::CreateTable;
+use crate::storage::Storage;
+
+/// The executor of `create table` statement.
+pub struct CreateTableExecutor<S: Storage> {
+    pub plan: CreateTable,
+    pub storage: Arc<S>,
+}
+
+impl<S: Storage> CreateTableExecutor<S> {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self) {
+        self.storage
+            .create_table(
+                self.plan.database_id,
+                self.plan.schema_id,
+                &self.plan.table_name,
+                &self.plan.columns,
+                &self.plan.ordered_pk_ids,
+            )
+            .await?;
+
+        let chunk = DataChunk::single(1);
+        yield chunk
+    }
+}

--- a/src/executor_v2/drop.rs
+++ b/src/executor_v2/drop.rs
@@ -1,0 +1,23 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use super::*;
+use crate::binder_v2::{BoundDrop, Object};
+use crate::storage::Storage;
+
+/// The executor of `drop` statement.
+pub struct DropExecutor<S: Storage> {
+    pub plan: BoundDrop,
+    pub storage: Arc<S>,
+}
+
+impl<S: Storage> DropExecutor<S> {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self) {
+        match self.plan.object {
+            Object::Table(id) => self.storage.drop_table(id).await?,
+        }
+        yield DataChunk::single(1);
+    }
+}

--- a/src/executor_v2/evaluator.rs
+++ b/src/executor_v2/evaluator.rs
@@ -76,6 +76,7 @@ impl<'a> ExprRef<'a> {
                         .collect(),
                 ))
             }
+            Asc(a) | Desc(a) => self.next(*a).eval(chunk),
             e => {
                 if let Some((op, a, b)) = e.binary_op() {
                     let left = self.next(a).eval(chunk)?;
@@ -135,5 +136,18 @@ impl<'a> ExprRef<'a> {
             Last(a) => Ok(self.next(*a).eval(chunk)?.last().or(state)),
             t => panic!("not aggregation: {t}"),
         }
+    }
+
+    /// Returns a list of bools for order keys.
+    ///
+    /// The bool is false if the order is ascending, true if the order is descending.
+    pub fn orders(&self) -> Vec<bool> {
+        (self.node().as_list().iter())
+            .map(|id| match self.next(*id).node() {
+                Expr::Asc(_) => false,
+                Expr::Desc(_) => true,
+                _ => panic!("not order"),
+            })
+            .collect()
     }
 }

--- a/src/executor_v2/explain.rs
+++ b/src/executor_v2/explain.rs
@@ -9,11 +9,17 @@ use crate::planner::{costs, Explain};
 /// The executor of `explain` statement.
 pub struct ExplainExecutor {
     pub plan: RecExpr,
+    pub catalog: RootCatalogRef,
 }
 
 impl ExplainExecutor {
     pub fn execute(self) -> BoxedExecutor {
-        let explain = format!("{}", Explain::with_costs(&self.plan, &costs(&self.plan)));
+        let explain = format!(
+            "{}",
+            Explain::of(&self.plan)
+                .with_costs(&costs(&self.plan))
+                .with_catalog(&self.catalog)
+        );
         let chunk =
             DataChunk::from_iter([ArrayImpl::new_utf8(Utf8Array::from_iter([Some(explain)]))]);
 

--- a/src/executor_v2/hash_agg.rs
+++ b/src/executor_v2/hash_agg.rs
@@ -1,0 +1,54 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::collections::HashMap;
+
+use iter_chunks::IterChunks;
+use smallvec::{smallvec, SmallVec};
+
+use super::*;
+use crate::array::{ArrayBuilderImpl, ArrayImpl, DataChunkBuilder};
+use crate::types::DataValue;
+
+/// The executor of hash aggregation.
+pub struct HashAggExecutor {
+    pub aggs: RecExpr,
+    pub group_keys: RecExpr,
+    pub types: Vec<DataType>,
+}
+
+pub type GroupKeys = SmallVec<[DataValue; 16]>;
+pub type AggValue = SmallVec<[DataValue; 16]>;
+
+impl HashAggExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, child: BoxedExecutor) {
+        let len = self.aggs.as_ref().last().unwrap().as_list().len();
+        let mut states = HashMap::<GroupKeys, AggValue>::new();
+
+        #[for_await]
+        for chunk in child {
+            let chunk = chunk?;
+            let keys_chunk = ExprRef::new(&self.group_keys).eval_list(&chunk)?;
+
+            for i in 0..chunk.cardinality() {
+                let keys = keys_chunk.row(i).values().collect();
+                let states = states
+                    .entry(keys)
+                    .or_insert_with(|| smallvec![DataValue::Null; len]);
+                ExprRef::new(&self.aggs).eval_agg_list(states, &chunk.slice(i..=i))?;
+            }
+        }
+
+        let mut batches = IterChunks::chunks(states.into_iter(), PROCESSING_WINDOW_SIZE);
+        while let Some(batch) = batches.next() {
+            let mut builder = DataChunkBuilder::new(&self.types, PROCESSING_WINDOW_SIZE);
+            println!("{:?}", self.types);
+            for (key, aggs) in batch {
+                builder.push_row(aggs.into_iter().chain(key.into_iter()));
+            }
+            if let Some(chunk) = builder.take() {
+                yield chunk;
+            }
+        }
+    }
+}

--- a/src/executor_v2/hash_agg.rs
+++ b/src/executor_v2/hash_agg.rs
@@ -42,7 +42,6 @@ impl HashAggExecutor {
         let mut batches = IterChunks::chunks(states.into_iter(), PROCESSING_WINDOW_SIZE);
         while let Some(batch) = batches.next() {
             let mut builder = DataChunkBuilder::new(&self.types, PROCESSING_WINDOW_SIZE);
-            println!("{:?}", self.types);
             for (key, aggs) in batch {
                 builder.push_row(aggs.into_iter().chain(key.into_iter()));
             }

--- a/src/executor_v2/hash_join.rs
+++ b/src/executor_v2/hash_join.rs
@@ -1,0 +1,104 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::collections::{HashMap, HashSet};
+use std::vec::Vec;
+
+use futures::TryStreamExt;
+use smallvec::SmallVec;
+
+use super::*;
+use crate::array::{DataChunk, DataChunkBuilder, RowRef};
+use crate::binder::{BoundExpr, BoundJoinOperator};
+use crate::types::{DataType, DataValue};
+
+/// The executor for hash join
+pub struct HashJoinExecutor {
+    pub op: Expr,
+    pub left_keys: RecExpr,
+    pub right_keys: RecExpr,
+    pub left_types: Vec<DataType>,
+    pub right_types: Vec<DataType>,
+}
+
+pub type JoinKeys = SmallVec<[DataValue; 16]>;
+
+impl HashJoinExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, left: BoxedExecutor, right: BoxedExecutor) {
+        // collect all chunks from children
+        let (left_chunks, right_chunks) = async {
+            tokio::try_join!(
+                left.try_collect::<Vec<DataChunk>>(),
+                right.try_collect::<Vec<DataChunk>>(),
+            )
+        }
+        .await?;
+
+        // build
+        let mut hash_map: HashMap<JoinKeys, Vec<RowRef<'_>>> = HashMap::new();
+        for chunk in &left_chunks {
+            let keys_chunk = ExprRef::new(&self.left_keys).eval_list(chunk)?;
+            for i in 0..chunk.cardinality() {
+                let keys = keys_chunk.row(i).values().collect();
+                let row = chunk.row(i);
+                hash_map.entry(keys).or_insert_with(Vec::new).push(row);
+                tokio::task::consume_budget().await;
+            }
+        }
+
+        let data_types = self.left_types.iter().chain(self.right_types.iter());
+        let mut builder = DataChunkBuilder::new(data_types, PROCESSING_WINDOW_SIZE);
+        let mut right_keys = HashSet::new();
+
+        // probe
+        for chunk in &right_chunks {
+            let keys_chunk = ExprRef::new(&self.right_keys).eval_list(chunk)?;
+            for i in 0..chunk.cardinality() {
+                let right_row = chunk.row(i);
+                let keys: JoinKeys = keys_chunk.row(i).values().collect();
+                right_keys.insert(keys.clone());
+                if let Some(left_rows) = hash_map.get(&keys) {
+                    for left_row in left_rows {
+                        let values = left_row.values().chain(right_row.values());
+                        if let Some(chunk) = builder.push_row(values) {
+                            yield chunk;
+                        }
+                    }
+                } else if matches!(self.op, Expr::RightOuter | Expr::FullOuter) {
+                    // append row: (NULL, right)
+                    let values =
+                        (self.left_types.iter().map(|_| DataValue::Null)).chain(right_row.values());
+                    if let Some(chunk) = builder.push_row(values) {
+                        yield chunk;
+                    }
+                }
+                tokio::task::consume_budget().await;
+            }
+        }
+
+        // append rows for left outer join
+        if matches!(self.op, Expr::LeftOuter | Expr::FullOuter) {
+            for chunk in &left_chunks {
+                let keys_chunk = ExprRef::new(&self.left_keys).eval_list(chunk)?;
+                for i in 0..chunk.cardinality() {
+                    let keys: JoinKeys = keys_chunk.row(i).values().collect();
+                    let row = chunk.row(i);
+                    if right_keys.contains(&keys) {
+                        continue;
+                    }
+                    // append row: (left, NULL)
+                    let values =
+                        (row.values()).chain(self.right_types.iter().map(|_| DataValue::Null));
+                    if let Some(chunk) = builder.push_row(values) {
+                        yield chunk;
+                    }
+                    tokio::task::consume_budget().await;
+                }
+            }
+        }
+
+        if let Some(chunk) = builder.take() {
+            yield chunk;
+        }
+    }
+}

--- a/src/executor_v2/insert.rs
+++ b/src/executor_v2/insert.rs
@@ -1,0 +1,111 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use super::*;
+use crate::array::{ArrayBuilderImpl, DataChunk};
+use crate::catalog::{ColumnCatalog, TableRefId};
+use crate::storage::{Storage, Table, Transaction};
+use crate::types::{ColumnId, ColumnIndex, DataType, DataValue};
+
+/// The executor of `insert` statement.
+pub struct InsertExecutor<S: Storage> {
+    pub table_id: TableRefId,
+    pub column_ids: Vec<ColumnId>,
+    pub storage: Arc<S>,
+}
+
+impl<S: Storage> InsertExecutor<S> {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, child: BoxedExecutor) {
+        let table = self.storage.get_table(self.table_id)?;
+        let columns = table.columns()?;
+        let projs = columns
+            .iter()
+            .map(
+                |col| match self.column_ids.iter().position(|&id| id == col.id()) {
+                    Some(index) => Expr::ColumnIndex(ColumnIndex(index as _)),
+                    None => Expr::Type(col.datatype().kind()),
+                },
+            )
+            .collect_vec();
+
+        let mut txn = table.write().await?;
+        let mut cnt = 0;
+        #[for_await]
+        for chunk in child {
+            let chunk = chunk?;
+            let chunk: DataChunk = projs
+                .iter()
+                .map(|col| match col {
+                    Expr::ColumnIndex(idx) => chunk.array_at(idx.0 as _).clone(),
+                    Expr::Type(ty) => {
+                        let mut builder = ArrayBuilderImpl::with_capacity(
+                            chunk.cardinality(),
+                            &ty.clone().nullable(),
+                        );
+                        for _ in 0..chunk.cardinality() {
+                            builder.push(&DataValue::Null);
+                        }
+                        builder.finish()
+                    }
+                    _ => unreachable!(),
+                })
+                .collect();
+            cnt += chunk.cardinality();
+            txn.append(chunk).await?;
+        }
+        txn.commit().await?;
+
+        yield DataChunk::single(cnt as i32);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::array::ArrayImpl;
+    use crate::catalog::{ColumnCatalog, TableRefId};
+    use crate::storage::InMemoryStorage;
+    use crate::types::DataTypeKind;
+
+    #[tokio::test]
+    async fn simple() {
+        let storage = create_table().await;
+        let executor = InsertExecutor {
+            table_id: TableRefId::new(0, 0, 0),
+            column_ids: vec![0, 1],
+            storage: storage.as_in_memory_storage(),
+        };
+        let source = async_stream::try_stream! {
+            yield [
+                ArrayImpl::new_int32((0..4).collect()),
+                ArrayImpl::new_int32((100..104).collect()),
+            ]
+            .into_iter()
+            .collect();
+        }
+        .boxed();
+        executor.execute(source).next().await.unwrap().unwrap();
+    }
+
+    async fn create_table() -> StorageImpl {
+        let storage = StorageImpl::InMemoryStorage(Arc::new(InMemoryStorage::new()));
+        storage
+            .as_in_memory_storage()
+            .create_table(
+                0,
+                0,
+                "t".into(),
+                &[
+                    ColumnCatalog::new(0, DataTypeKind::Int32.not_null().to_column("v1".into())),
+                    ColumnCatalog::new(1, DataTypeKind::Int32.not_null().to_column("v2".into())),
+                ],
+                &[],
+            )
+            .await;
+        storage
+    }
+}

--- a/src/executor_v2/insert.rs
+++ b/src/executor_v2/insert.rs
@@ -98,7 +98,7 @@ mod tests {
             .create_table(
                 0,
                 0,
-                "t".into(),
+                "t",
                 &[
                     ColumnCatalog::new(0, DataTypeKind::Int32.not_null().to_column("v1".into())),
                     ColumnCatalog::new(1, DataTypeKind::Int32.not_null().to_column("v2".into())),

--- a/src/executor_v2/limit.rs
+++ b/src/executor_v2/limit.rs
@@ -1,0 +1,82 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use super::*;
+use crate::array::DataChunk;
+
+/// The executor of a limit operation.
+pub struct LimitExecutor {
+    pub offset: usize,
+    pub limit: usize,
+}
+
+impl LimitExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, child: BoxedExecutor) {
+        // the number of rows have been processed
+        let mut processed = 0;
+
+        #[for_await]
+        for batch in child {
+            if self.limit == 0 {
+                break;
+            }
+            let batch = batch?;
+            let cardinality = batch.cardinality();
+            let start = processed.max(self.offset) - processed;
+            let end = (processed + cardinality).min(self.offset + self.limit) - processed;
+            processed += cardinality;
+            if start >= end {
+                continue;
+            }
+            if (start..end) == (0..cardinality) {
+                yield batch;
+            } else {
+                yield batch.slice(start..end);
+            }
+            if processed >= self.offset + self.limit {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+
+    use futures::TryStreamExt;
+    use test_case::test_case;
+
+    use super::*;
+    use crate::array::ArrayImpl;
+
+    #[test_case(&[(0..6)], 1, 4, &[(1..5)])]
+    #[test_case(&[(0..6)], 0, 10, &[(0..6)])]
+    #[test_case(&[(0..6)], 10, 0, &[])]
+    #[test_case(&[(0..2), (2..4), (4..6)], 1, 4, &[(1..2),(2..4),(4..5)])]
+    #[test_case(&[(0..2), (2..4), (4..6)], 1, 2, &[(1..2),(2..3)])]
+    #[test_case(&[(0..2), (2..4), (4..6)], 3, 0, &[])]
+    #[tokio::test]
+    async fn limit(
+        inputs: &'static [Range<i32>],
+        offset: usize,
+        limit: usize,
+        outputs: &'static [Range<i32>],
+    ) {
+        let executor = LimitExecutor { offset, limit };
+        let child = futures::stream::iter(inputs.iter().map(range_to_chunk).map(Ok)).boxed();
+        let actual = executor
+            .execute(child)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let outputs = outputs.iter().map(range_to_chunk).collect_vec();
+        assert_eq!(actual, outputs);
+    }
+
+    fn range_to_chunk(range: &Range<i32>) -> DataChunk {
+        [ArrayImpl::new_int32(range.clone().collect())]
+            .into_iter()
+            .collect()
+    }
+}

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -22,11 +22,11 @@ use futures_async_stream::try_stream;
 use itertools::Itertools;
 use minitrace::prelude::*;
 
-use self::evaluator::*;
 // pub use self::aggregation::*;
 // use self::copy_from_file::*;
 // use self::copy_to_file::*;
-// use self::create::*;
+use self::create::*;
+use self::evaluator::*;
 // use self::delete::*;
 // use self::drop::*;
 // use self::dummy_scan::*;
@@ -60,7 +60,7 @@ use crate::types::{ConvertError, DataType, DataValue};
 // mod aggregation;
 // mod copy_from_file;
 // mod copy_to_file;
-// mod create;
+mod create;
 // mod delete;
 // mod drop;
 // mod dummy_scan;
@@ -235,7 +235,13 @@ impl<S: Storage> Builder<S> {
             Join(_) => todo!(),
             HashJoin(_) => todo!(),
             Agg(_) => todo!(),
-            CreateTable(_) => todo!(),
+
+            CreateTable(plan) => CreateTableExecutor {
+                plan,
+                storage: self.storage.clone(),
+            }
+            .execute(),
+
             Drop(_) => todo!(),
 
             Insert([table, cols, child]) => InsertExecutor {

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -37,7 +37,7 @@ use self::insert::*;
 // use self::internal::*;
 // use self::limit::*;
 // use self::nested_loop_join::*;
-// use self::order::*;
+use self::order::*;
 // #[allow(unused_imports)]
 // use self::perfect_hash_agg::*;
 use self::projection::*;
@@ -72,7 +72,7 @@ mod insert;
 // mod internal;
 // mod limit;
 // mod nested_loop_join;
-// mod order;
+mod order;
 // mod perfect_hash_agg;
 mod projection;
 mod simple_agg;
@@ -222,7 +222,12 @@ impl<S: Storage> Builder<S> {
             }
             .execute(self.build_id(child)),
 
-            Order(_) => todo!(),
+            Order([order_keys, child]) => OrderExecutor {
+                order_keys: self.resolve_column_index(order_keys, child),
+                types: self.plan_types(id).to_vec(),
+            }
+            .execute(self.build_id(child)),
+
             Limit(_) => todo!(),
             TopN(_) => todo!(),
             Join(_) => todo!(),

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -25,9 +25,9 @@ use minitrace::prelude::*;
 // use self::copy_from_file::*;
 // use self::copy_to_file::*;
 use self::create::*;
-use self::evaluator::*;
 // use self::delete::*;
-// use self::drop::*;
+use self::drop::*;
+use self::evaluator::*;
 // use self::dummy_scan::*;
 use self::explain::*;
 use self::filter::*;
@@ -61,7 +61,7 @@ use crate::types::{ConvertError, DataType, DataValue};
 // mod copy_to_file;
 mod create;
 // mod delete;
-// mod drop;
+mod drop;
 // mod dummy_scan;
 mod evaluator;
 mod explain;
@@ -257,7 +257,11 @@ impl<S: Storage> Builder<S> {
             }
             .execute(),
 
-            Drop(_) => todo!(),
+            Drop(plan) => DropExecutor {
+                plan,
+                storage: self.storage.clone(),
+            }
+            .execute(),
 
             Insert([table, cols, child]) => InsertExecutor {
                 table_id: self.node(table).as_table(),

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -34,7 +34,7 @@ use self::explain::*;
 use self::filter::*;
 // use self::hash_agg::*;
 // use self::hash_join::*;
-// use self::insert::*;
+use self::insert::*;
 // use self::internal::*;
 // use self::limit::*;
 // use self::nested_loop_join::*;
@@ -69,7 +69,7 @@ mod explain;
 mod filter;
 // mod hash_agg;
 // mod hash_join;
-// mod insert;
+mod insert;
 // mod internal;
 // mod limit;
 // mod nested_loop_join;
@@ -237,7 +237,16 @@ impl<S: Storage> Builder<S> {
             Agg(_) => todo!(),
             CreateTable(_) => todo!(),
             Drop(_) => todo!(),
-            Insert(_) => todo!(),
+
+            Insert([table, cols, child]) => InsertExecutor {
+                table_id: self.node(table).as_table(),
+                column_ids: (self.node(cols).as_list().iter())
+                    .map(|id| self.node(*id).as_column().column_id)
+                    .collect(),
+                storage: self.storage.clone(),
+            }
+            .execute(self.build_id(child)),
+
             Delete(_) => todo!(),
             CopyFrom(_) => todo!(),
             CopyTo(_) => todo!(),

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -35,7 +35,7 @@ use self::hash_agg::*;
 use self::hash_join::*;
 use self::insert::*;
 // use self::internal::*;
-// use self::limit::*;
+use self::limit::*;
 // use self::nested_loop_join::*;
 use self::order::*;
 // #[allow(unused_imports)]
@@ -70,7 +70,7 @@ mod hash_agg;
 mod hash_join;
 mod insert;
 // mod internal;
-// mod limit;
+mod limit;
 // mod nested_loop_join;
 mod order;
 // mod perfect_hash_agg;
@@ -228,7 +228,12 @@ impl<S: Storage> Builder<S> {
             }
             .execute(self.build_id(child)),
 
-            Limit(_) => todo!(),
+            Limit([limit, offset, child]) => LimitExecutor {
+                limit: (self.node(limit).as_const().as_usize().unwrap()).unwrap_or(usize::MAX / 2),
+                offset: self.node(offset).as_const().as_usize().unwrap().unwrap(),
+            }
+            .execute(self.build_id(child)),
+
             TopN(_) => todo!(),
             Join(_) => todo!(),
 

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -143,6 +143,7 @@ pub fn build(catalog: RootCatalogRef, storage: Arc<impl Storage>, plan: &RecExpr
 /// The builder of executor.
 struct Builder<S: Storage> {
     storage: Arc<S>,
+    catalog: RootCatalogRef,
     egraph: egg::EGraph<Expr, TypeSchemaAnalysis>,
     root: Id,
 }
@@ -150,10 +151,13 @@ struct Builder<S: Storage> {
 impl<S: Storage> Builder<S> {
     /// Create a new executor builder.
     fn new(catalog: RootCatalogRef, storage: Arc<S>, plan: &RecExpr) -> Self {
-        let mut egraph = egg::EGraph::new(TypeSchemaAnalysis { catalog });
+        let mut egraph = egg::EGraph::new(TypeSchemaAnalysis {
+            catalog: catalog.clone(),
+        });
         let root = egraph.add_expr(plan);
         Builder {
             storage,
+            catalog,
             egraph,
             root,
         }
@@ -295,6 +299,7 @@ impl<S: Storage> Builder<S> {
 
             Explain(plan) => ExplainExecutor {
                 plan: self.recexpr(plan),
+                catalog: self.catalog.clone(),
             }
             .execute(),
 

--- a/src/executor_v2/nested_loop_join.rs
+++ b/src/executor_v2/nested_loop_join.rs
@@ -1,0 +1,98 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::vec::Vec;
+
+use futures::TryStreamExt;
+
+use super::*;
+use crate::array::{
+    Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, BoolArrayBuilder, DataChunk, DataChunkBuilder,
+};
+use crate::types::{DataType, DataTypeKind, DataValue};
+
+/// The executor for nested loop join.
+pub struct NestedLoopJoinExecutor {
+    pub op: Expr,
+    pub condition: RecExpr,
+    pub left_types: Vec<DataType>,
+    pub right_types: Vec<DataType>,
+}
+
+impl NestedLoopJoinExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, left_child: BoxedExecutor, right_child: BoxedExecutor) {
+        if matches!(self.op, Expr::RightOuter | Expr::FullOuter) {
+            todo!("unsupported join type: {:?}", self.op);
+        }
+        let left_chunks = left_child.try_collect::<Vec<DataChunk>>().await?;
+
+        let left_rows = || left_chunks.iter().flat_map(|chunk| chunk.rows());
+
+        let data_types = self.left_types.iter().chain(self.right_types.iter());
+        let mut builder = DataChunkBuilder::new(data_types, PROCESSING_WINDOW_SIZE);
+        let mut filter_builder = BoolArrayBuilder::with_capacity(PROCESSING_WINDOW_SIZE);
+
+        let mut right_row_num = 0;
+        // inner join: left x right
+        #[for_await]
+        for right_chunk in right_child {
+            let right_chunk = right_chunk?;
+            for right_row in right_chunk.rows() {
+                for left_row in left_rows() {
+                    let values = left_row.values().chain(right_row.values());
+                    if let Some(chunk) = builder.push_row(values) {
+                        // evaluate filter bitmap
+                        let ArrayImpl::Bool(a) = ExprRef::new(&self.condition).eval(&chunk)? else {
+                            panic!("join condition should return bool");
+                        };
+                        yield chunk.filter(a.iter().map(|b| matches!(b, Some(true))));
+                        filter_builder.append(&a);
+                    }
+                    tokio::task::consume_budget().await;
+                }
+            }
+            right_row_num += right_chunk.cardinality();
+        }
+
+        // take rest of data
+        if let Some(chunk) = builder.take() {
+            // evaluate filter bitmap
+            let ArrayImpl::Bool(a) = ExprRef::new(&self.condition).eval(&chunk)? else {
+                panic!("join condition should return bool");
+            };
+            yield chunk.filter(a.iter().map(|b| matches!(b, Some(true))));
+            filter_builder.append(&a);
+        }
+        let filter = filter_builder.take();
+
+        // append rows for left outer join
+        if matches!(self.op, Expr::LeftOuter) {
+            // we need to pick row of left_row which unmatched rows
+            let left_row_num = left_rows().count();
+            for (mut i, left_row) in left_rows().enumerate() {
+                let mut matched = false;
+                for _ in 0..right_row_num {
+                    // the `filter` has all matching results of the cross join result `right x left`
+                    // to compute the unmatched rows, we will need to first pick a row of left_row
+                    // (namely the i-th row). then we check if all `filter[i + left_row_num * j]`
+                    matched |= matches!(filter.get(i), Some(true));
+                    i += left_row_num;
+                }
+                if matched {
+                    continue;
+                }
+                // if all false, we append row: (left, NULL)
+                let values =
+                    (left_row.values()).chain(self.right_types.iter().map(|_| DataValue::Null));
+                if let Some(chunk) = builder.push_row(values) {
+                    yield chunk;
+                }
+                tokio::task::consume_budget().await;
+            }
+        }
+
+        if let Some(chunk) = builder.take() {
+            yield chunk;
+        }
+    }
+}

--- a/src/executor_v2/order.rs
+++ b/src/executor_v2/order.rs
@@ -52,7 +52,7 @@ impl OrderExecutor {
 /// Compare two rows by orders.
 ///
 /// The order is `false` for ascending and `true` for descending.
-pub(super) fn cmp(row1: &RowRef, row2: &RowRef, orders: &[bool]) -> Ordering {
+fn cmp(row1: &RowRef, row2: &RowRef, orders: &[bool]) -> Ordering {
     for ((v1, v2), desc) in row1.values().zip_eq(row2.values()).zip(orders) {
         match v1.cmp(&v2) {
             Ordering::Equal => continue,

--- a/src/executor_v2/order.rs
+++ b/src/executor_v2/order.rs
@@ -1,0 +1,69 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::cmp::Ordering;
+
+use futures::TryStreamExt;
+
+use super::*;
+use crate::array::{DataChunk, DataChunkBuilder, RowRef};
+use crate::types::DataType;
+
+/// The executor of an order operation.
+pub struct OrderExecutor {
+    /// A list of expressions to order by.
+    ///
+    /// e.g. `(list (asc (+ #0 #1)) (desc #0))`
+    pub order_keys: RecExpr,
+    pub types: Vec<DataType>,
+}
+
+impl OrderExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, child: BoxedExecutor) {
+        // evaluate order keys and append the original rows
+        // chunks = keys || child
+        let mut chunks = vec![];
+        #[for_await]
+        for chunk in child {
+            let chunk = chunk?;
+            let order_key_chunk = ExprRef::new(&self.order_keys).eval_list(&chunk)?;
+            chunks.push(order_key_chunk.row_concat(chunk));
+        }
+
+        // sort the rows by keys
+        let mut rows = gen_row_array(&chunks);
+        let orders = ExprRef::new(&self.order_keys).orders();
+        rows.sort_unstable_by(|row1, row2| cmp(row1, row2, &orders));
+
+        // build chunk by the new order
+        let order_keys_len = self.order_keys.as_ref().last().unwrap().as_list().len();
+        let mut builder = DataChunkBuilder::new(&self.types, PROCESSING_WINDOW_SIZE);
+        for row in rows {
+            if let Some(chunk) = builder.push_row(row.values().skip(order_keys_len)) {
+                yield chunk;
+            }
+        }
+        if let Some(chunk) = builder.take() {
+            yield chunk;
+        }
+    }
+}
+
+/// Compare two rows by orders.
+///
+/// The order is `false` for ascending and `true` for descending.
+pub(super) fn cmp(row1: &RowRef, row2: &RowRef, orders: &[bool]) -> Ordering {
+    for ((v1, v2), desc) in row1.values().zip_eq(row2.values()).zip(orders) {
+        match v1.cmp(&v2) {
+            Ordering::Equal => continue,
+            o if *desc => return o.reverse(),
+            o => return o,
+        }
+    }
+    Ordering::Equal
+}
+
+/// Generate an array of rows for the chunks.
+fn gen_row_array(chunks: &[DataChunk]) -> Vec<RowRef<'_>> {
+    chunks.iter().flat_map(|chunk| chunk.rows()).collect()
+}

--- a/src/executor_v2/projection.rs
+++ b/src/executor_v2/projection.rs
@@ -5,7 +5,10 @@ use crate::array::DataChunk;
 
 /// The executor of project operation.
 pub struct ProjectionExecutor {
-    pub projs: Vec<RecExpr>,
+    /// A list of expressions.
+    ///
+    /// e.g. `(list (+ #0 #1) #0)`
+    pub projs: RecExpr,
 }
 
 impl ProjectionExecutor {
@@ -13,13 +16,7 @@ impl ProjectionExecutor {
     pub async fn execute(self, child: BoxedExecutor) {
         #[for_await]
         for batch in child {
-            let batch = batch?;
-            let chunk: Vec<_> = self
-                .projs
-                .iter()
-                .map(|expr| ExprRef::new(expr).eval(&batch))
-                .try_collect()?;
-            yield chunk.into_iter().collect();
+            yield ExprRef::new(&self.projs).eval_list(&batch?)?;
         }
     }
 }

--- a/src/executor_v2/simple_agg.rs
+++ b/src/executor_v2/simple_agg.rs
@@ -1,0 +1,29 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use itertools::Itertools;
+
+use super::*;
+use crate::array::{ArrayBuilderImpl, ArrayImpl};
+use crate::types::DataValue;
+
+/// The executor of simple aggregation.
+pub struct SimpleAggExecutor {
+    /// A list of aggregations.
+    ///
+    /// e.g. `(list (sum #0) (count #1))`
+    pub aggs: RecExpr,
+}
+
+impl SimpleAggExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, child: BoxedExecutor) {
+        let len = self.aggs.as_ref().last().unwrap().as_list().len();
+        let mut states = vec![DataValue::Null; len];
+        #[for_await]
+        for chunk in child {
+            let chunk = chunk?;
+            ExprRef::new(&self.aggs).eval_agg_list(&mut states, &chunk)?;
+        }
+        yield states.iter().map(ArrayImpl::from).collect();
+    }
+}

--- a/src/executor_v2/top_n.rs
+++ b/src/executor_v2/top_n.rs
@@ -1,0 +1,76 @@
+// Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::cmp::Ordering;
+
+use binary_heap_plus::BinaryHeap;
+
+use super::*;
+use crate::array::{DataChunk, DataChunkBuilder};
+use crate::types::{DataType, Row};
+
+/// The executor of a Top N operation.
+pub struct TopNExecutor {
+    pub offset: usize,
+    pub limit: usize,
+    /// A list of expressions to order by.
+    ///
+    /// e.g. `(list (asc (+ #0 #1)) (desc #0))`
+    pub order_keys: RecExpr,
+    pub types: Vec<DataType>,
+}
+
+impl TopNExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, child: BoxedExecutor) {
+        // initialize heap
+        let heap_size = self.offset + self.limit;
+        let orders = ExprRef::new(&self.order_keys).orders();
+        let mut heap =
+            BinaryHeap::with_capacity_by(heap_size, |row1, row2| cmp(row1, row2, &orders));
+
+        // evaluate order keys and append the original rows
+        // chunks = keys || child
+        #[for_await]
+        for chunk in child {
+            let chunk = chunk?;
+            let order_key_chunk = ExprRef::new(&self.order_keys).eval_list(&chunk)?;
+            for row in order_key_chunk.row_concat(chunk).rows() {
+                heap.push(row.to_owned());
+                if heap.len() > heap_size {
+                    heap.pop();
+                }
+            }
+        }
+
+        // build chunk
+        let order_keys_len = self.order_keys.as_ref().last().unwrap().as_list().len();
+        let mut builder = DataChunkBuilder::new(self.types.iter(), PROCESSING_WINDOW_SIZE);
+        for row in heap
+            .into_sorted_vec()
+            .into_iter()
+            .skip(self.offset)
+            .take(self.limit)
+        {
+            if let Some(chunk) = builder.push_row(row.into_iter().skip(order_keys_len)) {
+                yield chunk;
+            }
+        }
+        if let Some(chunk) = builder.take() {
+            yield chunk;
+        }
+    }
+}
+
+/// Compare two rows by orders.
+///
+/// The order is `false` for ascending and `true` for descending.
+fn cmp(row1: &Row, row2: &Row, orders: &[bool]) -> Ordering {
+    for ((v1, v2), desc) in row1.iter().zip_eq(row2.iter()).zip(orders) {
+        match v1.cmp(v2) {
+            Ordering::Equal => continue,
+            o if *desc => return o.reverse(),
+            o => return o,
+        }
+    }
+    Ordering::Equal
+}

--- a/src/planner/cost.rs
+++ b/src/planner/cost.rs
@@ -60,7 +60,7 @@ impl egg::CostFunction<Expr> for CostFn<'_> {
             HashJoin([_, _, _, l, r]) => {
                 (rows(l) + 1.0).log2() * (rows(l) + rows(r)) + out() + costs(l) + costs(r)
             }
-            Insert([_, c]) | CopyTo([_, c]) => rows(c) * cols(c) + costs(c),
+            Insert([_, _, c]) | CopyTo([_, c]) => rows(c) * cols(c) + costs(c),
             // for expressions, the cost is 0.1x AST size
             _ => enode.fold(0.1, |sum, id| sum + costs(&id)),
         };

--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -236,7 +236,7 @@ impl Display for Explain<'_> {
             Drop(t) => writeln!(f, "{tab}Drop: {}, ...{cost}", t.object),
             Insert([table, cols, child]) => write!(f, "{tab}Insert: {}{}{cost}\n{}", self.expr(table), self.expr(cols), self.child(child)),
             Delete([table, child]) => write!(f, "{tab}Delete: from={}{cost}\n{}", self.expr(table), self.child(child)),
-            CopyFrom(src) => writeln!(f, "{tab}CopyFrom: {}{cost}", self.expr(src)),
+            CopyFrom([src, _]) => writeln!(f, "{tab}CopyFrom: {}{cost}", self.expr(src)),
             CopyTo([dst, child]) => write!(f, "{tab}CopyTo: {}{cost}\n{}", self.expr(dst), self.child(child)),
             Explain(child) => write!(f, "{tab}Explain:{cost}\n{}", self.child(child)),
             Prune(_) => panic!("cannot explain Prune"),

--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -3,6 +3,7 @@ use std::fmt::{Display, Formatter, Result};
 use egg::Id;
 
 use super::{Expr, RecExpr};
+use crate::catalog::RootCatalog;
 
 /// A wrapper over [`RecExpr`] to explain it in [`Display`].
 ///
@@ -15,6 +16,7 @@ use super::{Expr, RecExpr};
 pub struct Explain<'a> {
     expr: &'a RecExpr,
     costs: Option<&'a [f32]>,
+    catalog: Option<&'a RootCatalog>,
     id: Id,
     depth: u8,
 }
@@ -25,19 +27,22 @@ impl<'a> Explain<'a> {
         Self {
             expr,
             costs: None,
+            catalog: None,
             id: Id::from(expr.as_ref().len() - 1),
             depth: 0,
         }
     }
 
-    /// Create a [`Explain`] with costs.
-    pub fn with_costs(expr: &'a RecExpr, costs: &'a [f32]) -> Self {
-        Self {
-            expr,
-            costs: Some(costs),
-            id: Id::from(expr.as_ref().len() - 1),
-            depth: 0,
-        }
+    /// Explain with costs.
+    pub fn with_costs(mut self, costs: &'a [f32]) -> Self {
+        self.costs = Some(costs);
+        self
+    }
+
+    /// Explain column in name.
+    pub fn with_catalog(mut self, catalog: &'a RootCatalog) -> Self {
+        self.catalog = Some(catalog);
+        self
     }
 
     /// Returns a explain for the sub expression.
@@ -46,6 +51,7 @@ impl<'a> Explain<'a> {
         Explain {
             expr: self.expr,
             costs: self.costs,
+            catalog: self.catalog,
             id: *id,
             depth: self.depth,
         }
@@ -57,6 +63,7 @@ impl<'a> Explain<'a> {
         Explain {
             expr: self.expr,
             costs: self.costs,
+            catalog: self.catalog,
             id: *id,
             depth: self.depth + 1,
         }
@@ -109,7 +116,9 @@ impl Display for Explain<'_> {
             Constant(v) => write!(f, "{v}"),
             Type(t) => write!(f, "{t}"),
             Table(i) => write!(f, "{i}"),
-            Column(i) => write!(f, "{i}"),
+            Column(i) => if let Some(catalog) = self.catalog {
+                write!(f, "{}", catalog.get_column(i).expect("no column").name())
+            } else { write!(f, "{i}") },
             ColumnIndex(i) => write!(f, "{i}"),
             ExtSource(src) => write!(f, "path={:?}, format={}", src.path, src.format),
             Symbol(s) => write!(f, "{s}"),
@@ -208,7 +217,7 @@ impl Display for Explain<'_> {
             }
             HashJoin([ty, lkeys, rkeys, left, right]) => write!(
                 f,
-                "{tab}HashJoin: {}, lkey={}, rkey={}{cost}\n{}{}",
+                "{tab}HashJoin: {}, on=({} = {}){cost}\n{}{}",
                 self.expr(ty),
                 self.expr(lkeys),
                 self.expr(rkeys),

--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -224,7 +224,7 @@ impl Display for Explain<'_> {
             ),
             CreateTable(t) => writeln!(f, "{tab}CreateTable: name={:?}, ...{cost}", t.table_name),
             Drop(t) => writeln!(f, "{tab}Drop: {}, ...{cost}", t.object),
-            Insert([cols, child]) => write!(f, "{tab}Insert: {}{cost}\n{}", self.expr(cols), self.child(child)),
+            Insert([table, cols, child]) => write!(f, "{tab}Insert: {}{}{cost}\n{}", self.expr(table), self.expr(cols), self.child(child)),
             Delete([table, child]) => write!(f, "{tab}Delete: from={}{cost}\n{}", self.expr(table), self.child(child)),
             CopyFrom(src) => writeln!(f, "{tab}CopyFrom: {}{cost}", self.expr(src)),
             CopyTo([dst, child]) => write!(f, "{tab}CopyTo: {}{cost}\n{}", self.expr(dst), self.child(child)),

--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -214,7 +214,7 @@ impl Display for Explain<'_> {
                 self.child(left),
                 self.child(right)
             ),
-            Inner | LeftOuter | RightOuter | FullOuter | Cross => write!(f, "{}", enode),
+            Inner | LeftOuter | RightOuter | FullOuter => write!(f, "{}", enode),
             Agg([aggs, group_keys, child]) => write!(
                 f,
                 "{tab}Aggregate: {}, groupby={}{cost}\n{}",

--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -151,14 +151,15 @@ impl Display for Explain<'_> {
             In([a, b]) => write!(f, "({} in {})", self.expr(a), self.expr(b)),
             Cast([a, b]) => write!(f, "({} :: {})", self.expr(a), self.expr(b)),
 
-            Select([distinct, projection, from, where_, groupby, having]) => write!(
+            Select([distinct, projection, from, where_, groupby, having, orderby]) => write!(
                 f,
-                "{tab}Select:{cost}\n  {tab}distinct={}\n  {tab}projection={}\n  {tab}where={}\n  {tab}groupby={}\n  {tab}having={}\n{}",
+                "{tab}Select:{cost}\n  {tab}distinct={}\n  {tab}projection={}\n  {tab}where={}\n  {tab}groupby={}\n  {tab}having={}\n  {tab}orderby={}\n{}",
                 self.expr(distinct),
                 self.expr(projection),
                 self.expr(where_),
                 self.expr(groupby),
                 self.expr(having),
+                self.expr(orderby),
                 self.child(from),
             ),
             Distinct(_) => todo!(),

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -128,6 +128,10 @@ impl Expr {
         Self::Constant(DataValue::Null)
     }
 
+    pub const fn zero() -> Self {
+        Self::Constant(DataValue::Int32(0))
+    }
+
     pub fn as_const(&self) -> DataValue {
         let Self::Constant(v) = self else { panic!("not a constant") };
         v.clone()

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -98,7 +98,6 @@ define_language! {
             "left_outer" = LeftOuter,
             "right_outer" = RightOuter,
             "full_outer" = FullOuter,
-            "cross" = Cross,
         "agg" = Agg([Id; 3]),                   // (agg aggs=[expr..] group_keys=[expr..] child)
                                                     // expressions must be agg
                                                     // output = aggs || group_keys

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -72,13 +72,14 @@ define_language! {
 
         "cast" = Cast([Id; 2]),                 // (cast type expr)
 
-        "select" = Select([Id; 6]),             // (select
+        "select" = Select([Id; 7]),             // (select
                                                 //      distinct=[expr..]
                                                 //      select_list=[expr..]
                                                 //      from=join
                                                 //      where=expr
                                                 //      groupby=[expr..]
                                                 //      having=expr
+                                                //      orderby=[order_key..]
                                                 // )
         "distinct" = Distinct([Id; 2]),         // (distinct [expr..] child)
 

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -104,7 +104,7 @@ define_language! {
                                                     // output = aggs || group_keys
         CreateTable(CreateTable),
         Drop(BoundDrop),
-        "insert" = Insert([Id; 2]),             // (insert [column..] child)
+        "insert" = Insert([Id; 3]),             // (insert table [column..] child)
         "delete" = Delete([Id; 2]),             // (delete table child)
         "copy_from" = CopyFrom(Id),             // (copy_from dest)
         "copy_to" = CopyTo([Id; 2]),            // (copy_to dest child)
@@ -129,31 +129,28 @@ impl Expr {
     }
 
     pub fn as_const(&self) -> DataValue {
-        match self {
-            Self::Constant(v) => v.clone(),
-            _ => panic!("not a constant"),
-        }
+        let Self::Constant(v) = self else { panic!("not a constant") };
+        v.clone()
     }
 
     pub fn as_list(&self) -> &[Id] {
-        match self {
-            Self::List(list) => list,
-            _ => panic!("not a list"),
-        }
+        let Self::List(l) = self else { panic!("not a list") };
+        l
     }
 
     pub fn as_column(&self) -> ColumnRefId {
-        match self {
-            Self::Column(c) => *c,
-            _ => panic!("not a column"),
-        }
+        let Self::Column(c) = self else { panic!("not a columnn") };
+        *c
+    }
+
+    pub fn as_table(&self) -> TableRefId {
+        let Self::Table(t) = self else { panic!("not a table") };
+        *t
     }
 
     pub fn as_type(&self) -> &DataTypeKind {
-        match self {
-            Self::Type(t) => t,
-            _ => panic!("not a type"),
-        }
+        let Self::Type(t) = self else { panic!("not a type") };
+        t
     }
 
     pub const fn binary_op(&self) -> Option<(BinaryOperator, Id, Id)> {

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -1,6 +1,7 @@
 use egg::{define_language, CostFunction, Id, Symbol};
 
-use crate::binder_v2::{BoundDrop, CreateTable, ExtSource};
+use crate::binder_v2::copy::ExtSource;
+use crate::binder_v2::{BoundDrop, CreateTable};
 use crate::catalog::{ColumnRefId, TableRefId};
 use crate::parser::{BinaryOperator, UnaryOperator};
 use crate::types::{ColumnIndex, DataTypeKind, DataValue};
@@ -106,7 +107,7 @@ define_language! {
         Drop(BoundDrop),
         "insert" = Insert([Id; 3]),             // (insert table [column..] child)
         "delete" = Delete([Id; 2]),             // (delete table child)
-        "copy_from" = CopyFrom(Id),             // (copy_from dest)
+        "copy_from" = CopyFrom([Id; 2]),        // (copy_from dest types)
         "copy_to" = CopyTo([Id; 2]),            // (copy_to dest child)
         "explain" = Explain(Id),                // (explain child)
 
@@ -155,6 +156,11 @@ impl Expr {
     pub fn as_type(&self) -> &DataTypeKind {
         let Self::Type(t) = self else { panic!("not a type") };
         t
+    }
+
+    pub fn as_ext_source(&self) -> ExtSource {
+        let Self::ExtSource(v) = self else { panic!("not an external source") };
+        v.clone()
     }
 
     pub const fn binary_op(&self) -> Option<(BinaryOperator, Id, Id)> {

--- a/src/planner/rules/agg.rs
+++ b/src/planner/rules/agg.rs
@@ -284,8 +284,8 @@ mod tests {
                 true
                 (list (desc (sum (* $7.5 (- 1 $7.6)))) (asc $6.4))
             ))" => "
-        (topn 10 0 (list (desc (sum (* $7.5 (- 1 $7.6)))) (asc $6.4))
-            (proj (list $7.0 (sum (* $7.5 (- 1 $7.6))) $6.4 $6.7)
+        (proj (list $7.0 (sum (* $7.5 (- 1 $7.6))) $6.4 $6.7)
+            (topn 10 0 (list (desc (sum (* $7.5 (- 1 $7.6)))) (asc $6.4))
                 (agg
                     (list (sum (* $7.5 (- 1 $7.6))))
                     (list $7.0 $6.4 $6.7)

--- a/src/planner/rules/agg.rs
+++ b/src/planner/rules/agg.rs
@@ -272,7 +272,7 @@ mod tests {
     egg::test_fn! {
         tpch_q3,
         rules(),
-        "(limit 10 null
+        "(limit 10 0
             (select list (list $7.0 (sum (* $7.5 (- 1 $7.6))) $6.4 $6.7)
                 (join inner true
                     (join inner true
@@ -284,7 +284,7 @@ mod tests {
                 true
                 (list (desc (sum (* $7.5 (- 1 $7.6)))) (asc $6.4))
             ))" => "
-        (topn 10 null (list (desc (sum (* $7.5 (- 1 $7.6)))) (asc $6.4))
+        (topn 10 0 (list (desc (sum (* $7.5 (- 1 $7.6)))) (asc $6.4))
             (proj (list $7.0 (sum (* $7.5 (- 1 $7.6))) $6.4 $6.7)
                 (agg
                     (list (sum (* $7.5 (- 1 $7.6))))

--- a/src/planner/rules/agg.rs
+++ b/src/planner/rules/agg.rs
@@ -272,8 +272,8 @@ mod tests {
         rules(),
         "(topn 10 null (list (desc (sum (* $7.5 (- 1 $7.6)))) (asc $6.4))
             (select list (list $7.0 (sum (* $7.5 (- 1 $7.6))) $6.4 $6.7)
-                (join cross true
-                    (join cross true
+                (join inner true
+                    (join inner true
                         (scan (list $5.0 $5.6))
                         (scan (list $6.0 $6.1 $6.4 $6.7)))
                     (scan (list $7.0 $7.5 $7.6 $7.10)))
@@ -285,8 +285,8 @@ mod tests {
                 (agg
                     (list (sum (* $7.5 (- 1 $7.6))))
                     (list $7.0 $6.4 $6.7)
-                    (hashjoin cross (list $6.0) (list $7.0)
-                        (hashjoin cross (list $5.0) (list $6.1)
+                    (hashjoin inner (list $6.0) (list $7.0)
+                        (hashjoin inner (list $5.0) (list $6.1)
                             (filter (= $5.6 'BUILDING')
                                 (scan (list $5.0 $5.6)))
                             (filter (< $6.4 1995-03-15)

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -27,6 +27,7 @@ use std::sync::LazyLock;
 use egg::{rewrite as rw, *};
 
 use super::{EGraph, Expr, Pattern, RecExpr, Rewrite};
+use crate::catalog::RootCatalogRef;
 use crate::types::F32;
 
 mod agg;
@@ -132,7 +133,9 @@ impl Analysis<Expr> for ExprAnalysis {
 
 /// Analysis used in binding and building executor.
 #[derive(Default)]
-pub struct TypeSchemaAnalysis;
+pub struct TypeSchemaAnalysis {
+    pub catalog: RootCatalogRef,
+}
 
 #[derive(Debug)]
 pub struct TypeSchema {
@@ -151,7 +154,11 @@ impl Analysis<Expr> for TypeSchemaAnalysis {
 
     fn make(egraph: &egg::EGraph<Expr, Self>, enode: &Expr) -> Self::Data {
         TypeSchema {
-            type_: type_::analyze_type(enode, |i| egraph[*i].data.type_.clone()),
+            type_: type_::analyze_type(
+                enode,
+                |i| egraph[*i].data.type_.clone(),
+                &egraph.analysis.catalog,
+            ),
             schema: schema::analyze_schema(enode, |i| egraph[*i].data.schema.clone()),
         }
     }

--- a/src/planner/rules/plan.rs
+++ b/src/planner/rules/plan.rs
@@ -14,7 +14,7 @@ pub fn always_better_rules() -> Vec<Rewrite> {
 
 #[rustfmt::skip]
 fn cancel_rules() -> Vec<Rewrite> { vec![
-    rw!("limit-null";   "(limit null null ?child)" => "?child"),
+    rw!("limit-null";   "(limit null 0 ?child)" => "?child"),
     rw!("limit-0";      "(limit 0 ?offset ?child)" => "(values)"),
     rw!("filter-true";  "(filter true ?child)" => "?child"),
     rw!("filter-false"; "(filter false ?child)" => "(values)"),

--- a/src/planner/rules/plan.rs
+++ b/src/planner/rules/plan.rs
@@ -24,10 +24,6 @@ fn cancel_rules() -> Vec<Rewrite> { vec![
 
 #[rustfmt::skip]
 fn merge_rules() -> Vec<Rewrite> { vec![
-    rw!("topn-limit-order";
-        "(topn ?limit ?offset ?keys ?child)" =>
-        "(limit ?limit ?offset (order ?keys ?child))"
-    ),
     rw!("limit-order-topn";
         "(limit ?limit ?offset (order ?keys ?child))" =>
         "(topn ?limit ?offset ?keys ?child)"
@@ -45,6 +41,7 @@ fn merge_rules() -> Vec<Rewrite> { vec![
 #[rustfmt::skip]
 fn pushdown_rules() -> Vec<Rewrite> { vec![
     pushdown("proj", "?exprs", "limit", "?limit ?offset"),
+    pushdown("limit", "?limit ?offset", "proj", "?exprs"),
     pushdown("filter", "?cond", "order", "?keys"),
     pushdown("filter", "?cond", "limit", "?limit ?offset"),
     pushdown("filter", "?cond", "topn", "?limit ?offset ?keys"),

--- a/src/planner/rules/plan.rs
+++ b/src/planner/rules/plan.rs
@@ -44,9 +44,7 @@ fn merge_rules() -> Vec<Rewrite> { vec![
 
 #[rustfmt::skip]
 fn pushdown_rules() -> Vec<Rewrite> { vec![
-    pushdown("proj", "?exprs", "order", "?keys"),
     pushdown("proj", "?exprs", "limit", "?limit ?offset"),
-    pushdown("proj", "?exprs", "topn", "?limit ?offset ?keys"),
     pushdown("filter", "?cond", "order", "?keys"),
     pushdown("filter", "?cond", "limit", "?limit ?offset"),
     pushdown("filter", "?cond", "topn", "?limit ?offset ?keys"),

--- a/src/planner/rules/plan.rs
+++ b/src/planner/rules/plan.rs
@@ -51,27 +51,27 @@ fn pushdown_rules() -> Vec<Rewrite> { vec![
     pushdown("filter", "?cond", "limit", "?limit ?offset"),
     pushdown("filter", "?cond", "topn", "?limit ?offset ?keys"),
     rw!("pushdown-filter-join";
-        "(filter ?cond (join ?type ?on ?left ?right))" =>
-        "(join ?type (and ?on ?cond) ?left ?right)"
+        "(filter ?cond (join inner ?on ?left ?right))" =>
+        "(join inner (and ?on ?cond) ?left ?right)"
     ),
     rw!("pushdown-join-left";
-        "(join ?type (and ?cond1 ?cond2) ?left ?right)" =>
-        "(join ?type ?cond2 (filter ?cond1 ?left) ?right)"
+        "(join inner (and ?cond1 ?cond2) ?left ?right)" =>
+        "(join inner ?cond2 (filter ?cond1 ?left) ?right)"
         if columns_is_subset("?cond1", "?left")
     ),
     rw!("pushdown-join-left-1";
-        "(join ?type ?cond1 ?left ?right)" =>
-        "(join ?type true (filter ?cond1 ?left) ?right)"
+        "(join inner ?cond1 ?left ?right)" =>
+        "(join inner true (filter ?cond1 ?left) ?right)"
         if columns_is_subset("?cond1", "?left")
     ),
     rw!("pushdown-join-right";
-        "(join ?type (and ?cond1 ?cond2) ?left ?right)" =>
-        "(join ?type ?cond2 ?left (filter ?cond1 ?right))"
+        "(join inner (and ?cond1 ?cond2) ?left ?right)" =>
+        "(join inner ?cond2 ?left (filter ?cond1 ?right))"
         if columns_is_subset("?cond1", "?right")
     ),
     rw!("pushdown-join-right-1";
-        "(join ?type ?cond1 ?left ?right)" =>
-        "(join ?type true ?left (filter ?cond1 ?right))"
+        "(join inner ?cond1 ?left ?right)" =>
+        "(join inner true ?left (filter ?cond1 ?right))"
         if columns_is_subset("?cond1", "?right")
     ),
 ]}

--- a/src/planner/rules/rows.rs
+++ b/src/planner/rules/rows.rs
@@ -20,9 +20,15 @@ pub fn analyze_rows(egraph: &EGraph, enode: &Expr) -> Rows {
         Values(v) => v.len() as f32,
         Scan(_) => 1000.0, // TODO: get from table
         Proj([_, c]) | Order([_, c]) => x(c),
-        Agg([_, _, _c]) => 1.0, // TODO: group by cardinality
+        Agg([_, groupby, c]) => {
+            if egraph[*groupby].nodes[0].as_list().is_empty() {
+                1.0
+            } else {
+                x(c) / 2.0 // TODO: group by cardinality
+            }
+        }
         Filter([cond, c]) => x(c) * x(cond),
-        Limit([_, limit, c]) | TopN([_, limit, _, c]) => x(c).min(get_limit_num(limit)),
+        Limit([limit, _, c]) | TopN([limit, _, _, c]) => x(c).min(get_limit_num(limit)),
         Join([_, on, l, r]) => x(l) * x(r) * x(on),
         HashJoin([_, _, _, l, r]) => x(l).max(x(r)),
         Prune([_, c]) => x(c),

--- a/src/types/interval.rs
+++ b/src/types/interval.rs
@@ -1,8 +1,9 @@
 // Copyright 2022 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt::{Display, Formatter};
+use std::iter::Sum;
 use std::num::ParseIntError;
-use std::ops::Neg;
+use std::ops::{Add, Neg, Sub};
 use std::str::FromStr;
 
 use serde::Serialize;
@@ -100,6 +101,35 @@ impl Interval {
     }
 }
 
+impl Add for Interval {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let months = self.months + rhs.months;
+        let mut days = self.days + rhs.days;
+        let mut ms = self.ms + rhs.ms;
+        days += ms / (1000 * 60 * 60 * 24);
+        ms %= 1000 * 60 * 60 * 24;
+        Interval { months, days, ms }
+    }
+}
+
+impl Add for &Interval {
+    type Output = Interval;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        (*self).add(*rhs)
+    }
+}
+
+impl Sub for Interval {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self + -rhs
+    }
+}
+
 impl Neg for Interval {
     type Output = Interval;
 
@@ -109,6 +139,18 @@ impl Neg for Interval {
             days: -self.days,
             ms: -self.ms,
         }
+    }
+}
+
+impl Sum for Interval {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Interval::default(), |a, b| a + b)
+    }
+}
+
+impl<'a> Sum<&'a Interval> for Interval {
+    fn sum<I: Iterator<Item = &'a Interval>>(iter: I) -> Self {
+        iter.fold(Interval::default(), |a, b| a + *b)
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,24 +2,22 @@
 
 use std::hash::Hash;
 use std::num::ParseIntError;
+use std::str::FromStr;
 
-use num_traits::ToPrimitive;
-use ordered_float::OrderedFloat;
 use parse_display::Display;
-use rust_decimal::prelude::FromStr;
-use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 mod blob;
 mod date;
 mod interval;
 mod native;
+mod value;
 
 pub use self::blob::*;
 pub use self::date::*;
 pub use self::interval::*;
 pub use self::native::*;
-use crate::array::ArrayImpl;
+pub use self::value::*;
 
 /// Data type.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -244,158 +242,6 @@ pub(crate) type SchemaId = u32;
 pub(crate) type TableId = u32;
 pub(crate) type ColumnId = u32;
 
-/// Primitive SQL value.
-#[derive(Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
-pub enum DataValue {
-    // NOTE: Null comes first.
-    // => NULL is less than any non-NULL values
-    #[display("null")]
-    Null,
-    #[display("{0}")]
-    Bool(bool),
-    #[display("{0}")]
-    Int32(i32),
-    #[display("{0}")]
-    Int64(i64),
-    #[display("{0}")]
-    Float64(F64),
-    #[display("'{0}'")]
-    String(String),
-    #[display("{0}")]
-    Blob(Blob),
-    #[display("{0}")]
-    Decimal(Decimal),
-    #[display("{0}")]
-    Date(Date),
-    #[display("{0}")]
-    Interval(Interval),
-}
-
-/// A wrapper around floats providing implementations of `Eq`, `Ord`, and `Hash`.
-pub type F32 = OrderedFloat<f32>;
-pub type F64 = OrderedFloat<f64>;
-
-macro_rules! impl_arith_for_datavalue {
-    ($Trait:ident, $name:ident) => {
-        impl std::ops::$Trait for &DataValue {
-            type Output = DataValue;
-
-            fn $name(self, rhs: Self) -> Self::Output {
-                use DataValue::*;
-                match (self, rhs) {
-                    (&Int32(x), &Int32(y)) => Int32(x.$name(y)),
-                    (&Int64(x), &Int64(y)) => Int64(x.$name(y)),
-                    (&Float64(x), &Float64(y)) => Float64(x.$name(y)),
-                    (&Decimal(x), &Decimal(y)) => Decimal(x.$name(y)),
-                    (&Date(x), &Interval(y)) => Date(x.$name(y)),
-                    _ => panic!(
-                        "invalid operation: {:?} {} {:?}",
-                        self,
-                        stringify!($name),
-                        rhs
-                    ),
-                }
-            }
-        }
-    };
-}
-impl_arith_for_datavalue!(Add, add);
-impl_arith_for_datavalue!(Sub, sub);
-impl_arith_for_datavalue!(Mul, mul);
-impl_arith_for_datavalue!(Div, div);
-impl_arith_for_datavalue!(Rem, rem);
-
-impl DataValue {
-    /// Returns `true` if value is null.
-    pub const fn is_null(&self) -> bool {
-        matches!(self, Self::Null)
-    }
-
-    /// Whether the value is divisible by another.
-    pub fn is_divisible_by(&self, other: &DataValue) -> bool {
-        use DataValue::*;
-        match (self, other) {
-            (&Int32(x), &Int32(y)) => y != 0 && x % y == 0,
-            (&Int64(x), &Int64(y)) => y != 0 && x % y == 0,
-            (&Float64(x), &Float64(y)) => y != 0.0 && x % y == 0.0,
-            (&Decimal(x), &Decimal(y)) => !y.is_zero() && (x % y).is_zero(),
-            _ => false,
-        }
-    }
-
-    /// Returns `true` if value is positive and `false` if the number is zero or negative.
-    pub fn is_positive(&self) -> bool {
-        match self {
-            Self::Null => false,
-            Self::Bool(v) => *v,
-            Self::Int32(v) => v.is_positive(),
-            Self::Int64(v) => v.is_positive(),
-            Self::Float64(v) => v.0.is_sign_positive(),
-            Self::String(_) => false,
-            Self::Blob(_) => false,
-            Self::Decimal(v) => v.is_sign_positive(),
-            Self::Date(_) => false,
-            Self::Interval(v) => v.is_positive(),
-        }
-    }
-
-    /// Returns `true` if value is zero.
-    pub fn is_zero(&self) -> bool {
-        match self {
-            Self::Null => false,
-            Self::Bool(v) => !*v,
-            Self::Int32(v) => *v == 0,
-            Self::Int64(v) => *v == 0,
-            Self::Float64(v) => v.0 == 0.0,
-            Self::String(_) => false,
-            Self::Blob(_) => false,
-            Self::Decimal(v) => v.is_zero(),
-            Self::Date(_) => false,
-            Self::Interval(v) => v.is_zero(),
-        }
-    }
-
-    /// Get the type of value.
-    pub fn data_type(&self) -> DataType {
-        match self {
-            Self::Null => DataTypeKind::Null.nullable(),
-            Self::Bool(_) => DataTypeKind::Bool.not_null(),
-            Self::Int32(_) => DataTypeKind::Int32.not_null(),
-            Self::Int64(_) => DataTypeKind::Int64.not_null(),
-            Self::Float64(_) => DataTypeKind::Float64.not_null(),
-            Self::String(_) => DataTypeKind::String.not_null(),
-            Self::Blob(_) => DataTypeKind::Blob.not_null(),
-            Self::Decimal(_) => DataTypeKind::Decimal(None, None).not_null(),
-            Self::Date(_) => DataTypeKind::Date.not_null(),
-            Self::Interval(_) => DataTypeKind::Interval.not_null(),
-        }
-    }
-
-    /// Convert the value to a usize.
-    pub fn as_usize(&self) -> Result<Option<usize>, ConvertError> {
-        let cast_err = || ConvertError::Cast(self.to_string(), "usize");
-        Ok(Some(match self {
-            Self::Null => return Ok(None),
-            &Self::Bool(b) => b as usize,
-            &Self::Int32(v) => v.try_into().map_err(|_| cast_err())?,
-            &Self::Int64(v) => v.try_into().map_err(|_| cast_err())?,
-            &Self::Float64(f) if f.is_sign_negative() => return Err(cast_err()),
-            &Self::Float64(f) => f.0.to_usize().ok_or_else(cast_err)?,
-            &Self::Decimal(d) if d.is_sign_negative() => return Err(cast_err()),
-            &Self::Decimal(d) => d.to_usize().ok_or_else(cast_err)?,
-            &Self::Date(_) => return Err(cast_err()),
-            &Self::Interval(_) => return Err(cast_err()),
-            Self::String(s) => s.parse::<usize>().map_err(|_| cast_err())?,
-            Self::Blob(_) => return Err(cast_err()),
-        }))
-    }
-
-    /// Cast the value to another type.
-    pub fn cast(&self, ty: &DataTypeKind) -> Result<Self, ConvertError> {
-        Ok(ArrayImpl::from(self).try_cast(ty)?.get(0))
-    }
-}
-
 /// The error type of value type convention.
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 #[allow(named_arguments_used_positionally)]
@@ -432,49 +278,6 @@ pub enum ConvertError {
     NoUnaryOp(String, &'static str),
     #[error("no function {0}({1}, {2})")]
     NoBinaryOp(String, &'static str, &'static str),
-}
-
-/// memory table row type
-pub(crate) type Row = Vec<DataValue>;
-
-#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
-pub enum ParseValueError {
-    #[error("invalid interval: {0}")]
-    ParseIntervalError(#[from] ParseIntervalError),
-    #[error("invalid date: {0}")]
-    ParseDateError(#[from] ParseDateError),
-    #[error("invalid blob: {0}")]
-    ParseBlobError(#[from] ParseBlobError),
-    #[error("invalid value: {0}")]
-    Invalid(String),
-}
-
-impl FromStr for DataValue {
-    type Err = ParseValueError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "null" {
-            Ok(DataValue::Null)
-        } else if let Ok(bool) = s.parse::<bool>() {
-            Ok(Self::Bool(bool))
-        } else if let Ok(int) = s.parse::<i32>() {
-            Ok(Self::Int32(int))
-        } else if let Ok(bigint) = s.parse::<i64>() {
-            Ok(Self::Int64(bigint))
-        } else if let Ok(d) = s.parse::<Decimal>() {
-            Ok(Self::Decimal(d))
-        } else if s.starts_with('\'') && s.ends_with('\'') {
-            Ok(Self::String(s[1..s.len() - 1].to_string()))
-        } else if s.starts_with("b\'") && s.ends_with('\'') {
-            Ok(Self::Blob(s[2..s.len() - 1].parse()?))
-        } else if let Some(s) = s.strip_prefix("interval") {
-            Ok(Self::Interval(s.trim().trim_matches('\'').parse()?))
-        } else if let Some(s) = s.strip_prefix("date") {
-            Ok(Self::Date(s.trim().trim_matches('\'').parse()?))
-        } else {
-            Err(ParseValueError::Invalid(s.into()))
-        }
-    }
 }
 
 /// The physical index to the column from child plan.

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -1,0 +1,203 @@
+use num_traits::ToPrimitive;
+use ordered_float::OrderedFloat;
+use parse_display::Display;
+use rust_decimal::Decimal;
+use serde::Serialize;
+
+use super::*;
+use crate::array::ArrayImpl;
+
+/// Primitive SQL value.
+#[derive(Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+pub enum DataValue {
+    // NOTE: Null comes first.
+    // => NULL is less than any non-NULL values
+    #[display("null")]
+    Null,
+    #[display("{0}")]
+    Bool(bool),
+    #[display("{0}")]
+    Int32(i32),
+    #[display("{0}")]
+    Int64(i64),
+    #[display("{0}")]
+    Float64(F64),
+    #[display("'{0}'")]
+    String(String),
+    #[display("{0}")]
+    Blob(Blob),
+    #[display("{0}")]
+    Decimal(Decimal),
+    #[display("{0}")]
+    Date(Date),
+    #[display("{0}")]
+    Interval(Interval),
+}
+
+/// memory table row type
+pub type Row = Vec<DataValue>;
+
+/// A wrapper around floats providing implementations of `Eq`, `Ord`, and `Hash`.
+pub type F32 = OrderedFloat<f32>;
+pub type F64 = OrderedFloat<f64>;
+
+macro_rules! impl_arith_for_datavalue {
+    ($Trait:ident, $name:ident) => {
+        impl std::ops::$Trait for &DataValue {
+            type Output = DataValue;
+
+            fn $name(self, rhs: Self) -> Self::Output {
+                use DataValue::*;
+                match (self, rhs) {
+                    (&Int32(x), &Int32(y)) => Int32(x.$name(y)),
+                    (&Int64(x), &Int64(y)) => Int64(x.$name(y)),
+                    (&Float64(x), &Float64(y)) => Float64(x.$name(y)),
+                    (&Decimal(x), &Decimal(y)) => Decimal(x.$name(y)),
+                    (&Date(x), &Interval(y)) => Date(x.$name(y)),
+                    _ => panic!(
+                        "invalid operation: {:?} {} {:?}",
+                        self,
+                        stringify!($name),
+                        rhs
+                    ),
+                }
+            }
+        }
+    };
+}
+impl_arith_for_datavalue!(Add, add);
+impl_arith_for_datavalue!(Sub, sub);
+impl_arith_for_datavalue!(Mul, mul);
+impl_arith_for_datavalue!(Div, div);
+impl_arith_for_datavalue!(Rem, rem);
+
+impl DataValue {
+    /// Returns `true` if value is null.
+    pub const fn is_null(&self) -> bool {
+        matches!(self, Self::Null)
+    }
+
+    /// Whether the value is divisible by another.
+    pub fn is_divisible_by(&self, other: &DataValue) -> bool {
+        use DataValue::*;
+        match (self, other) {
+            (&Int32(x), &Int32(y)) => y != 0 && x % y == 0,
+            (&Int64(x), &Int64(y)) => y != 0 && x % y == 0,
+            (&Float64(x), &Float64(y)) => y != 0.0 && x % y == 0.0,
+            (&Decimal(x), &Decimal(y)) => !y.is_zero() && (x % y).is_zero(),
+            _ => false,
+        }
+    }
+
+    /// Returns `true` if value is positive and `false` if the number is zero or negative.
+    pub fn is_positive(&self) -> bool {
+        match self {
+            Self::Null => false,
+            Self::Bool(v) => *v,
+            Self::Int32(v) => v.is_positive(),
+            Self::Int64(v) => v.is_positive(),
+            Self::Float64(v) => v.0.is_sign_positive(),
+            Self::String(_) => false,
+            Self::Blob(_) => false,
+            Self::Decimal(v) => v.is_sign_positive(),
+            Self::Date(_) => false,
+            Self::Interval(v) => v.is_positive(),
+        }
+    }
+
+    /// Returns `true` if value is zero.
+    pub fn is_zero(&self) -> bool {
+        match self {
+            Self::Null => false,
+            Self::Bool(v) => !*v,
+            Self::Int32(v) => *v == 0,
+            Self::Int64(v) => *v == 0,
+            Self::Float64(v) => v.0 == 0.0,
+            Self::String(_) => false,
+            Self::Blob(_) => false,
+            Self::Decimal(v) => v.is_zero(),
+            Self::Date(_) => false,
+            Self::Interval(v) => v.is_zero(),
+        }
+    }
+
+    /// Get the type of value.
+    pub fn data_type(&self) -> DataType {
+        match self {
+            Self::Null => DataTypeKind::Null.nullable(),
+            Self::Bool(_) => DataTypeKind::Bool.not_null(),
+            Self::Int32(_) => DataTypeKind::Int32.not_null(),
+            Self::Int64(_) => DataTypeKind::Int64.not_null(),
+            Self::Float64(_) => DataTypeKind::Float64.not_null(),
+            Self::String(_) => DataTypeKind::String.not_null(),
+            Self::Blob(_) => DataTypeKind::Blob.not_null(),
+            Self::Decimal(_) => DataTypeKind::Decimal(None, None).not_null(),
+            Self::Date(_) => DataTypeKind::Date.not_null(),
+            Self::Interval(_) => DataTypeKind::Interval.not_null(),
+        }
+    }
+
+    /// Convert the value to a usize.
+    pub fn as_usize(&self) -> Result<Option<usize>, ConvertError> {
+        let cast_err = || ConvertError::Cast(self.to_string(), "usize");
+        Ok(Some(match self {
+            Self::Null => return Ok(None),
+            &Self::Bool(b) => b as usize,
+            &Self::Int32(v) => v.try_into().map_err(|_| cast_err())?,
+            &Self::Int64(v) => v.try_into().map_err(|_| cast_err())?,
+            &Self::Float64(f) if f.is_sign_negative() => return Err(cast_err()),
+            &Self::Float64(f) => f.0.to_usize().ok_or_else(cast_err)?,
+            &Self::Decimal(d) if d.is_sign_negative() => return Err(cast_err()),
+            &Self::Decimal(d) => d.to_usize().ok_or_else(cast_err)?,
+            &Self::Date(_) => return Err(cast_err()),
+            &Self::Interval(_) => return Err(cast_err()),
+            Self::String(s) => s.parse::<usize>().map_err(|_| cast_err())?,
+            Self::Blob(_) => return Err(cast_err()),
+        }))
+    }
+
+    /// Cast the value to another type.
+    pub fn cast(&self, ty: &DataTypeKind) -> Result<Self, ConvertError> {
+        Ok(ArrayImpl::from(self).try_cast(ty)?.get(0))
+    }
+}
+
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum ParseValueError {
+    #[error("invalid interval: {0}")]
+    ParseIntervalError(#[from] ParseIntervalError),
+    #[error("invalid date: {0}")]
+    ParseDateError(#[from] ParseDateError),
+    #[error("invalid blob: {0}")]
+    ParseBlobError(#[from] ParseBlobError),
+    #[error("invalid value: {0}")]
+    Invalid(String),
+}
+
+impl FromStr for DataValue {
+    type Err = ParseValueError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "null" {
+            Ok(DataValue::Null)
+        } else if let Ok(bool) = s.parse::<bool>() {
+            Ok(Self::Bool(bool))
+        } else if let Ok(int) = s.parse::<i32>() {
+            Ok(Self::Int32(int))
+        } else if let Ok(bigint) = s.parse::<i64>() {
+            Ok(Self::Int64(bigint))
+        } else if let Ok(d) = s.parse::<Decimal>() {
+            Ok(Self::Decimal(d))
+        } else if s.starts_with('\'') && s.ends_with('\'') {
+            Ok(Self::String(s[1..s.len() - 1].to_string()))
+        } else if s.starts_with("b\'") && s.ends_with('\'') {
+            Ok(Self::Blob(s[2..s.len() - 1].parse()?))
+        } else if let Some(s) = s.strip_prefix("interval") {
+            Ok(Self::Interval(s.trim().trim_matches('\'').parse()?))
+        } else if let Some(s) = s.strip_prefix("date") {
+            Ok(Self::Date(s.trim().trim_matches('\'').parse()?))
+        } else {
+            Err(ParseValueError::Invalid(s.into()))
+        }
+    }
+}

--- a/src/types/value.rs
+++ b/src/types/value.rs
@@ -202,7 +202,7 @@ macro_rules! impl_min_max {
                 match (self, other) {
                     (Self::Null, a) | (a, Self::Null) => a.clone(),
                     $(
-                        (Self::$Value(a), Self::$Value(b)) => Self::$Value(a.min(b)),
+                        (Self::$Value(a), Self::$Value(b)) => Self::$Value(a.max(b)),
                     )*
                     (a, b) => panic!("invalid operation: max({a:?}, {b:?})"),
                 }


### PR DESCRIPTION
This PR migrates the following executors to fit the new planner:
- CreateTable / Drop
- Insert
- CopyFrom / CopyTo
- NestedLoopJoin / HashJoin
- SimpleAgg / HashAgg
- Limit
- Order / TopN

TPCH Q1,3,5,6,10 is able to run. But Q6 will produce a wrong result due to an incorrect decimal cast.

This PR also adds support for showing column names in explain. Here is an example of TPCH Q3:
```
Projection: [l_orderkey, sum((l_extendedprice * (1 - l_discount))), o_orderdate, o_shippriority] (cost=57537.88)              
  TopN: limit=10, offset=0, orderby=[sum((l_extendedprice * (1 - l_discount))) desc, o_orderdate asc] (cost=57487.88)         
    Aggregate: [sum((l_extendedprice * (1 - l_discount)))], groupby=[l_orderkey, o_orderdate, o_shippriority] (cost=56064.105)
      HashJoin: inner, on=([o_orderkey] = [l_orderkey]) (cost=53584.105)                                                      
        HashJoin: inner, on=([c_custkey] = [o_custkey]) (cost=22651.05)                                                       
          Filter: (c_mktsegment = 'BUILDING') (cost=2700)                                                                     
            Scan: [c_custkey, c_mktsegment] (cost=2000)                                                                       
          Filter: (1995-03-15 > o_orderdate) (cost=7500)                                                                      
            Scan: [o_orderkey, o_custkey, o_orderdate, o_shippriority] (cost=4000)                                            
        Filter: (l_shipdate > 1995-03-15) (cost=7500)                                                                         
          Scan: [l_orderkey, l_extendedprice, l_discount, l_shipdate] (cost=4000)                                             
```