### PR TITLE
fix: complete the implementaion of `stringconcat`

### DIFF
--- a/tests/sql/stringconcat.slt
+++ b/tests/sql/stringconcat.slt
@@ -1,0 +1,35 @@
+statement ok
+create table t(v varchar(20))
+
+statement ok
+insert into t values ('test1'), ('test2'), ('test3'), ('test4'), ('test5'), ('test6'), ('test7'), ('test8')
+
+statement ok
+create table t2(v varchar(20))
+
+statement ok
+insert into t2 values ('done')
+
+query I
+select v || 'test' from t
+----
+test1test
+test2test
+test3test
+test4test
+test5test
+test6test
+test7test
+test8test
+
+query II
+select t.v || t2.v from t join t2
+----
+test1done
+test2done
+test3done
+test4done
+test5done
+test6done
+test7done
+test8done

--- a/tests/sqllogictest/tests/sqllogictest.rs
+++ b/tests/sqllogictest/tests/sqllogictest.rs
@@ -14,7 +14,12 @@ fn main() {
     const PATTERN: &str = "tests/sql/**/[!_]*.slt"; // ignore files start with '_'
     const MEM_BLOCKLIST: &[&str] = &["statistics.slt"];
     const DISK_BLOCKLIST: &[&str] = &[];
-    const V1_BLOCKLIST: &[&str] = &["subquery.slt", "tpch.slt", "replace.slt"];
+    const V1_BLOCKLIST: &[&str] = &[
+        "subquery.slt",
+        "tpch.slt",
+        "replace.slt",
+        "stringconcat.slt",
+    ];
 
     let mut tests = vec![];
 


### PR DESCRIPTION
The implementation of `stringconcat` hasn't been completed. It will raise error `execute error: conversion error: no function ||(Utf8, Utf8)`, which needs to add `concat` function in `binary_op`.

Also, could I ask the reason of `O::Item: Sized` limit in `binary_op`? Could I remove it?