### PR TITLE
fix(optimizer): support pushdown pk to storage scan

### DIFF
--- a/src/binder/table.rs
+++ b/src/binder/table.rs
@@ -55,7 +55,7 @@ impl Binder {
     /// Returns a `Scan` plan of table or a plan of subquery.
     ///
     /// # Example
-    /// - `bind_table_factor(t)` => `(scan $1 (list $1.1 $1.2 $1.3) null)`
+    /// - `bind_table_factor(t)` => `(scan $1 (list $1.1 $1.2 $1.3) true)`
     /// - `bind_table_factor(select 1)` => `(values (1))`
     fn bind_table_factor(&mut self, table: TableFactor) -> Result {
         match table {
@@ -135,7 +135,7 @@ impl Binder {
     /// This function defines the table name so that it can be referred later.
     ///
     /// # Example
-    /// - `bind_table_def(t)` => `(scan $1 (list $1.1 $1.2) null)`
+    /// - `bind_table_def(t)` => `(scan $1 (list $1.1 $1.2) true)`
     pub(super) fn bind_table_def(
         &mut self,
         name: &ObjectName,
@@ -194,8 +194,8 @@ impl Binder {
         // return a Scan node
         let table = self.egraph.add(Node::Table(ref_id));
         let cols = self.egraph.add(Node::List(ids.into()));
-        let null = self.egraph.add(Node::null());
-        let scan = self.egraph.add(Node::Scan([table, cols, null]));
+        let true_ = self.egraph.add(Node::true_());
+        let scan = self.egraph.add(Node::Scan([table, cols, true_]));
         Ok(scan)
     }
 

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -201,9 +201,22 @@ impl<S: Storage> Builder<S> {
                     .collect_vec();
                 // analyze range filter
                 let filter = {
+                    use std::ops::Bound;
                     let mut egraph = egg::EGraph::new(ExprAnalysis::default());
                     let root = egraph.add_expr(&self.recexpr(filter));
-                    egraph[root].data.range.clone().map(|(_, r)| r)
+                    let expr: Option<crate::storage::KeyRange> =
+                        egraph[root].data.range.clone().map(|(_, r)| r);
+                    if matches!(
+                        expr,
+                        Some(crate::storage::KeyRange {
+                            start: Bound::Unbounded,
+                            end: Bound::Unbounded
+                        })
+                    ) {
+                        None
+                    } else {
+                        expr
+                    }
                 };
 
                 if let Some(subscriber) = self.views.get(&table_id) {

--- a/src/planner/rules/range.rs
+++ b/src/planner/rules/range.rs
@@ -106,11 +106,11 @@ fn is_primary_key_range(expr: &str) -> impl Fn(&mut EGraph, Id, &Subst) -> bool 
         let Some((column, _)) = &egraph[subst[var]].data.range else {
             return false;
         };
-        egraph
-            .analysis
-            .catalog
-            .get_column(column)
-            .unwrap()
-            .is_primary()
+        if let Some(col) = egraph.analysis.catalog.get_column(column) {
+            col.is_primary()
+        } else {
+            // handle the case that catalog is not initialized, like in test cases
+            false
+        }
     }
 }

--- a/tests/planner_test/count.planner.sql
+++ b/tests/planner_test/count.planner.sql
@@ -4,7 +4,7 @@ explain select count(*) from t
 /*
 Projection { exprs: [ rowcount ], cost: 1.13, rows: 1 }
 └── Agg { aggs: [ rowcount ], cost: 1.11, rows: 1 }
-    └── Scan { table: t, list: [], filter: null, cost: 0, rows: 1 }
+    └── Scan { table: t, list: [], filter: true, cost: 0, rows: 1 }
 */
 
 -- count(*) with projection
@@ -13,6 +13,6 @@ explain select count(*) + 1 from t
 /*
 Projection { exprs: [ + { lhs: rowcount, rhs: 1 } ], cost: 1.33, rows: 1 }
 └── Agg { aggs: [ rowcount ], cost: 1.11, rows: 1 }
-    └── Scan { table: t, list: [], filter: null, cost: 0, rows: 1 }
+    └── Scan { table: t, list: [], filter: true, cost: 0, rows: 1 }
 */
 

--- a/tests/planner_test/extract-common-predicate.planner.sql
+++ b/tests/planner_test/extract-common-predicate.planner.sql
@@ -6,6 +6,6 @@ Filter
 ├── cond: and { lhs: = { lhs: a, rhs: 1 }, rhs: or { lhs: = { lhs: b, rhs: 2 }, rhs: = { lhs: c, rhs: 3 } } }
 ├── cost: 4.955
 ├── rows: 0.375
-└── Scan { table: t, list: [ a, b, c ], filter: null, cost: 3, rows: 1 }
+└── Scan { table: t, list: [ a, b, c ], filter: true, cost: 3, rows: 1 }
 */
 

--- a/tests/planner_test/storage-pushdown.planner.sql
+++ b/tests/planner_test/storage-pushdown.planner.sql
@@ -1,0 +1,57 @@
+-- use merge join for primary key joins
+explain select * from t1 join t2 on a = c;
+
+/*
+Join { type: inner, on: = { lhs: c, rhs: a }, cost: 0, rows: 0 }
+├── Scan { table: t1, list: [ a, b ], filter: true, cost: 0, rows: 0 }
+└── Scan { table: t2, list: [ c, d ], filter: true, cost: 0, rows: 0 }
+*/
+
+-- use storage order by instead of sorting by primary key
+explain select * from t1 order by a;
+
+/*
+Scan { table: t1, list: [ a, b ], filter: true, cost: 0, rows: 0 }
+*/
+
+-- use storage filter for primary key
+explain select * from t1 where a = 1;
+
+/*
+Scan { table: t1, list: [ a, b ], filter: = { lhs: a, rhs: 1 }, cost: 10, rows: 5 }
+*/
+
+-- use storage filter for a combination of primary key and other keys
+explain select * from t1 where a > 1 and a < 3 and b > 1;
+
+/*
+Filter { cond: > { lhs: b, rhs: 1 }, cost: 16.05, rows: 2.5 }
+└── Scan
+    ├── table: t1
+    ├── list: [ a, b ]
+    ├── filter: and { lhs: > { lhs: 3, rhs: a }, rhs: > { lhs: a, rhs: 1 } }
+    ├── cost: 10
+    └── rows: 5
+*/
+
+-- use storage filter for a combination of primary key (always false) and other keys
+explain select * from t1 where a > 1 and a < 0 and b > 1;
+
+/*
+Filter { cond: > { lhs: b, rhs: 1 }, cost: 16.05, rows: 2.5 }
+└── Scan
+    ├── table: t1
+    ├── list: [ a, b ]
+    ├── filter: and { lhs: > { lhs: 0, rhs: a }, rhs: > { lhs: a, rhs: 1 } }
+    ├── cost: 10
+    └── rows: 5
+*/
+
+-- use storage filter for a combination of primary key (could be eliminated) and other keys
+explain select * from t1 where a > 1 and a > 3 and b > 1;
+
+/*
+Filter { cond: and { lhs: > { lhs: b, rhs: 1 }, rhs: > { lhs: a, rhs: 3 } }, cost: 15.1, rows: 1.25 }
+└── Scan { table: t1, list: [ a, b ], filter: > { lhs: a, rhs: 1 }, cost: 10, rows: 5 }
+*/
+

--- a/tests/planner_test/storage-pushdown.yml
+++ b/tests/planner_test/storage-pushdown.yml
@@ -1,0 +1,47 @@
+- sql: |
+    explain select * from t1 join t2 on a = c;
+  desc: use merge join for primary key joins
+  before:
+    - create table t1(a int primary key, b int);
+      create table t2(c int primary key, d int);
+  tasks:
+    - print
+- sql: |
+    explain select * from t1 order by a;
+  desc: use storage order by instead of sorting by primary key
+  before:
+    - create table t1(a int primary key, b int);
+  tasks:
+    - print
+- sql: |
+    explain select * from t1 where a = 1;
+  desc: use storage filter for primary key
+  before:
+    - create table t1(a int primary key, b int);
+      insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+  tasks:
+    - print
+- sql: |
+    explain select * from t1 where a > 1 and a < 3 and b > 1;
+  desc: use storage filter for a combination of primary key and other keys
+  before:
+    - create table t1(a int primary key, b int);
+      insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+  tasks:
+    - print
+- sql: |
+    explain select * from t1 where a > 1 and a < 0 and b > 1;
+  desc: use storage filter for a combination of primary key (always false) and other keys
+  before:
+    - create table t1(a int primary key, b int);
+      insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+  tasks:
+    - print
+- sql: |
+    explain select * from t1 where a > 1 and a > 3 and b > 1;
+  desc: use storage filter for a combination of primary key (could be eliminated) and other keys
+  before:
+    - create table t1(a int primary key, b int);
+      insert into t1 values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+  tasks:
+    - print

--- a/tests/planner_test/tpch.planner.sql
+++ b/tests/planner_test/tpch.planner.sql
@@ -189,7 +189,7 @@ Projection
                 └── Scan
                     ├── table: lineitem
                     ├── list: [ l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate ]
-                    ├── filter: null
+                    ├── filter: true
                     ├── cost: 42008504
                     └── rows: 6001215
 */
@@ -265,14 +265,14 @@ Projection
                 │       │       └── Scan
                 │       │           ├── table: customer
                 │       │           ├── list: [ c_custkey, c_mktsegment ]
-                │       │           ├── filter: null
+                │       │           ├── filter: true
                 │       │           ├── cost: 300000
                 │       │           └── rows: 150000
                 │       └── Filter { cond: > { lhs: 1995-03-15, rhs: o_orderdate }, cost: 9315000, rows: 750000 }
                 │           └── Scan
                 │               ├── table: orders
                 │               ├── list: [ o_orderkey, o_custkey, o_orderdate, o_shippriority ]
-                │               ├── filter: null
+                │               ├── filter: true
                 │               ├── cost: 6000000
                 │               └── rows: 1500000
                 └── Projection { exprs: [ l_orderkey, l_extendedprice, l_discount ], cost: 37387570, rows: 3000607.5 }
@@ -280,7 +280,7 @@ Projection
                         └── Scan
                             ├── table: lineitem
                             ├── list: [ l_orderkey, l_extendedprice, l_discount, l_shipdate ]
-                            ├── filter: null
+                            ├── filter: true
                             ├── cost: 24004860
                             └── rows: 6001215
 */
@@ -354,19 +354,19 @@ Projection
                 │       │       │       └── Scan
                 │       │       │           ├── table: region
                 │       │       │           ├── list: [ r_regionkey, r_name ]
-                │       │       │           ├── filter: null
+                │       │       │           ├── filter: true
                 │       │       │           ├── cost: 10
                 │       │       │           └── rows: 5
                 │       │       └── Scan
                 │       │           ├── table: nation
                 │       │           ├── list: [ n_nationkey, n_name, n_regionkey ]
-                │       │           ├── filter: null
+                │       │           ├── filter: true
                 │       │           ├── cost: 75
                 │       │           └── rows: 25
                 │       └── Scan
                 │           ├── table: supplier
                 │           ├── list: [ s_suppkey, s_nationkey ]
-                │           ├── filter: null
+                │           ├── filter: true
                 │           ├── cost: 20000
                 │           └── rows: 10000
                 └── Projection
@@ -387,7 +387,7 @@ Projection
                         │       ├── Scan
                         │       │   ├── table: customer
                         │       │   ├── list: [ c_custkey, c_nationkey ]
-                        │       │   ├── filter: null
+                        │       │   ├── filter: true
                         │       │   ├── cost: 300000
                         │       │   └── rows: 150000
                         │       └── Projection { exprs: [ o_orderkey, o_custkey ], cost: 6416250, rows: 375000 }
@@ -400,13 +400,13 @@ Projection
                         │               └── Scan
                         │                   ├── table: orders
                         │                   ├── list: [ o_orderkey, o_custkey, o_orderdate ]
-                        │                   ├── filter: null
+                        │                   ├── filter: true
                         │                   ├── cost: 4500000
                         │                   └── rows: 1500000
                         └── Scan
                             ├── table: lineitem
                             ├── list: [ l_orderkey, l_suppkey, l_extendedprice, l_discount ]
-                            ├── filter: null
+                            ├── filter: true
                             ├── cost: 24004860
                             └── rows: 6001215
 */
@@ -447,7 +447,7 @@ Projection
             └── Scan
                 ├── table: lineitem
                 ├── list: [ l_quantity, l_extendedprice, l_discount, l_shipdate ]
-                ├── filter: null
+                ├── filter: true
                 ├── cost: 24004860
                 └── rows: 6001215
 */
@@ -548,19 +548,19 @@ Projection
                         │       │       ├── Scan
                         │       │       │   ├── table: nation
                         │       │       │   ├── list: [ n_nationkey(1), n_name(1) ]
-                        │       │       │   ├── filter: null
+                        │       │       │   ├── filter: true
                         │       │       │   ├── cost: 50
                         │       │       │   └── rows: 25
                         │       │       └── Scan
                         │       │           ├── table: customer
                         │       │           ├── list: [ c_custkey, c_nationkey ]
-                        │       │           ├── filter: null
+                        │       │           ├── filter: true
                         │       │           ├── cost: 300000
                         │       │           └── rows: 150000
                         │       └── Scan
                         │           ├── table: orders
                         │           ├── list: [ o_orderkey, o_custkey ]
-                        │           ├── filter: null
+                        │           ├── filter: true
                         │           ├── cost: 3000000
                         │           └── rows: 1500000
                         └── Projection
@@ -581,13 +581,13 @@ Projection
                                 │       ├── Scan
                                 │       │   ├── table: nation
                                 │       │   ├── list: [ n_nationkey, n_name ]
-                                │       │   ├── filter: null
+                                │       │   ├── filter: true
                                 │       │   ├── cost: 50
                                 │       │   └── rows: 25
                                 │       └── Scan
                                 │           ├── table: supplier
                                 │           ├── list: [ s_suppkey, s_nationkey ]
-                                │           ├── filter: null
+                                │           ├── filter: true
                                 │           ├── cost: 20000
                                 │           └── rows: 10000
                                 └── Filter
@@ -599,7 +599,7 @@ Projection
                                     └── Scan
                                         ├── table: lineitem
                                         ├── list: [ l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate ]
-                                        ├── filter: null
+                                        ├── filter: true
                                         ├── cost: 30006076
                                         └── rows: 6001215
 */
@@ -695,7 +695,7 @@ Projection
                     │   ├── Scan
                     │   │   ├── table: nation
                     │   │   ├── list: [ n_nationkey(1), n_name(1) ]
-                    │   │   ├── filter: null
+                    │   │   ├── filter: true
                     │   │   ├── cost: 50
                     │   │   └── rows: 25
                     │   └── Projection { exprs: [ r_regionkey ], cost: 16.099998, rows: 2.5 }
@@ -703,7 +703,7 @@ Projection
                     │           └── Scan
                     │               ├── table: region
                     │               ├── list: [ r_regionkey, r_name ]
-                    │               ├── filter: null
+                    │               ├── filter: true
                     │               ├── cost: 10
                     │               └── rows: 5
                     └── Projection
@@ -733,13 +733,13 @@ Projection
                             │       │       ├── Scan
                             │       │       │   ├── table: nation
                             │       │       │   ├── list: [ n_nationkey, n_regionkey ]
-                            │       │       │   ├── filter: null
+                            │       │       │   ├── filter: true
                             │       │       │   ├── cost: 50
                             │       │       │   └── rows: 25
                             │       │       └── Scan
                             │       │           ├── table: customer
                             │       │           ├── list: [ c_custkey, c_nationkey ]
-                            │       │           ├── filter: null
+                            │       │           ├── filter: true
                             │       │           ├── cost: 300000
                             │       │           └── rows: 150000
                             │       └── Filter
@@ -751,7 +751,7 @@ Projection
                             │           └── Scan
                             │               ├── table: orders
                             │               ├── list: [ o_orderkey, o_custkey, o_orderdate ]
-                            │               ├── filter: null
+                            │               ├── filter: true
                             │               ├── cost: 4500000
                             │               └── rows: 1500000
                             └── Projection
@@ -766,7 +766,7 @@ Projection
                                     ├── Scan
                                     │   ├── table: supplier
                                     │   ├── list: [ s_suppkey, s_nationkey ]
-                                    │   ├── filter: null
+                                    │   ├── filter: true
                                     │   ├── cost: 20000
                                     │   └── rows: 10000
                                     └── Projection
@@ -786,7 +786,7 @@ Projection
                                             │       └── Scan
                                             │           ├── table: part
                                             │           ├── list: [ p_partkey, p_type ]
-                                            │           ├── filter: null
+                                            │           ├── filter: true
                                             │           ├── cost: 400000
                                             │           └── rows: 200000
                                             └── Scan
@@ -797,7 +797,7 @@ Projection
                                                 │   ├── l_suppkey
                                                 │   ├── l_extendedprice
                                                 │   └── l_discount
-                                                ├── filter: null
+                                                ├── filter: true
                                                 ├── cost: 30006076
                                                 └── rows: 6001215
 */
@@ -879,7 +879,7 @@ Projection
                 ├── Scan
                 │   ├── table: orders
                 │   ├── list: [ o_orderkey, o_orderdate ]
-                │   ├── filter: null
+                │   ├── filter: true
                 │   ├── cost: 3000000
                 │   └── rows: 1500000
                 └── Projection
@@ -894,7 +894,7 @@ Projection
                         ├── Scan
                         │   ├── table: partsupp
                         │   ├── list: [ ps_partkey, ps_suppkey, ps_supplycost ]
-                        │   ├── filter: null
+                        │   ├── filter: true
                         │   ├── cost: 2400000
                         │   └── rows: 800000
                         └── Projection
@@ -922,13 +922,13 @@ Projection
                                 │       ├── Scan
                                 │       │   ├── table: nation
                                 │       │   ├── list: [ n_nationkey, n_name ]
-                                │       │   ├── filter: null
+                                │       │   ├── filter: true
                                 │       │   ├── cost: 50
                                 │       │   └── rows: 25
                                 │       └── Scan
                                 │           ├── table: supplier
                                 │           ├── list: [ s_suppkey, s_nationkey ]
-                                │           ├── filter: null
+                                │           ├── filter: true
                                 │           ├── cost: 20000
                                 │           └── rows: 10000
                                 └── Projection
@@ -954,7 +954,7 @@ Projection
                                         │       └── Scan
                                         │           ├── table: part
                                         │           ├── list: [ p_partkey, p_name ]
-                                        │           ├── filter: null
+                                        │           ├── filter: true
                                         │           ├── cost: 400000
                                         │           └── rows: 200000
                                         └── Scan
@@ -966,7 +966,7 @@ Projection
                                             │   ├── l_quantity
                                             │   ├── l_extendedprice
                                             │   └── l_discount
-                                            ├── filter: null
+                                            ├── filter: true
                                             ├── cost: 36007290
                                             └── rows: 6001215
 */
@@ -1072,7 +1072,7 @@ Projection
                 │       │       ├── Scan
                 │       │       │   ├── table: nation
                 │       │       │   ├── list: [ n_nationkey, n_name ]
-                │       │       │   ├── filter: null
+                │       │       │   ├── filter: true
                 │       │       │   ├── cost: 50
                 │       │       │   └── rows: 25
                 │       │       └── Scan
@@ -1085,7 +1085,7 @@ Projection
                 │       │           │   ├── c_phone
                 │       │           │   ├── c_acctbal
                 │       │           │   └── c_comment
-                │       │           ├── filter: null
+                │       │           ├── filter: true
                 │       │           ├── cost: 1050000
                 │       │           └── rows: 150000
                 │       └── Projection { exprs: [ o_orderkey, o_custkey ], cost: 6416250, rows: 375000 }
@@ -1098,7 +1098,7 @@ Projection
                 │               └── Scan
                 │                   ├── table: orders
                 │                   ├── list: [ o_orderkey, o_custkey, o_orderdate ]
-                │                   ├── filter: null
+                │                   ├── filter: true
                 │                   ├── cost: 4500000
                 │                   └── rows: 1500000
                 └── Projection { exprs: [ l_orderkey, l_extendedprice, l_discount ], cost: 37387570, rows: 3000607.5 }
@@ -1106,7 +1106,7 @@ Projection
                         └── Scan
                             ├── table: lineitem
                             ├── list: [ l_orderkey, l_extendedprice, l_discount, l_returnflag ]
-                            ├── filter: null
+                            ├── filter: true
                             ├── cost: 24004860
                             └── rows: 6001215
 */
@@ -1206,13 +1206,13 @@ Projection
                 │           └── Scan
                 │               ├── table: lineitem
                 │               ├── list: [ l_orderkey, l_shipdate, l_commitdate, l_receiptdate, l_shipmode ]
-                │               ├── filter: null
+                │               ├── filter: true
                 │               ├── cost: 30006076
                 │               └── rows: 6001215
                 └── Scan
                     ├── table: orders
                     ├── list: [ o_orderkey, o_orderpriority ]
-                    ├── filter: null
+                    ├── filter: true
                     ├── cost: 3000000
                     └── rows: 1500000
 */
@@ -1281,7 +1281,7 @@ Projection
                         ├── on: = { lhs: [ c_custkey ], rhs: [ o_custkey ] }
                         ├── cost: 9792252
                         ├── rows: 750000
-                        ├── Scan { table: customer, list: [ c_custkey ], filter: null, cost: 150000, rows: 150000 }
+                        ├── Scan { table: customer, list: [ c_custkey ], filter: true, cost: 150000, rows: 150000 }
                         └── Projection { exprs: [ o_orderkey, o_custkey ], cost: 7237500, rows: 750000 }
                             └── Filter
                                 ├── cond:not
@@ -1291,7 +1291,7 @@ Projection
                                 └── Scan
                                     ├── table: orders
                                     ├── list: [ o_orderkey, o_custkey, o_comment ]
-                                    ├── filter: null
+                                    ├── filter: true
                                     ├── cost: 4500000
                                     └── rows: 1500000
 */
@@ -1344,7 +1344,7 @@ Projection
     ├── rows: 1
     └── Projection { exprs: [ p_type, l_extendedprice, l_discount ], cost: 41447668, rows: 1500303.8 }
         └── HashJoin { type: inner, on: = { lhs: [ p_partkey ], rhs: [ l_partkey ] }, cost: 41387656, rows: 1500303.8 }
-            ├── Scan { table: part, list: [ p_partkey, p_type ], filter: null, cost: 400000, rows: 200000 }
+            ├── Scan { table: part, list: [ p_partkey, p_type ], filter: true, cost: 400000, rows: 200000 }
             └── Projection { exprs: [ l_partkey, l_extendedprice, l_discount ], cost: 33186720, rows: 1500303.8 }
                 └── Filter
                     ├── cond:and
@@ -1355,7 +1355,7 @@ Projection
                     └── Scan
                         ├── table: lineitem
                         ├── list: [ l_partkey, l_extendedprice, l_discount, l_shipdate ]
-                        ├── filter: null
+                        ├── filter: true
                         ├── cost: 24004860
                         └── rows: 6001215
 */
@@ -1460,7 +1460,7 @@ Projection
                     │   └── Scan
                     │       ├── table: part
                     │       ├── list: [ p_partkey, p_brand, p_size, p_container ]
-                    │       ├── filter: null
+                    │       ├── filter: true
                     │       ├── cost: 800000
                     │       └── rows: 200000
                     └── Projection
@@ -1484,7 +1484,7 @@ Projection
                                 │   ├── l_discount
                                 │   ├── l_shipinstruct
                                 │   └── l_shipmode
-                                ├── filter: null
+                                ├── filter: true
                                 ├── cost: 36007290
                                 └── rows: 6001215
 */


### PR DESCRIPTION
Add a new rule that maps null to true so that storage filter on pk can be pushed down.