### PR TITLE
feat: support WITH clause

### DIFF
--- a/src/binder/delete.rs
+++ b/src/binder/delete.rs
@@ -11,16 +11,14 @@ impl Binder {
         if from.len() != 1 || !from[0].joins.is_empty() {
             return Err(BindError::Todo(format!("delete from {from:?}")));
         }
-        let TableFactor::Table { name, .. } = &from[0].relation else {
+        let TableFactor::Table { name, alias, .. } = &from[0].relation else {
             return Err(BindError::Todo(format!("delete from {from:?}")));
         };
         let (table_id, is_internal) = self.bind_table_id(name)?;
         if is_internal {
             return Err(BindError::NotSupportedOnInternalTable);
         }
-        let cols = self.bind_table_def(name, None, true)?;
-        let true_ = self.egraph.add(Node::true_());
-        let scan = self.egraph.add(Node::Scan([table_id, cols, true_]));
+        let scan = self.bind_table_def(name, alias.clone(), true)?;
         let cond = self.bind_where(selection)?;
         let filter = self.egraph.add(Node::Filter([cond, scan]));
         Ok(self.egraph.add(Node::Delete([table_id, filter])))

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -108,7 +108,7 @@ impl Binder {
 
         let map = self
             .current_ctx()
-            .aliases
+            .column_aliases
             .get(column_name)
             .ok_or_else(|| BindError::InvalidColumn(column_name.into()))?;
         if let Some(table_name) = table_name {

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -342,12 +342,6 @@ impl Binder {
         // may override the same name
     }
 
-    /// Add a table alias to the current context. Return false if the alias exists.
-    fn add_table_alias(&mut self, table_name: &str) -> bool {
-        let context = self.contexts.last_mut().unwrap();
-        context.table_aliases.insert(table_name.into())
-    }
-
     /// Find an CTE.
     fn find_cte(&self, cte_name: &str) -> Option<&(Id, HashMap<String, Id>)> {
         self.contexts

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -45,6 +45,10 @@ pub enum BindError {
     ColumnExists(String),
     #[error("duplicated alias {0:?}")]
     DuplicatedAlias(String),
+    #[error("duplicate CTE name {0:?}")]
+    DuplicatedCteName(String),
+    #[error("table {0:?} has {1} columns available but {2} columns specified")]
+    ColumnCountMismatch(String, usize, usize),
     #[error("invalid expression {0}")]
     InvalidExpression(String),
     #[error("not nullable column {0:?}")]
@@ -233,16 +237,22 @@ pub fn bind_header(mut chunk: array::Chunk, stmt: &Statement) -> array::Chunk {
     chunk
 }
 
-/// The context of binder execution.
+/// A set of current accessible table and column aliases.
+///
+/// Context can be nested to represent subqueries.
+/// Binder maintains a stack of contexts.
 #[derive(Debug, Default)]
 struct Context {
-    /// Table names that can be accessed from the current query.
+    /// Defined CTEs.
+    /// cte_name -> (query_id, column_alias -> id)
+    ctes: HashMap<String, (Id, HashMap<String, Id>)>,
+    /// Table aliases that can be accessed from the current query.
     table_aliases: HashSet<String>,
-    /// Column names that can be accessed from the current query.
-    /// column_name -> (table_name -> id)
-    aliases: HashMap<String, HashMap<String, Id>>,
-    /// Column names that can be accessed from the outside query.
-    /// column_name -> id
+    /// Column aliases that can be accessed from the current query.
+    /// column_alias -> (table_alias -> id)
+    column_aliases: HashMap<String, HashMap<String, Id>>,
+    /// Column aliases that can be accessed from the outside query.
+    /// column_alias -> id
     output_aliases: HashMap<String, Id>,
 }
 
@@ -321,15 +331,21 @@ impl Binder {
         self.contexts.last_mut().unwrap()
     }
 
-    /// Add an alias to the current context.
+    /// Add a column alias to the current context.
     fn add_alias(&mut self, column_name: String, table_name: String, id: Id) {
         let context = self.contexts.last_mut().unwrap();
         context
-            .aliases
+            .column_aliases
             .entry(column_name)
             .or_default()
             .insert(table_name, id);
         // may override the same name
+    }
+
+    /// Add a table alias to the current context. Return false if the alias exists.
+    fn add_table_alias(&mut self, table_name: &str) -> bool {
+        let context = self.contexts.last_mut().unwrap();
+        context.table_aliases.insert(table_name.into())
     }
 
     fn type_(&self, id: Id) -> Result<crate::types::DataType> {

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -348,6 +348,14 @@ impl Binder {
         context.table_aliases.insert(table_name.into())
     }
 
+    /// Find an CTE.
+    fn find_cte(&self, cte_name: &str) -> Option<&(Id, HashMap<String, Id>)> {
+        self.contexts
+            .iter()
+            .rev()
+            .find_map(|ctx| ctx.ctes.get(cte_name))
+    }
+
     fn type_(&self, id: Id) -> Result<crate::types::DataType> {
         Ok(self.egraph[id].data.type_.clone()?)
     }

--- a/src/binder/table.rs
+++ b/src/binder/table.rs
@@ -59,13 +59,7 @@ impl Binder {
     /// - `bind_table_factor(select 1)` => `(values (1))`
     fn bind_table_factor(&mut self, table: TableFactor) -> Result {
         match table {
-            TableFactor::Table { name, alias, .. } => {
-                let (table_id, _) = self.bind_table_id(&name)?;
-                let cols = self.bind_table_def(&name, alias, false)?;
-                let null = self.egraph.add(Node::null());
-                let id = self.egraph.add(Node::Scan([table_id, cols, null]));
-                Ok(id)
-            }
+            TableFactor::Table { name, alias, .. } => self.bind_table_def(&name, alias, false),
             TableFactor::Derived {
                 subquery, alias, ..
             } => {
@@ -76,7 +70,7 @@ impl Binder {
                     // 'as t(a, b, ..)'
                     let table_name = &alias.name.value;
                     for (column, id) in alias.columns.iter().zip(self.schema(id)) {
-                        self.add_alias(column.value.clone(), table_name.clone(), id);
+                        self.add_alias(column.value.to_lowercase(), table_name.clone(), id);
                     }
                 } else {
                     // move `output_aliases` to current context
@@ -135,12 +129,13 @@ impl Binder {
         }
     }
 
-    /// Returns a list of all columns in the table.
+    /// Defines the table name so that it can be referred later.
+    /// Returns a `Scan` node if the table is a base table, or a subquery if it is a CTE.
     ///
     /// This function defines the table name so that it can be referred later.
     ///
     /// # Example
-    /// - `bind_table_def(t)` => `(list $1.1 $1.2)`
+    /// - `bind_table_def(t)` => `(scan $1 (list $1.1 $1.2) null)`
     pub(super) fn bind_table_def(
         &mut self,
         name: &ObjectName,
@@ -149,11 +144,8 @@ impl Binder {
     ) -> Result {
         let name = lower_case_name(name);
         let (schema_name, table_name) = split_name(&name)?;
-        let ref_id = self
-            .catalog
-            .get_table_id_by_name(schema_name, table_name)
-            .ok_or_else(|| BindError::InvalidTable(table_name.into()))?;
 
+        // check duplicated alias
         let table_alias = match &alias {
             Some(alias) => &alias.name.value,
             None => table_name,
@@ -165,6 +157,21 @@ impl Binder {
         {
             return Err(BindError::DuplicatedAlias(table_alias.into()));
         }
+
+        // find cte
+        if let Some((query, columns)) = self.current_ctx().ctes.get(table_name).cloned() {
+            // add column aliases
+            for (column_name, id) in columns {
+                self.add_alias(column_name, table_alias.into(), id);
+            }
+            return Ok(query);
+        }
+
+        // find table in catalog
+        let ref_id = self
+            .catalog
+            .get_table_id_by_name(schema_name, table_name)
+            .ok_or_else(|| BindError::InvalidTable(table_name.into()))?;
 
         let table = self.catalog.get_table(&ref_id).unwrap();
         let table_occurence = {
@@ -183,8 +190,13 @@ impl Binder {
             self.add_alias(column.name().into(), table_alias.into(), id);
             ids.push(id);
         }
-        let id = self.egraph.add(Node::List(ids.into()));
-        Ok(id)
+
+        // return a Scan node
+        let table = self.egraph.add(Node::Table(ref_id));
+        let cols = self.egraph.add(Node::List(ids.into()));
+        let null = self.egraph.add(Node::null());
+        let scan = self.egraph.add(Node::Scan([table, cols, null]));
+        Ok(scan)
     }
 
     /// Returns a list of given columns in the table.

--- a/src/binder/table.rs
+++ b/src/binder/table.rs
@@ -159,7 +159,7 @@ impl Binder {
         }
 
         // find cte
-        if let Some((query, columns)) = self.current_ctx().ctes.get(table_name).cloned() {
+        if let Some((query, columns)) = self.find_cte(table_name).cloned() {
             // add column aliases
             for (column_name, id) in columns {
                 self.add_alias(column_name, table_alias.into(), id);

--- a/src/planner/rules/plan.rs
+++ b/src/planner/rules/plan.rs
@@ -263,7 +263,11 @@ fn columns_is(
                 .data
                 .columns
                 .iter()
-                .map(|e| egraph.lookup(e.clone()).unwrap())
+                .map(|e| {
+                    egraph
+                        .lookup(e.clone())
+                        .unwrap_or_else(|| panic!("node not found in egraph: {}", e))
+                })
                 .collect()
         };
         f(&get_set(var1), &get_set(var2))

--- a/tests/sql/cte.slt
+++ b/tests/sql/cte.slt
@@ -22,7 +22,7 @@ statement ok
 insert into t values (42);
 
 query I
-with cte as (select a * 100 from t)
+with cte as (select a from t)
 select * from cte;
 ----
 42
@@ -36,4 +36,25 @@ select * from cte;
 # 4200
 
 statement ok
+insert into t values (43);
+
+# FIXME: correct column reference when join cte with itself
+#        now it can not distinguish between t1.a and t2.a
+# query II rowsort
+# with cte as (select a from t)
+# select * from cte as t1, cte as t2 where t1.a = t2.a;
+# ----
+# 42 42
+# 43 43
+
+statement ok
 drop table t;
+
+query error duplicate CTE name
+with cte as (select 42 as x),
+     cte as (select * from cte)
+select * from cte;
+
+query error table "cte" has 1 columns available but 2 columns specified
+with cte(a, b) as (select 42 as x)
+select * from cte;

--- a/tests/sql/cte.slt
+++ b/tests/sql/cte.slt
@@ -1,0 +1,39 @@
+# FIXME: panic
+# # create a CTE called "cte" and use it in the main query
+# query I
+# WITH cte AS (SELECT 42 AS x)
+# SELECT * FROM cte;
+# ----
+# 42
+# 
+# # create two CTEs, where the second CTE references the first CTE
+# query I
+# WITH cte AS (SELECT 42 AS i),
+#      cte2 AS (SELECT i*100 AS x FROM cte)
+# SELECT * FROM cte2;
+# ----
+# 4200
+
+
+statement ok
+create table t(a int);
+
+statement ok
+insert into t values (42);
+
+query I
+with cte as (select a * 100 from t)
+select * from cte;
+----
+42
+
+# FIXME: panic
+# query I
+# with cte as (select a as i from t),
+#      cte2 as (select i*100 as x from cte)
+# select * from cte2;
+# ----
+# 4200
+
+statement ok
+drop table t;


### PR DESCRIPTION
This PR adds support for specifying CTEs using the `WITH` clause. We treat CTEs just as named subqueries. The implementation simply adds CTE queries to the binder context and inlines them when referenced.

However, due to an optimizer bug (which has been fixed in #796), the current CTE is pretty useless as most practice use cases will lead to panics.