### PR TITLE
feat: use in-memory storage by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,12 @@ jobs:
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}-${{ env.CACHE_KEY_SUFFIX }}
       - name: Generate TPC-H 1GB dataset
-        run: |
-          rm -rf risinglight.db
-          make tpch
+        run: make tpch
       - name: Build RisingLight (in release mode)
-        run: |
-          cargo build --release
+        run: cargo build --release
       - name: Run TPC-H Test
         run: |
-          ./target/release/risinglight -f tests/sql/tpch/create.sql
-          ./target/release/risinglight -f tests/sql/tpch/import.sql
-          ./target/release/risinglight -f tests/sql/tpch-full/_tpch_full.slt
+          rm -rf tpch.db
+          ./target/release/risinglight tpch.db -f tests/sql/tpch/create.sql
+          ./target/release/risinglight tpch.db -f tests/sql/tpch/import.sql
+          ./target/release/risinglight tpch.db -f tests/sql/tpch-full/_tpch_full.slt


### PR DESCRIPTION
To keep consistent with sqlite and duckdb:

```sh
risinglight # use in-memory storage
risinglight test.db # use disk storage
```