### PR TITLE
feat(type): support type-string for timestamp type

### DIFF
--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -165,6 +165,14 @@ impl Binder {
                 })?;
                 Ok(self.egraph.add(Node::Constant(DataValue::Date(date))))
             }
+            DataType::Timestamp(_, _) => {
+                let timestamp = value.parse().map_err(|_| {
+                    BindError::CastError(DataValue::String(value), DataTypeKind::Timestamp)
+                })?;
+                Ok(self
+                    .egraph
+                    .add(Node::Constant(DataValue::Timestamp(timestamp))))
+            }
             t => todo!("support typed string: {:?}", t),
         }
     }

--- a/tests/sql/basic_test.slt
+++ b/tests/sql/basic_test.slt
@@ -40,12 +40,10 @@ SELECT EXTRACT(YEAR FROM DATE '2022-09-08') AS year,
 ----
 2022 9 8
 
-# FIXME: support timestamp
-
-# query T
-# select timestamp '1999-01-08 01:00:00'
-# ----
-# 1999-01-08 01:00:00
+query T
+select timestamp '1999-01-08 01:00:00'
+----
+1999-01-08 01:00:00
 
 subtest NullType
 

--- a/tests/sql/basic_test.slt
+++ b/tests/sql/basic_test.slt
@@ -45,6 +45,16 @@ select timestamp '1999-01-08 01:00:00'
 ----
 1999-01-08 01:00:00
 
+query T
+select timestamp '1991-01-08 04:05:06 AD';
+----
+1991-01-08 04:05:06
+
+query T
+select timestamp '1991-01-08 04:05:06 BC';
+----
+1991-01-08 04:05:06 BC
+
 subtest NullType
 
 statement ok


### PR DESCRIPTION
I feel like it’s very simple whether timestamp will support it. There may be some problems that I didn’t pay attention to.