### PR TITLE
executor: use const generics to optimize hash join 

### DIFF
--- a/src/executor_v2/hash_join.rs
+++ b/src/executor_v2/hash_join.rs
@@ -2,16 +2,21 @@
 
 use std::collections::{HashMap, HashSet};
 use std::vec::Vec;
-
 use futures::TryStreamExt;
 use smallvec::SmallVec;
-
 use super::*;
 use crate::array::{DataChunk, DataChunkBuilder, RowRef};
 use crate::types::{DataType, DataValue};
 
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum JoinType {
+    Inner,
+    LeftOuter,
+    RightOuter,
+    FullOuter,
+}
 /// The executor for hash join
-pub struct HashJoinExecutor {
+pub struct HashJoinExecutor<const T: JoinType>  {
     pub op: Expr,
     pub left_keys: RecExpr,
     pub right_keys: RecExpr,
@@ -21,7 +26,7 @@ pub struct HashJoinExecutor {
 
 pub type JoinKeys = SmallVec<[DataValue; 2]>;
 
-impl HashJoinExecutor {
+impl<const T: JoinType>  HashJoinExecutor<T> {
     #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
     pub async fn execute(self, left: BoxedExecutor, right: BoxedExecutor) {
         // collect all chunks from children

--- a/src/executor_v2/hash_join.rs
+++ b/src/executor_v2/hash_join.rs
@@ -2,15 +2,16 @@
 
 use std::collections::{HashMap, HashSet};
 use std::vec::Vec;
+
 use futures::TryStreamExt;
 use smallvec::SmallVec;
+
 use super::*;
 use crate::array::{DataChunk, DataChunkBuilder, RowRef};
 use crate::types::{DataType, DataValue};
 
-
 /// The executor for hash join
-pub struct HashJoinExecutor<const T: JoinType>  {
+pub struct HashJoinExecutor<const T: JoinType> {
     pub op: Expr,
     pub left_keys: RecExpr,
     pub right_keys: RecExpr,
@@ -20,7 +21,7 @@ pub struct HashJoinExecutor<const T: JoinType>  {
 
 pub type JoinKeys = SmallVec<[DataValue; 2]>;
 
-impl<const T: JoinType>  HashJoinExecutor<T> {
+impl<const T: JoinType> HashJoinExecutor<T> {
     #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
     pub async fn execute(self, left: BoxedExecutor, right: BoxedExecutor) {
         // collect all chunks from children

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -86,15 +86,15 @@ pub enum JoinType {
 }
 
 macro_rules! generate_hash_join_operator {
-    ($self:item, $join_type:expr, $op:expr, $lkeys:expr, $rkeys:expr, $left:expr, $right:expr) => {
-        return HashJoinExecutor::<{ $join_type }> {
-            op: self.node($op).clone(),
-            left_keys: self.resolve_column_index($lkeys, $left),
-            right_keys: self.resolve_column_index($rkeys, $right),
-            left_types: self.plan_types(left).to_vec(),
-            right_types: self.plan_types(right).to_vec(),
+    ($self:ident, $join_type:expr, $op:expr, $lkeys:expr, $rkeys:expr, $left:expr, $right:expr) => {
+        HashJoinExecutor::<{ $join_type }> {
+            op: $self.node($op).clone(),
+            left_keys: $self.resolve_column_index($lkeys, $left),
+            right_keys: $self.resolve_column_index($rkeys, $right),
+            left_types: $self.plan_types($left).to_vec(),
+            right_types: $self.plan_types($right).to_vec(),
         }
-        .execute(self.build_id(left), self.build_id(right));
+        .execute($self.build_id($left), $self.build_id($right))
     };
 }
 /// The error type of execution.

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -244,7 +244,48 @@ impl<S: Storage> Builder<S> {
                 right_types: self.plan_types(right).to_vec(),
             }
             .execute(self.build_id(left), self.build_id(right)),
-
+            HashJoin([op, lkeys, rkeys, left, right]) => {
+                if matches!(self.node(op), Expr::Inner) {
+                    HashJoinExecutor::<{JoinType::Inner}> {
+                        op: self.node(op).clone(),
+                        left_keys: self.resolve_column_index(lkeys, left),
+                        right_keys: self.resolve_column_index(rkeys, right),
+                        left_types: self.plan_types(left).to_vec(),
+                        right_types: self.plan_types(right).to_vec(),
+                    }
+                    .execute(self.build_id(left), self.build_id(right))
+                } else if matches!(self.node(op), Expr::LeftOuter) {
+                    HashJoinExecutor::<{JoinType::LeftOuter}> {
+                        op: self.node(op).clone(),
+                        left_keys: self.resolve_column_index(lkeys, left),
+                        right_keys: self.resolve_column_index(rkeys, right),
+                        left_types: self.plan_types(left).to_vec(),
+                        right_types: self.plan_types(right).to_vec(),
+                    }
+                    .execute(self.build_id(left), self.build_id(right))
+                } else if matches!(self.node(op), Expr::RightOuter) {
+                    HashJoinExecutor::<{JoinType::RightOuter}> {
+                        op: self.node(op).clone(),
+                        left_keys: self.resolve_column_index(lkeys, left),
+                        right_keys: self.resolve_column_index(rkeys, right),
+                        left_types: self.plan_types(left).to_vec(),
+                        right_types: self.plan_types(right).to_vec(),
+                    }
+                    .execute(self.build_id(left), self.build_id(right))
+                } else if matches!(self.node(op), Expr::FullOuter) {
+                    HashJoinExecutor::<{JoinType::FullOuter}> {
+                        op: self.node(op).clone(),
+                        left_keys: self.resolve_column_index(lkeys, left),
+                        right_keys: self.resolve_column_index(rkeys, right),
+                        left_types: self.plan_types(left).to_vec(),
+                        right_types: self.plan_types(right).to_vec(),
+                    }
+                    .execute(self.build_id(left), self.build_id(right))
+                } else {
+                    unimplemented!()
+                }
+            },
+            /* 
             HashJoin([op, lkeys, rkeys, left, right]) => HashJoinExecutor {
                 op: self.node(op).clone(),
                 left_keys: self.resolve_column_index(lkeys, left),
@@ -252,7 +293,7 @@ impl<S: Storage> Builder<S> {
                 left_types: self.plan_types(left).to_vec(),
                 right_types: self.plan_types(right).to_vec(),
             }
-            .execute(self.build_id(left), self.build_id(right)),
+            .execute(self.build_id(left), self.build_id(right)),*/
 
             Agg([aggs, group_keys, child]) => {
                 let aggs = self.resolve_column_index(aggs, child);

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -255,7 +255,7 @@ impl<S: Storage> Builder<S> {
             .execute(self.build_id(left), self.build_id(right)),
             HashJoin([op, lkeys, rkeys, left, right]) => {
                 if matches!(self.node(op), Expr::Inner) {
-                    HashJoinExecutor::<{JoinType::Inner}> {
+                    HashJoinExecutor::<{ JoinType::Inner }> {
                         op: self.node(op).clone(),
                         left_keys: self.resolve_column_index(lkeys, left),
                         right_keys: self.resolve_column_index(rkeys, right),
@@ -264,7 +264,7 @@ impl<S: Storage> Builder<S> {
                     }
                     .execute(self.build_id(left), self.build_id(right))
                 } else if matches!(self.node(op), Expr::LeftOuter) {
-                    HashJoinExecutor::<{JoinType::LeftOuter}> {
+                    HashJoinExecutor::<{ JoinType::LeftOuter }> {
                         op: self.node(op).clone(),
                         left_keys: self.resolve_column_index(lkeys, left),
                         right_keys: self.resolve_column_index(rkeys, right),
@@ -273,7 +273,7 @@ impl<S: Storage> Builder<S> {
                     }
                     .execute(self.build_id(left), self.build_id(right))
                 } else if matches!(self.node(op), Expr::RightOuter) {
-                    HashJoinExecutor::<{JoinType::RightOuter}> {
+                    HashJoinExecutor::<{ JoinType::RightOuter }> {
                         op: self.node(op).clone(),
                         left_keys: self.resolve_column_index(lkeys, left),
                         right_keys: self.resolve_column_index(rkeys, right),
@@ -282,7 +282,7 @@ impl<S: Storage> Builder<S> {
                     }
                     .execute(self.build_id(left), self.build_id(right))
                 } else if matches!(self.node(op), Expr::FullOuter) {
-                    HashJoinExecutor::<{JoinType::FullOuter}> {
+                    HashJoinExecutor::<{ JoinType::FullOuter }> {
                         op: self.node(op).clone(),
                         left_keys: self.resolve_column_index(lkeys, left),
                         right_keys: self.resolve_column_index(rkeys, right),
@@ -293,17 +293,15 @@ impl<S: Storage> Builder<S> {
                 } else {
                     unimplemented!()
                 }
-            },
-            /* 
-            HashJoin([op, lkeys, rkeys, left, right]) => HashJoinExecutor {
-                op: self.node(op).clone(),
-                left_keys: self.resolve_column_index(lkeys, left),
-                right_keys: self.resolve_column_index(rkeys, right),
-                left_types: self.plan_types(left).to_vec(),
-                right_types: self.plan_types(right).to_vec(),
             }
-            .execute(self.build_id(left), self.build_id(right)),*/
-
+            // HashJoin([op, lkeys, rkeys, left, right]) => HashJoinExecutor {
+            // op: self.node(op).clone(),
+            // left_keys: self.resolve_column_index(lkeys, left),
+            // right_keys: self.resolve_column_index(rkeys, right),
+            // left_types: self.plan_types(left).to_vec(),
+            // right_types: self.plan_types(right).to_vec(),
+            // }
+            // .execute(self.build_id(left), self.build_id(right)),
             Agg([aggs, group_keys, child]) => {
                 let aggs = self.resolve_column_index(aggs, child);
                 let group_keys = self.resolve_column_index(group_keys, child);

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -76,6 +76,15 @@ mod table_scan;
 mod top_n;
 mod values;
 
+/// Join types for generating join code during the compilation.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum JoinType {
+    Inner,
+    LeftOuter,
+    RightOuter,
+    FullOuter,
+}
+
 /// The error type of execution.
 #[derive(thiserror::Error, Debug)]
 pub enum ExecutorError {

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -294,14 +294,6 @@ impl<S: Storage> Builder<S> {
                     unimplemented!()
                 }
             }
-            // HashJoin([op, lkeys, rkeys, left, right]) => HashJoinExecutor {
-            // op: self.node(op).clone(),
-            // left_keys: self.resolve_column_index(lkeys, left),
-            // right_keys: self.resolve_column_index(rkeys, right),
-            // left_types: self.plan_types(left).to_vec(),
-            // right_types: self.plan_types(right).to_vec(),
-            // }
-            // .execute(self.build_id(left), self.build_id(right)),
             Agg([aggs, group_keys, child]) => {
                 let aggs = self.resolve_column_index(aggs, child);
                 let group_keys = self.resolve_column_index(group_keys, child);

--- a/src/executor_v2/mod.rs
+++ b/src/executor_v2/mod.rs
@@ -85,7 +85,7 @@ pub enum JoinType {
     FullOuter,
 }
 
-macro_rules! generate_hash_join_operator {
+macro_rules! hash_join_operator {
     ($self:ident, $join_type:expr, $op:expr, $lkeys:expr, $rkeys:expr, $left:expr, $right:expr) => {
         HashJoinExecutor::<{ $join_type }> {
             op: $self.node($op).clone(),
@@ -267,45 +267,13 @@ impl<S: Storage> Builder<S> {
             .execute(self.build_id(left), self.build_id(right)),
             HashJoin([op, lkeys, rkeys, left, right]) => {
                 if matches!(self.node(op), Expr::Inner) {
-                    generate_hash_join_operator!(
-                        self,
-                        JoinType::Inner,
-                        op,
-                        lkeys,
-                        rkeys,
-                        left,
-                        right
-                    )
+                    hash_join_operator!(self, JoinType::Inner, op, lkeys, rkeys, left, right)
                 } else if matches!(self.node(op), Expr::LeftOuter) {
-                    generate_hash_join_operator!(
-                        self,
-                        JoinType::LeftOuter,
-                        op,
-                        lkeys,
-                        rkeys,
-                        left,
-                        right
-                    )
+                    hash_join_operator!(self, JoinType::LeftOuter, op, lkeys, rkeys, left, right)
                 } else if matches!(self.node(op), Expr::RightOuter) {
-                    generate_hash_join_operator!(
-                        self,
-                        JoinType::RightOuter,
-                        op,
-                        lkeys,
-                        rkeys,
-                        left,
-                        right
-                    )
+                    hash_join_operator!(self, JoinType::RightOuter, op, lkeys, rkeys, left, right)
                 } else if matches!(self.node(op), Expr::FullOuter) {
-                    generate_hash_join_operator!(
-                        self,
-                        JoinType::FullOuter,
-                        op,
-                        lkeys,
-                        rkeys,
-                        left,
-                        right
-                    )
+                    hash_join_operator!(self, JoinType::FullOuter, op, lkeys, rkeys, left, right)
                 } else {
                     unimplemented!()
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(proc_macro_hygiene)]
 #![feature(core_intrinsics)]
 #![feature(trusted_len)]
+#![feature(adt_const_params)]
 #![feature(once_cell)]
 #![feature(array_methods)]
 #![feature(iterator_try_collect)]

--- a/tests/planner_test/tpch.planner.sql
+++ b/tests/planner_test/tpch.planner.sql
@@ -230,7 +230,7 @@ where
 Projection: [sum((l_discount * l_extendedprice))] (cost=8163.5923)
   Aggregate: [sum((l_discount * l_extendedprice))], groupby=[] (cost=8161.992)
     Projection: [l_extendedprice, l_discount] (cost=7964.3843)
-      Filter: ((24 > l_quantity) and ((l_shipdate >= 1994-01-01) and ((0.09 >= l_discount) and ((1995-01-01 > l_shipdate) and (l_discount >= 0.07))))) (cost=7210.72)
+      Filter: ((l_shipdate >= 1994-01-01) and ((1995-01-01 > l_shipdate) and ((0.09 >= l_discount) and ((24 > l_quantity) and (l_discount >= 0.07))))) (cost=7210.72)
         Scan: lineitem[l_quantity, l_extendedprice, l_discount, l_shipdate] (cost=4000)
 */
 

--- a/tests/planner_test/tpch.planner.sql
+++ b/tests/planner_test/tpch.planner.sql
@@ -230,7 +230,7 @@ where
 Projection: [sum((l_discount * l_extendedprice))] (cost=8163.5923)
   Aggregate: [sum((l_discount * l_extendedprice))], groupby=[] (cost=8161.992)
     Projection: [l_extendedprice, l_discount] (cost=7964.3843)
-      Filter: ((l_shipdate >= 1994-01-01) and ((1995-01-01 > l_shipdate) and ((0.09 >= l_discount) and ((24 > l_quantity) and (l_discount >= 0.07))))) (cost=7210.72)
+      Filter: ((24 > l_quantity) and ((l_shipdate >= 1994-01-01) and ((0.09 >= l_discount) and ((1995-01-01 > l_shipdate) and (l_discount >= 0.07))))) (cost=7210.72)
         Scan: lineitem[l_quantity, l_extendedprice, l_discount, l_shipdate] (cost=4000)
 */
 


### PR DESCRIPTION
Generate hash join code in the compilation time to avoid testing join types during the execution for **every row**.  