### PR TITLE
feat: support simple window functions

### DIFF
--- a/src/binder_v2/expr.rs
+++ b/src/binder_v2/expr.rs
@@ -233,7 +233,7 @@ impl Binder {
             "row_number" => Node::RowNumber,
             name => todo!("Unsupported function: {}", name),
         };
-        let mut id = self.egraph.add(node.clone());
+        let mut id = self.egraph.add(node);
         if let Some(window) = func.over {
             id = self.bind_window_function(id, window)?;
         }

--- a/src/binder_v2/expr.rs
+++ b/src/binder_v2/expr.rs
@@ -51,6 +51,15 @@ impl Binder {
         Ok(id)
     }
 
+    /// Bind a list of expressions.
+    pub fn bind_exprs(&mut self, exprs: Vec<Expr>) -> Result {
+        let list = exprs
+            .into_iter()
+            .map(|expr| self.bind_expr(expr))
+            .try_collect()?;
+        Ok(self.egraph.add(Node::List(list)))
+    }
+
     fn bind_ident(&mut self, idents: impl IntoIterator<Item = Ident>) -> Result {
         let idents = idents
             .into_iter()
@@ -221,9 +230,26 @@ impl Binder {
             "first" => Node::First(args[0]),
             "last" => Node::Last(args[0]),
             "replace" => Node::Replace([args[0], args[1], args[2]]),
+            "row_number" => Node::RowNumber,
             name => todo!("Unsupported function: {}", name),
         };
-        Ok(self.egraph.add(node))
+        let mut id = self.egraph.add(node.clone());
+        if let Some(window) = func.over {
+            if !node.is_window_function() {
+                return Err(BindError::NotAgg(node.to_string()));
+            }
+            id = self.bind_window_function(id, window)?;
+        }
+        Ok(id)
+    }
+
+    fn bind_window_function(&mut self, func: Id, window: WindowSpec) -> Result {
+        let partitionby = self.bind_exprs(window.partition_by)?;
+        let orderby = self.bind_orderby(window.order_by)?;
+        if window.window_frame.is_some() {
+            todo!("support window frame");
+        }
+        Ok(self.egraph.add(Node::Over([func, partitionby, orderby])))
     }
 }
 

--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -73,6 +73,8 @@ pub enum BindError {
     AggInWhere,
     #[error("GROUP BY clause cannot contain aggregates")]
     AggInGroupBy,
+    #[error("window function calls cannot be nested")]
+    NestedWindow,
     #[error("WHERE clause cannot contain window functions")]
     WindowInWhere,
     #[error("HAVING clause cannot contain window functions")]

--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -79,6 +79,8 @@ pub enum BindError {
     OrderKeyNotInDistinct,
     #[error("operation on internal table is not supported")]
     NotSupportedOnInternalTable,
+    #[error("{0} is not an aggregate function")]
+    NotAgg(String),
 }
 
 /// The binder resolves all expressions referring to schema objects such as

--- a/src/binder_v2/mod.rs
+++ b/src/binder_v2/mod.rs
@@ -73,6 +73,10 @@ pub enum BindError {
     AggInWhere,
     #[error("GROUP BY clause cannot contain aggregates")]
     AggInGroupBy,
+    #[error("WHERE clause cannot contain window functions")]
+    WindowInWhere,
+    #[error("HAVING clause cannot contain window functions")]
+    WindowInHaving,
     #[error("column {0} must appear in the GROUP BY clause or be used in an aggregate function")]
     ColumnNotInAgg(String),
     #[error("ORDER BY items must appear in the select list if DISTINCT is specified")]
@@ -194,6 +198,10 @@ impl Binder {
 
     fn aggs(&self, id: Id) -> &[Node] {
         &self.egraph[id].data.aggs
+    }
+
+    fn overs(&self, id: Id) -> &[Node] {
+        &self.egraph[id].data.overs
     }
 
     fn node(&self, id: Id) -> &Node {

--- a/src/executor_v2/window.rs
+++ b/src/executor_v2/window.rs
@@ -1,0 +1,33 @@
+// Copyright 2023 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use super::*;
+use crate::array::DataChunkBuilder;
+
+/// The executor of window functions.
+pub struct WindowExecutor {
+    /// A list of over window functions.
+    ///
+    /// e.g. `(list (over (lag #0) list list))`
+    pub exprs: RecExpr,
+    /// The types of window function columns.
+    pub types: Vec<DataType>,
+}
+
+impl WindowExecutor {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self, child: BoxedExecutor) {
+        let mut states = Evaluator::new(&self.exprs).init_agg_states::<Vec<_>>();
+
+        #[for_await]
+        for chunk in child {
+            let chunk = chunk?;
+            let mut builder = DataChunkBuilder::new(&self.types, chunk.cardinality() + 1);
+            for i in 0..chunk.cardinality() {
+                Evaluator::new(&self.exprs).agg_list_append(&mut states, chunk.row(i).values());
+                _ = builder.push_row(states.clone());
+            }
+            let window_chunk = builder.take().unwrap();
+            yield chunk.row_concat(window_chunk);
+        }
+    }
+}

--- a/src/planner/rules/agg.rs
+++ b/src/planner/rules/agg.rs
@@ -9,8 +9,7 @@ pub type AggSet = Vec<Expr>;
 ///
 /// Note: if there is an agg over agg, e.g. `sum(count(a))`, only the upper one will be returned.
 pub fn analyze_aggs(enode: &Expr, x: impl Fn(&Id) -> AggSet) -> AggSet {
-    use Expr::*;
-    if let RowCount | Max(_) | Min(_) | Sum(_) | Avg(_) | Count(_) | First(_) | Last(_) = enode {
+    if enode.is_aggregate_function() {
         return vec![enode.clone()];
     }
     // merge the set from all children

--- a/src/planner/rules/agg.rs
+++ b/src/planner/rules/agg.rs
@@ -12,6 +12,9 @@ pub fn analyze_aggs(enode: &Expr, x: impl Fn(&Id) -> AggSet) -> AggSet {
     if enode.is_aggregate_function() {
         return vec![enode.clone()];
     }
+    if let Expr::Over(_) = enode {
+        return vec![];
+    }
     // merge the set from all children
     // TODO: ignore plan nodes
     enode.children().iter().flat_map(x).collect()

--- a/src/planner/rules/agg.rs
+++ b/src/planner/rules/agg.rs
@@ -19,3 +19,16 @@ pub fn analyze_aggs(enode: &Expr, x: impl Fn(&Id) -> AggSet) -> AggSet {
     // TODO: ignore plan nodes
     enode.children().iter().flat_map(x).collect()
 }
+
+/// The data type of over analysis.
+pub type OverSet = Vec<Expr>;
+
+/// Returns all over nodes in the tree.
+pub fn analyze_overs(enode: &Expr, x: impl Fn(&Id) -> OverSet) -> OverSet {
+    if let Expr::Over(_) = enode {
+        return vec![enode.clone()];
+    }
+    // merge the set from all children
+    // TODO: ignore plan nodes
+    enode.children().iter().flat_map(x).collect()
+}

--- a/src/planner/rules/mod.rs
+++ b/src/planner/rules/mod.rs
@@ -77,6 +77,7 @@ pub struct Data {
 
     /// A list of expressions produced by plan node.
     pub schema: schema::Schema,
+
     /// Estimate rows.
     pub rows: rows::Rows,
 }
@@ -138,6 +139,9 @@ pub struct TypeSchema {
 
     /// All aggragations in the tree.
     pub aggs: agg::AggSet,
+
+    /// All over nodes in the tree.
+    pub overs: agg::OverSet,
 }
 
 impl Analysis<Expr> for TypeSchemaAnalysis {
@@ -152,6 +156,7 @@ impl Analysis<Expr> for TypeSchemaAnalysis {
             ),
             schema: schema::analyze_schema(enode, |i| egraph[*i].data.schema.clone()),
             aggs: agg::analyze_aggs(enode, |i| egraph[*i].data.aggs.clone()),
+            overs: agg::analyze_overs(enode, |i| egraph[*i].data.overs.clone()),
         }
     }
 
@@ -159,7 +164,8 @@ impl Analysis<Expr> for TypeSchemaAnalysis {
         let merge_type = egg::merge_max(&mut to.type_, from.type_);
         let merge_schema = egg::merge_max(&mut to.schema, from.schema);
         let merge_aggs = egg::merge_max(&mut to.aggs, from.aggs);
-        merge_type | merge_schema | merge_aggs
+        let merge_overs = egg::merge_max(&mut to.overs, from.overs);
+        merge_type | merge_schema | merge_aggs | merge_overs
     }
 }
 

--- a/src/planner/rules/schema.rs
+++ b/src/planner/rules/schema.rs
@@ -26,6 +26,7 @@ pub fn analyze_schema(enode: &Expr, x: impl Fn(&Id) -> Schema) -> Schema {
         Values(vs) => x(&vs[0]),
         Proj([exprs, _]) => x(exprs),
         Agg([exprs, group_keys, _]) => concat(x(exprs), x(group_keys)),
+        Window([exprs, child]) => concat(x(child), x(exprs)),
         Empty(ids) => {
             let mut s = vec![];
             for id in ids.iter() {

--- a/src/planner/rules/type_.rs
+++ b/src/planner/rules/type_.rs
@@ -106,8 +106,9 @@ pub fn analyze_type(enode: &Expr, x: impl Fn(&Id) -> Type, catalog: &RootCatalog
         Avg(a) => check(enode, x(a)?, |a| a.is_number()),
 
         // agg
-        RowCount | Count(_) => Ok(Kind::Int32.not_null()),
+        RowCount | RowNumber | Count(_) => Ok(Kind::Int32.not_null()),
         First(a) | Last(a) => x(a),
+        Over([f, _, _]) => x(f),
 
         // scalar functions
         Replace([a, from, to]) => merge(enode, [x(a)?, x(from)?, x(to)?], |[a, from, to]| {

--- a/tests/sql/window_function.slt
+++ b/tests/sql/window_function.slt
@@ -4,12 +4,12 @@ CREATE TABLE t (a INT);
 statement ok
 INSERT INTO t(a) VALUES (1), (2), (3);
 
-query II
-SELECT a, row_number() OVER () FROM t;
+query I
+SELECT row_number() OVER () FROM t;
 ----
-1 1
-2 2
-3 3
+1
+2
+3
 
 query I
 SELECT a - row_number() OVER () FROM t;
@@ -17,3 +17,10 @@ SELECT a - row_number() OVER () FROM t;
 0
 0
 0
+
+query I
+SELECT sum(a) OVER () FROM t;
+----
+1
+3
+6

--- a/tests/sql/window_function.slt
+++ b/tests/sql/window_function.slt
@@ -1,0 +1,19 @@
+statement ok
+CREATE TABLE t (a INT);
+
+statement ok
+INSERT INTO t(a) VALUES (1), (2), (3);
+
+query II
+SELECT a, row_number() OVER () FROM t;
+----
+1 1
+2 2
+3 3
+
+query I
+SELECT a - row_number() OVER () FROM t;
+----
+0
+0
+0

--- a/tests/sql/window_function.slt
+++ b/tests/sql/window_function.slt
@@ -30,3 +30,6 @@ SELECT a FROM t WHERE sum(a) OVER () > 0;
 
 statement error HAVING clause cannot contain window functions
 SELECT a FROM t HAVING sum(a) OVER () > 0;
+
+statement error window function calls cannot be nested
+SELECT sum(sum(a) over ()) over () FROM t;

--- a/tests/sql/window_function.slt
+++ b/tests/sql/window_function.slt
@@ -24,3 +24,9 @@ SELECT sum(a) OVER () FROM t;
 1
 3
 6
+
+statement error WHERE clause cannot contain window functions
+SELECT a FROM t WHERE sum(a) OVER () > 0;
+
+statement error HAVING clause cannot contain window functions
+SELECT a FROM t HAVING sum(a) OVER () > 0;

--- a/tests/sqllogictest/tests/sqllogictest.rs
+++ b/tests/sqllogictest/tests/sqllogictest.rs
@@ -19,6 +19,7 @@ fn main() {
         "tpch.slt",
         "replace.slt",
         "stringconcat.slt",
+        "window_function.slt",
     ];
 
     let mut tests = vec![];


### PR DESCRIPTION
This PR adds basic support for window functions. Available functions include `row_number` and all existing aggregate functions. Only default window (`over ()`) is supported now.

Currently the `row_number` function shares the evaluation logic with aggregations. Next step we will specialize the evaluation for window functions.