### PR TITLE
feat(storage): Support composite primary keys

### DIFF
--- a/src/catalog/column.rs
+++ b/src/catalog/column.rs
@@ -126,17 +126,14 @@ impl ColumnCatalog {
 }
 
 /// Find the id of the sort key among column catalogs
-pub fn find_sort_key_id(column_infos: &[ColumnCatalog]) -> Option<usize> {
-    let mut key = None;
+pub fn find_sort_key_id(column_infos: &[ColumnCatalog]) -> Vec<usize> {
+    let mut keys = vec![];
     for (id, column_info) in column_infos.iter().enumerate() {
         if column_info.is_primary() {
-            if key.is_some() {
-                panic!("only one primary key is supported");
-            }
-            key = Some(id);
+            keys.push(id);
         }
     }
-    key
+    keys
 }
 
 #[cfg(test)]

--- a/src/storage/memory/table.rs
+++ b/src/storage/memory/table.rs
@@ -16,6 +16,7 @@ pub struct InMemoryTable {
     pub(super) table_ref_id: TableRefId,
     pub(super) columns: Arc<[ColumnCatalog]>,
     pub(super) inner: InMemoryTableInnerRef,
+    pub(super) ordered_pk_ids: Vec<ColumnId>,
 }
 
 pub(super) struct InMemoryTableInner {
@@ -58,6 +59,7 @@ impl InMemoryTable {
             table_ref_id,
             columns: columns.into(),
             inner: Arc::new(RwLock::new(InMemoryTableInner::new())),
+            ordered_pk_ids: Vec::new(),
         }
     }
 }
@@ -83,5 +85,9 @@ impl Table for InMemoryTable {
 
     async fn update(&self) -> StorageResult<InMemoryTransaction> {
         InMemoryTransaction::start(self)
+    }
+
+    fn ordered_pk_ids(&self) -> Vec<ColumnId> {
+        self.ordered_pk_ids.clone()
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -106,6 +106,9 @@ pub trait Table: Sync + Send + Clone + 'static {
 
     /// Get table id
     fn table_id(&self) -> TableRefId;
+
+    /// Get primary key
+    fn ordered_pk_ids(&self) -> Vec<ColumnId>;
 }
 
 /// Reference to a column.

--- a/src/storage/secondary/compactor.rs
+++ b/src/storage/secondary/compactor.rs
@@ -82,11 +82,11 @@ impl Compactor {
             );
         }
 
-        let sort_key = find_sort_key_id(&table.columns);
-        let mut iter: SecondaryIterator = if let Some(sort_key) = sort_key {
+        let sort_keys = find_sort_key_id(&table.columns);
+        let mut iter: SecondaryIterator = if !sort_keys.is_empty() {
             MergeIterator::new(
                 iters.into_iter().map(|iter| iter.into()).collect_vec(),
-                vec![sort_key],
+                sort_keys,
             )
             .into()
         } else {

--- a/src/storage/secondary/manifest.rs
+++ b/src/storage/secondary/manifest.rs
@@ -206,7 +206,7 @@ impl SecondaryStorage {
                 table_name.clone(),
                 column_descs.to_vec(),
                 false,
-                ordered_pk_ids,
+                ordered_pk_ids.clone(),
             )
             .map_err(|_| TracedStorageError::duplicated("table", table_name))?;
 
@@ -222,6 +222,7 @@ impl SecondaryStorage {
             self.version.clone(),
             self.block_cache.clone(),
             self.txn_mgr.clone(),
+            ordered_pk_ids,
         );
         self.tables.write().insert(id, table);
 

--- a/src/storage/secondary/rowset/mem_rowset.rs
+++ b/src/storage/secondary/rowset/mem_rowset.rs
@@ -174,9 +174,10 @@ impl SecondaryMemRowsetImpl {
         column_options: ColumnBuilderOptions,
         rowset_id: u32,
     ) -> Self {
-        if let Some(sort_key_idx) = find_sort_key_id(&columns) {
+        let sort_keys = find_sort_key_id(&columns);
+        if !sort_keys.is_empty() {
             Self::BTree(SecondaryMemRowset::<BTreeMapMemTable> {
-                mem_table: BTreeMapMemTable::new(columns.clone(), sort_key_idx),
+                mem_table: BTreeMapMemTable::new(columns.clone(), sort_keys[0]),
                 rowset_builder: RowsetBuilder::new(columns, column_options),
                 rowset_id,
             })

--- a/src/storage/secondary/rowset/mem_rowset.rs
+++ b/src/storage/secondary/rowset/mem_rowset.rs
@@ -40,15 +40,15 @@ pub trait MemTable {
 
 pub struct BTreeMapMemTable {
     columns: Arc<[ColumnCatalog]>,
-    primary_key_idx: usize,
-    multi_btree_map: BTreeMultiMap<ComparableDataValue, Row>,
+    ordered_pk_idx: Vec<usize>,
+    multi_btree_map: BTreeMultiMap<Vec<ComparableDataValue>, Row>,
 }
 
 impl BTreeMapMemTable {
-    fn new(columns: Arc<[ColumnCatalog]>, primary_key_idx: usize) -> Self {
+    fn new(columns: Arc<[ColumnCatalog]>, ordered_pk_idx: Vec<usize>) -> Self {
         Self {
             columns,
-            primary_key_idx,
+            ordered_pk_idx,
             multi_btree_map: BTreeMultiMap::new(),
         }
     }
@@ -58,7 +58,10 @@ impl MemTable for BTreeMapMemTable {
     fn append(&mut self, columns: DataChunk) -> StorageResult<()> {
         for row_idx in 0..columns.cardinality() {
             self.multi_btree_map.insert(
-                ComparableDataValue(columns.array_at(self.primary_key_idx).get(row_idx)),
+                self.ordered_pk_idx
+                    .iter()
+                    .map(|&idx| ComparableDataValue(columns.array_at(idx).get(row_idx)))
+                    .collect_vec(),
                 columns.row(row_idx).values().collect(),
             );
         }
@@ -177,7 +180,7 @@ impl SecondaryMemRowsetImpl {
         let sort_keys = find_sort_key_id(&columns);
         if !sort_keys.is_empty() {
             Self::BTree(SecondaryMemRowset::<BTreeMapMemTable> {
-                mem_table: BTreeMapMemTable::new(columns.clone(), sort_keys[0]),
+                mem_table: BTreeMapMemTable::new(columns.clone(), sort_keys),
                 rowset_builder: RowsetBuilder::new(columns, column_options),
                 rowset_id,
             })

--- a/src/storage/secondary/table.rs
+++ b/src/storage/secondary/table.rs
@@ -49,6 +49,7 @@ pub struct SecondaryTable {
 }
 
 impl SecondaryTable {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         storage_options: Arc<StorageOptions>,
         table_ref_id: TableRefId,

--- a/src/storage/secondary/table.rs
+++ b/src/storage/secondary/table.rs
@@ -14,7 +14,7 @@ use crate::storage::Table;
 /// A table in Secondary engine.
 ///
 /// As `SecondaryStorage` holds the reference to `SecondaryTable`, we cannot store
-/// `Arc<SecondaryStorage>` inside `SecondaryTable`. This sturct only contains necessary information
+/// `Arc<SecondaryStorage>` inside `SecondaryTable`. This struct only contains necessary information
 /// to decode the columns of the table.
 #[derive(Clone)]
 pub struct SecondaryTable {
@@ -26,6 +26,9 @@ pub struct SecondaryTable {
 
     /// Mapping from [`ColumnId`] to column index in `columns`.
     pub column_map: HashMap<ColumnId, usize>,
+
+    /// Ordered list of primary key columns.
+    pub ordered_pk_ids: Vec<ColumnId>,
 
     /// Root directory of the storage
     pub storage_options: Arc<StorageOptions>,
@@ -54,6 +57,7 @@ impl SecondaryTable {
         version: Arc<VersionManager>,
         block_cache: Cache<BlockCacheKey, Block>,
         txn_mgr: Arc<TransactionManager>,
+        ordered_pk_ids: Vec<ColumnId>,
     ) -> Self {
         Self {
             columns: columns.into(),
@@ -68,6 +72,7 @@ impl SecondaryTable {
             version,
             block_cache,
             txn_mgr,
+            ordered_pk_ids,
         }
     }
 
@@ -125,5 +130,9 @@ impl Table for SecondaryTable {
 
     async fn update(&self) -> StorageResult<SecondaryTransaction> {
         SecondaryTransaction::start(self, false, true).await
+    }
+
+    fn ordered_pk_ids(&self) -> Vec<ColumnId> {
+        self.ordered_pk_ids.clone()
     }
 }


### PR DESCRIPTION
Aims to solve #384, #385.

Still need to handle composite primary keys in `BTreeMapMemTable`, submitting for early feedback as there may be some other things I've got wrong about the code base.