### PR TITLE
fix: avoid div by zero error when vectorization

### DIFF
--- a/src/array/ops.rs
+++ b/src/array/ops.rs
@@ -607,7 +607,7 @@ macro_rules! impl_agg {
 for_all_variants! { impl_agg }
 
 fn safen_dividend(array: &ArrayImpl, valid: &BitVec) -> Option<ArrayImpl> {
-    fn f<'a, T, N>(array: &'a PrimitiveArray<N>, valid: &BitVec, value: N) -> T
+    fn f<T, N>(array: &PrimitiveArray<N>, valid: &BitVec, value: N) -> T
     where
         T: ArrayFromDataExt,
         N: NativeType + num_traits::Zero + Borrow<<T as Array>::Item>,

--- a/src/array/ops.rs
+++ b/src/array/ops.rs
@@ -661,25 +661,25 @@ fn safen_dividend(array: &ArrayImpl, valid: &BitVec) -> Option<ArrayImpl> {
 
     // all valid dividend case
     Some(match array {
-        ArrayImpl::Int16(array) => {
+        A::Int16(array) => {
             let array = f(array, valid, 1);
-            ArrayImpl::Int16(Arc::new(array))
+            A::new_int16(array)
         }
-        ArrayImpl::Int32(array) => {
+        A::Int32(array) => {
             let array = f(array, valid, 1);
-            ArrayImpl::Int32(Arc::new(array))
+            A::new_int32(array)
         }
-        ArrayImpl::Int64(array) => {
+        A::Int64(array) => {
             let array = f(array, valid, 1);
-            ArrayImpl::Int64(Arc::new(array))
+            A::new_int64(array)
         }
-        ArrayImpl::Float64(array) => {
+        A::Float64(array) => {
             let array = f(array, valid, 1.0.into());
-            ArrayImpl::Float64(Arc::new(array))
+            A::new_float64(array)
         }
-        ArrayImpl::Decimal(array) => {
+        A::Decimal(array) => {
             let array = f(array, valid, Decimal::new(1, 0));
-            ArrayImpl::Decimal(Arc::new(array))
+            A::new_decimal(array)
         }
         _ => return None,
     })

--- a/src/planner/rules/expr.rs
+++ b/src/planner/rules/expr.rs
@@ -118,7 +118,7 @@ pub fn eval_constant(egraph: &EGraph, enode: &Expr) -> ConstValue {
         Some(x(*e)?.clone())
     } else if let Some((op, a, b)) = enode.binary_op() {
         let (a, b) = (x(a)?, x(b)?);
-        if a.is_null() || b.is_null() || b.is_zero() {
+        if a.is_null() || b.is_null() {
             return Some(DataValue::Null);
         }
         let array_a = ArrayImpl::from(a);

--- a/src/planner/rules/expr.rs
+++ b/src/planner/rules/expr.rs
@@ -118,7 +118,7 @@ pub fn eval_constant(egraph: &EGraph, enode: &Expr) -> ConstValue {
         Some(x(*e)?.clone())
     } else if let Some((op, a, b)) = enode.binary_op() {
         let (a, b) = (x(a)?, x(b)?);
-        if a.is_null() || b.is_null() {
+        if a.is_null() || b.is_null() || b.is_zero() {
             return Some(DataValue::Null);
         }
         let array_a = ArrayImpl::from(a);

--- a/tests/sql/nullable_operator.slt
+++ b/tests/sql/nullable_operator.slt
@@ -1,0 +1,14 @@
+statement ok
+create table t(x int, y int)
+
+statement ok
+insert into t values (1, 2), (2, NULL)
+
+query I
+select x / y from t
+----
+0
+NULL
+
+statement ok
+drop table t

--- a/tests/sql/nullable_operator.slt
+++ b/tests/sql/nullable_operator.slt
@@ -10,5 +10,11 @@ select x / y from t
 0
 NULL
 
+query I
+select x / 0 from t
+----
+NULL
+NULL
+
 statement ok
 drop table t


### PR DESCRIPTION
modify `binary_op` so that op(`F`) only maps to non-empty array items, else `Default::default()`.
add `binary_lop`(binary logic operator), renamed from original `binary_op`

Actually I don't quite understand the vectorization here... I just found that doing it this way prevents the bug mentioned in the issue. Maybe it's wrong to zip like this, or lose the ability to auto-vectorize?

Thanks if anyone can review it.

fix #773.