### PR TITLE
feat(optimizer): upgrade column pruning to projection pushdown

### DIFF
--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -276,7 +276,7 @@ impl Display for Explain<'_> {
             ),
             Explain(child) => write!(f, "{tab}Explain:{cost}\n{}", self.child(child)),
             Empty(_) => writeln!(f, "{tab}Empty:{cost}"),
-            Prune(_) => panic!("cannot explain Prune"),
+            ColumnPrune(_) | ColumnMerge(_) => panic!("cannot explain {enode}"),
         }
     }
 }

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -1,7 +1,7 @@
 //! Optimization rules and related program analyses.
 //!
-//! Currently we have 4 kinds of rules.
-//! Each of them is defined in a sub-module and has its own analysis:
+//! Currently we have 6 kinds of analyses.
+//! Each of them is defined in a sub-module:
 //!
 //! |   module   |         rules         |            analysis           | analysis data  |
 //! |------------|-----------------------|-------------------------------|----------------|
@@ -28,7 +28,7 @@ use std::sync::LazyLock;
 
 use egg::{rewrite as rw, *};
 
-use super::{EGraph, Expr, Pattern, RecExpr, Rewrite};
+use super::{EGraph, Expr, Pattern, Rewrite};
 use crate::catalog::RootCatalogRef;
 use crate::types::F32;
 
@@ -39,27 +39,18 @@ mod rows;
 mod schema;
 mod type_;
 
-pub use self::schema::ColumnIndexResolver;
 pub use self::type_::TypeError;
 
 /// Stage1 rules in the optimizer.
 pub static STAGE1_RULES: LazyLock<Vec<Rewrite>> = LazyLock::new(|| {
-    let mut rules = vec![];
-    rules.append(&mut plan::column_prune_rules());
-    rules.append(&mut schema::rules());
-    rules
-});
-
-/// Stage2 rules in the optimizer.
-pub static STAGE2_RULES: LazyLock<Vec<Rewrite>> = LazyLock::new(|| {
     let mut rules = vec![];
     rules.append(&mut expr::rules());
     rules.append(&mut plan::always_better_rules());
     rules
 });
 
-/// Stage3 rules in the optimizer.
-pub static STAGE3_RULES: LazyLock<Vec<Rewrite>> = LazyLock::new(|| {
+/// Stage2 rules in the optimizer.
+pub static STAGE2_RULES: LazyLock<Vec<Rewrite>> = LazyLock::new(|| {
     let mut rules = vec![];
     rules.append(&mut expr::rules());
     rules.append(&mut plan::join_rules());

--- a/src/planner/rules/rows.rs
+++ b/src/planner/rules/rows.rs
@@ -32,7 +32,6 @@ pub fn analyze_rows(egraph: &EGraph, enode: &Expr) -> Rows {
         Limit([limit, _, c]) | TopN([limit, _, _, c]) => x(c).min(get_limit_num(limit)),
         Join([_, on, l, r]) => x(l) * x(r) * x(on),
         HashJoin([_, _, _, l, r]) => x(l).max(x(r)),
-        Prune([_, c]) => x(c),
         Empty(_) => 0.0,
 
         // for expressions, the result represents selectivity

--- a/src/planner/rules/schema.rs
+++ b/src/planner/rules/schema.rs
@@ -1,79 +1,6 @@
-//! Analyze schema and replace all column references with physical indices.
-//!
-//! This is the final step before executing.
+//! Analyze the output schema of plans.
 
 use super::*;
-use crate::types::ColumnIndex;
-
-#[rustfmt::skip]
-pub fn rules() -> Vec<Rewrite> { vec![
-    rw!("remove-identity-projection"; 
-        "(proj ?expr ?child)" => "?child"
-        if schema_is_eq("?expr", "?child")
-    ),
-]}
-
-/// Replaces all column references (`ColumnRef`) with
-/// physical indices ([`ColumnIndex`]) to the given schema.
-///
-/// # Example
-/// - given schema:           `sum(v1), v2`
-/// - the expressions:        `v2 + 1, sum(v1) + v2`
-/// - should be rewritten to: `#1 + 1, #0 + #1`
-///
-/// ```
-/// # use risinglight::planner::{RecExpr, ColumnIndexResolver};
-/// let schema = "(list (sum v1) v2)".parse().unwrap();
-/// let expr = "(list (+ v2 1) (+ (sum v1) v2))".parse().unwrap();
-/// assert_eq!(
-///     ColumnIndexResolver::new(&schema).resolve(&expr).to_string(),
-///     "(list (+ #1 1) (+ #0 #1))"
-/// );
-/// ```
-pub struct ColumnIndexResolver {
-    egraph: egg::EGraph<Expr, ()>,
-}
-
-impl ColumnIndexResolver {
-    pub fn new(schema: &RecExpr) -> Self {
-        let mut egraph = egg::EGraph::<Expr, ()>::default();
-        let root = egraph.add_expr(schema);
-        let list = egraph[root].nodes[0].as_list().to_vec();
-        // add expressions from schema and union them with index
-        for (i, expr) in list.into_iter().enumerate() {
-            let idx = egraph.add(Expr::ColumnIndex(ColumnIndex(i as u32)));
-            egraph.union(idx, expr);
-        }
-        egraph.rebuild();
-        ColumnIndexResolver { egraph }
-    }
-
-    /// Replaces all column references (`ColumnRef`) with
-    /// physical indices ([`ColumnIndex`]) in the expr.
-    pub fn resolve(&mut self, expr: &RecExpr) -> RecExpr {
-        struct PreferColumnIndex;
-        impl CostFunction<Expr> for PreferColumnIndex {
-            type Cost = u32;
-            fn cost<C>(&mut self, enode: &Expr, mut costs: C) -> Self::Cost
-            where
-                C: FnMut(Id) -> Self::Cost,
-            {
-                let op_cost = match enode {
-                    Expr::Column(_) => u32::MAX, // column ref should no longer exists
-                    _ => 1,
-                };
-                enode.fold(op_cost, |sum, id| {
-                    sum.checked_add(costs(id)).unwrap_or(u32::MAX)
-                })
-            }
-        }
-        // extract the best expression
-        let id = self.egraph.add_expr(expr);
-        let extractor = egg::Extractor::new(&self.egraph, PreferColumnIndex);
-        let (_, best) = extractor.find_best(id);
-        best
-    }
-}
 
 /// The data type of schema analysis.
 pub type Schema = Option<Vec<Id>>;
@@ -105,17 +32,13 @@ pub fn analyze_schema(enode: &Expr, x: impl Fn(&Id) -> Schema) -> Schema {
             s
         }
 
-        // prune node may changes the schema, but we don't know the exact result for now
-        // so just return `None` to indicate "unknown"
-        Prune(_) => return None,
-
         // not plan node
         _ => return None,
     })
 }
 
 /// Returns true if the schema of two nodes is equal.
-fn schema_is_eq(v1: &str, v2: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool {
+pub fn schema_is_eq(v1: &str, v2: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool {
     let v1 = var(v1);
     let v2 = var(v2);
     move |egraph, _, subst| {
@@ -123,28 +46,4 @@ fn schema_is_eq(v1: &str, v2: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool 
         let s2 = &egraph[subst[v2]].data.schema;
         s1.is_some() && s1 == s2
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::ColumnIndexResolver;
-
-    macro_rules! test_resolve_column_index {
-        ($name:ident,rewrite: $input:expr,schema: $schema:expr,expect: $expected:expr,) => {
-            #[test]
-            fn $name() {
-                let input = $input.parse().unwrap();
-                let schema = $schema.parse().unwrap();
-                let actual = ColumnIndexResolver::new(&schema).resolve(&input);
-                assert_eq!(actual.to_string(), $expected);
-            }
-        };
-    }
-
-    test_resolve_column_index!(
-        resolve_column_index1,
-        rewrite: "(list (+ (+ $1.2 1) (sum $1.1)))",
-        schema: "(list (+ $1.2 1) (sum $1.1) $1.2)",
-        expect: "(list (+ #0 #1))",
-    );
 }


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

This PR upgrades **column pruning** to **projection pushdown**. Additional projections will be inserted to the plan tree, so that columns can be pruned in time after their last use.

The implementation of projection pushdown is similar to the original column pruning. Instead of generating and pushdown the `prune` node, now we directly generate the projection node with the used columns as projection. Then identical projections will be removed by the `identical-proj` rule.

Here is the execution plan of TPC-H Q10 before and after enabling projection pushdown:
```diff
 Projection: [c_custkey, c_name, sum((l_extendedprice * (1 - l_discount))), c_acctbal, n_name, c_address, c_phone, c_comment]
   TopN: limit=20, offset=0, orderby=[sum((l_extendedprice * (1 - l_discount))) desc]
     Aggregate: [sum((l_extendedprice * (1 - l_discount)))], groupby=[c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment]
+      Projection: [n_name, c_custkey, c_name, c_address, c_phone, c_acctbal, c_comment, l_extendedprice, l_discount]
         HashJoin: inner, on=([c_nationkey] = [n_nationkey])
+          Projection: [c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment, l_extendedprice, l_discount]
+            HashJoin: inner, on=([o_orderkey] = [l_orderkey])
+              Projection: [c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment, o_orderkey]
                 HashJoin: inner, on=([c_custkey] = [o_custkey])
                   Scan: customer[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_comment]
-                  HashJoin: inner, on=([o_orderkey] = [l_orderkey])
+                  Projection: [o_orderkey, o_custkey]
                     Filter: ((o_orderdate >= 1993-10-01) and (1994-01-01 > o_orderdate))
                       Scan: orders[o_orderkey, o_custkey, o_orderdate]
+              Projection: [l_orderkey, l_extendedprice, l_discount]
                 Filter: (l_returnflag = 'R')
                   Scan: lineitem[l_orderkey, l_extendedprice, l_discount, l_returnflag]
           Scan: nation[n_nationkey, n_name]
```

As unused columns are removed before HashJoin, the join executor runs faster because there're fewer columns to build. The execution time of this query drops from 0.5s to 0.4s on my computer.

## Limitations

Projection nodes generated between join nodes prevent the join reordering rules. Now join reordering is temporarily unavailable. 😇
