### PR TITLE
feat(binder): support create index statements

### DIFF
--- a/src/binder/create_index.rs
+++ b/src/binder/create_index.rs
@@ -1,0 +1,100 @@
+// Copyright 2024 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::fmt;
+use std::str::FromStr;
+
+use pretty_xmlish::helper::delegate_fmt;
+use pretty_xmlish::Pretty;
+use serde::{Deserialize, Serialize};
+
+use super::*;
+use crate::catalog::{ColumnId, SchemaId, TableId};
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Serialize, Deserialize)]
+pub struct CreateIndex {
+    pub schema_id: SchemaId,
+    pub index_name: String,
+    pub table_id: TableId,
+    pub columns: Vec<ColumnId>,
+}
+
+impl fmt::Display for CreateIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let explainer = Pretty::childless_record("CreateIndex", self.pretty_index());
+        delegate_fmt(&explainer, f, String::with_capacity(1000))
+    }
+}
+
+impl CreateIndex {
+    pub fn pretty_index<'a>(&self) -> Vec<(&'a str, Pretty<'a>)> {
+        vec![
+            ("schema_id", Pretty::display(&self.schema_id)),
+            ("name", Pretty::display(&self.index_name)),
+            ("table_id", Pretty::display(&self.table_id)),
+            (
+                "columns",
+                Pretty::Array(self.columns.iter().map(Pretty::display).collect()),
+            ),
+        ]
+    }
+}
+
+impl FromStr for Box<CreateIndex> {
+    type Err = ();
+
+    fn from_str(_s: &str) -> std::result::Result<Self, Self::Err> {
+        Err(())
+    }
+}
+
+impl Binder {
+    pub(super) fn bind_create_index(&mut self, stat: crate::parser::CreateIndex) -> Result {
+        let Some(ref name) = stat.name else {
+            return Err(
+                ErrorKind::InvalidIndex(format!("index must have a name")).with_spanned(&stat)
+            );
+        };
+        let crate::parser::CreateIndex {
+            table_name,
+            columns,
+            ..
+        } = stat;
+        let index_name = lower_case_name(&name);
+        let (_, index_name) = split_name(&index_name)?;
+        let table_obj: ObjectName = table_name.clone();
+        let table_name = lower_case_name(&table_name);
+        let (schema_name, table_name) = split_name(&table_name)?;
+        let schema = self
+            .catalog
+            .get_schema_by_name(schema_name)
+            .ok_or_else(|| ErrorKind::InvalidSchema(schema_name.into()).with_spanned(&table_obj))?;
+        let Some(table) = schema.get_table_by_name(table_name) else {
+            return Err(ErrorKind::InvalidTable(table_name.into()).with_spanned(&table_obj));
+        };
+        // Check if every column exists in the table and get the column ids
+        let mut column_ids = Vec::new();
+        for column in &columns {
+            // Ensure column expr is a column reference
+            let OrderByExpr { expr, .. } = column;
+            let Expr::Identifier(column_name) = expr else {
+                return Err(
+                    ErrorKind::InvalidColumn("column reference expected".to_string())
+                        .with_spanned(column),
+                );
+            };
+            let column_name = column_name.value.to_lowercase();
+            let column_catalog = table
+                .get_column_by_name(&column_name)
+                .ok_or_else(|| ErrorKind::InvalidColumn(column_name).with_spanned(column))?;
+            column_ids.push(column_catalog.id());
+        }
+
+        let create = self.egraph.add(Node::CreateIndex(Box::new(CreateIndex {
+            schema_id: schema.id(),
+            index_name: index_name.into(),
+            table_id: table.id(),
+            columns: column_ids,
+        })));
+        Ok(create)
+    }
+}

--- a/src/binder/create_index.rs
+++ b/src/binder/create_index.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RisingLight Project Authors. Licensed under Apache-2.0.
+// Copyright 2025 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::fmt;
 use std::str::FromStr;
@@ -51,7 +51,7 @@ impl Binder {
     pub(super) fn bind_create_index(&mut self, stat: crate::parser::CreateIndex) -> Result {
         let Some(ref name) = stat.name else {
             return Err(
-                ErrorKind::InvalidIndex(format!("index must have a name")).with_spanned(&stat)
+                ErrorKind::InvalidIndex("index must have a name".to_string()).with_spanned(&stat),
             );
         };
         let crate::parser::CreateIndex {
@@ -59,7 +59,7 @@ impl Binder {
             columns,
             ..
         } = stat;
-        let index_name = lower_case_name(&name);
+        let index_name = lower_case_name(name);
         let (_, index_name) = split_name(&index_name)?;
         let table_obj: ObjectName = table_name.clone();
         let table_name = lower_case_name(&table_name);

--- a/src/binder/error.rs
+++ b/src/binder/error.rs
@@ -53,6 +53,8 @@ pub enum ErrorKind {
     InvalidSchema(String),
     #[error("invalid table {0:?}")]
     InvalidTable(String),
+    #[error("invalid index {0:?}")]
+    InvalidIndex(String),
     #[error("invalid column {0:?}")]
     InvalidColumn(String),
     #[error("table {0:?} already exists")]

--- a/src/binder/mod.rs
+++ b/src/binder/mod.rs
@@ -17,6 +17,7 @@ use crate::types::DataValue;
 
 pub mod copy;
 mod create_function;
+mod create_index;
 mod create_table;
 mod create_view;
 mod delete;
@@ -28,6 +29,7 @@ mod select;
 mod table;
 
 pub use self::create_function::CreateFunction;
+pub use self::create_index::CreateIndex;
 pub use self::create_table::CreateTable;
 pub use self::error::BindError;
 use self::error::ErrorKind;
@@ -226,6 +228,7 @@ impl Binder {
 
     fn bind_stmt(&mut self, stmt: Statement) -> Result {
         match stmt {
+            Statement::CreateIndex(create_index) => self.bind_create_index(create_index),
             Statement::CreateTable(create_table) => self.bind_create_table(create_table),
             Statement::CreateView {
                 name,

--- a/src/catalog/index.rs
+++ b/src/catalog/index.rs
@@ -1,0 +1,38 @@
+// Copyright 2025 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use super::*;
+
+/// The catalog of an index.
+pub struct IndexCatalog {
+    id: IndexId,
+    name: String,
+    table_id: TableId,
+    column_idxs: Vec<ColumnId>,
+}
+
+impl IndexCatalog {
+    pub fn new(id: IndexId, name: String, table_id: TableId, column_idxs: Vec<ColumnId>) -> Self {
+        Self {
+            id,
+            name,
+            table_id,
+            column_idxs,
+        }
+    }
+
+    pub fn table_id(&self) -> TableId {
+        self.table_id
+    }
+
+    pub fn column_idxs(&self) -> &[ColumnId] {
+        &self.column_idxs
+    }
+
+    pub fn id(&self) -> IndexId {
+        self.id
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}

--- a/src/catalog/mod.rs
+++ b/src/catalog/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 pub use self::column::*;
+pub use self::index::*;
 pub use self::root::*;
 pub use self::schema::*;
 pub use self::table::*;
@@ -13,12 +14,14 @@ use crate::types::*;
 
 mod column;
 pub mod function;
+mod index;
 mod root;
 mod schema;
 mod table;
 
 pub type SchemaId = u32;
 pub type TableId = u32;
+pub type IndexId = u32;
 pub type ColumnId = u32;
 
 pub type RootCatalogRef = Arc<RootCatalog>;

--- a/src/catalog/root.rs
+++ b/src/catalog/root.rs
@@ -234,10 +234,7 @@ const CREATE_SYSTEM_TABLE_SQL: &str = "
         schema_id int not null,
         schema_name string not null,
         table_id int not null,
-        table_name string not null,
-        index_id int not null,
-        index_name string not null,
-        on_columns string not null
+        table_name string not null
     );
     create table pg_indexes (
         schema_id int not null,

--- a/src/catalog/root.rs
+++ b/src/catalog/root.rs
@@ -98,6 +98,34 @@ impl RootCatalog {
         schema.add_view(name, columns, query)
     }
 
+    pub fn add_index(
+        &self,
+        schema_id: SchemaId,
+        index_name: String,
+        table_id: TableId,
+        column_idxs: &[ColumnId],
+    ) -> Result<IndexId, CatalogError> {
+        let mut inner = self.inner.lock().unwrap();
+        let schema = inner.schemas.get_mut(&schema_id).unwrap();
+        schema.add_index(index_name, table_id, column_idxs.to_vec())
+    }
+
+    pub fn get_index_on_table(&self, schema_id: SchemaId, table_id: TableId) -> Vec<IndexId> {
+        let mut inner = self.inner.lock().unwrap();
+        let schema = inner.schemas.get_mut(&schema_id).unwrap();
+        schema.get_indexes_on_table(table_id)
+    }
+
+    pub fn get_index_by_id(
+        &self,
+        schema_id: SchemaId,
+        index_id: IndexId,
+    ) -> Option<Arc<IndexCatalog>> {
+        let mut inner = self.inner.lock().unwrap();
+        let schema = inner.schemas.get_mut(&schema_id).unwrap();
+        schema.get_index_by_id(index_id)
+    }
+
     pub fn drop_table(&self, table_ref_id: TableRefId) {
         let mut inner = self.inner.lock().unwrap();
         let schema = inner.schemas.get_mut(&table_ref_id.schema_id).unwrap();

--- a/src/catalog/root.rs
+++ b/src/catalog/root.rs
@@ -234,7 +234,19 @@ const CREATE_SYSTEM_TABLE_SQL: &str = "
         schema_id int not null,
         schema_name string not null,
         table_id int not null,
-        table_name string not null
+        table_name string not null,
+        index_id int not null,
+        index_name string not null,
+        on_columns string not null
+    );
+    create table pg_indexes (
+        schema_id int not null,
+        schema_name string not null,
+        table_id int not null,
+        table_name string not null,
+        index_id int not null,
+        index_name string not null,
+        on_columns string not null
     );
     create table pg_attribute (
         schema_name string not null,

--- a/src/db.rs
+++ b/src/db.rs
@@ -65,6 +65,7 @@ impl Database {
         let tokens = cmd.split_whitespace().collect::<Vec<_>>();
         Ok(match tokens.as_slice() {
             ["dt"] => "SELECT * FROM pg_catalog.pg_tables".to_string(),
+            ["di"] => "SELECT * FROM pg_catalog.pg_indexes".to_string(),
             ["d", table] => format!(
                 "SELECT * FROM pg_catalog.pg_attribute WHERE table_name = '{table}'",
             ),

--- a/src/executor/create_index.rs
+++ b/src/executor/create_index.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 RisingLight Project Authors. Licensed under Apache-2.0.
+// Copyright 2025 RisingLight Project Authors. Licensed under Apache-2.0.
 
 use std::sync::Arc;
 

--- a/src/executor/create_index.rs
+++ b/src/executor/create_index.rs
@@ -1,0 +1,29 @@
+// Copyright 2024 RisingLight Project Authors. Licensed under Apache-2.0.
+
+use std::sync::Arc;
+
+use super::*;
+use crate::binder::CreateIndex;
+use crate::storage::Storage;
+
+/// The executor of `create index` statement.
+pub struct CreateIndexExecutor<S: Storage> {
+    pub index: Box<CreateIndex>,
+    pub storage: Arc<S>,
+}
+
+impl<S: Storage> CreateIndexExecutor<S> {
+    #[try_stream(boxed, ok = DataChunk, error = ExecutorError)]
+    pub async fn execute(self) {
+        self.storage
+            .create_index(
+                self.index.schema_id,
+                &self.index.index_name,
+                self.index.table_id,
+                &self.index.columns,
+            )
+            .await?;
+
+        yield DataChunk::single(1);
+    }
+}

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -27,6 +27,7 @@ use self::analyze::*;
 use self::copy_from_file::*;
 use self::copy_to_file::*;
 use self::create_function::*;
+use self::create_index::*;
 use self::create_table::*;
 use self::create_view::*;
 use self::delete::*;
@@ -79,6 +80,7 @@ mod nested_loop_join;
 mod order;
 mod system_table_scan;
 // mod perfect_hash_agg;
+mod create_index;
 mod error;
 mod merge_join;
 mod projection;
@@ -388,6 +390,12 @@ impl<S: Storage> Builder<S> {
 
             CreateTable(table) => CreateTableExecutor {
                 table,
+                storage: self.storage.clone(),
+            }
+            .execute(),
+
+            CreateIndex(index) => CreateIndexExecutor {
+                index,
                 storage: self.storage.clone(),
             }
             .execute(),

--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -326,6 +326,10 @@ impl<'a> Explain<'a> {
                 let fields = with_meta(t.pretty_table());
                 Pretty::childless_record("CreateTable", fields)
             }
+            CreateIndex(i) => {
+                let fields = with_meta(i.pretty_index());
+                Pretty::childless_record("CreateIndex", fields)
+            }
             CreateView([table, query]) => Pretty::simple_record(
                 "CreateView",
                 with_meta(vec![("table", self.expr(table).pretty())]),

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -3,7 +3,7 @@
 use egg::{define_language, Id, Symbol};
 
 use crate::binder::copy::ExtSource;
-use crate::binder::{CreateFunction, CreateTable};
+use crate::binder::{CreateFunction, CreateIndex, CreateTable};
 use crate::catalog::{ColumnRefId, TableRefId};
 use crate::parser::{BinaryOperator, UnaryOperator};
 use crate::types::{ColumnIndex, DataType, DataValue, DateTimeField};
@@ -119,6 +119,7 @@ define_language! {
         "window" = Window([Id; 2]),             // (window [over..] child)
                                                     // output = child || exprs
         CreateTable(Box<CreateTable>),
+        CreateIndex(Box<CreateIndex>),
         "create_view" = CreateView([Id; 2]),    // (create_view create_table child)
         CreateFunction(CreateFunction),
         "drop" = Drop(Id),                      // (drop [table..])

--- a/src/storage/index/mod.rs
+++ b/src/storage/index/mod.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use crate::catalog::{ColumnId, IndexId, SchemaId, TableId};
+
+pub trait InMemoryIndex: 'static + Send + Sync {}
+
+pub struct InMemoryIndexes {}
+
+impl InMemoryIndexes {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub fn add_index(
+        &self,
+        schema_id: SchemaId,
+        index_id: IndexId,
+        table_id: TableId,
+        column_idxs: &[ColumnId],
+    ) {
+    }
+
+    pub fn get_index(
+        &self,
+        schema_id: SchemaId,
+        index_id: IndexId,
+    ) -> Option<Arc<dyn InMemoryIndex>> {
+        None
+    }
+}

--- a/src/storage/index/mod.rs
+++ b/src/storage/index/mod.rs
@@ -1,3 +1,5 @@
+// Copyright 2025 RisingLight Project Authors. Licensed under Apache-2.0.
+
 use std::sync::Arc;
 
 use crate::catalog::{ColumnId, IndexId, SchemaId, TableId};
@@ -18,6 +20,7 @@ impl InMemoryIndexes {
         table_id: TableId,
         column_idxs: &[ColumnId],
     ) {
+        let _ = (schema_id, index_id, table_id, column_idxs);
     }
 
     pub fn get_index(
@@ -25,6 +28,7 @@ impl InMemoryIndexes {
         schema_id: SchemaId,
         index_id: IndexId,
     ) -> Option<Arc<dyn InMemoryIndex>> {
+        let _ = (schema_id, index_id);
         None
     }
 }

--- a/src/storage/secondary/storage.rs
+++ b/src/storage/secondary/storage.rs
@@ -12,6 +12,7 @@ use tracing::info;
 
 use super::{DiskRowset, Manifest, SecondaryStorage, StorageOptions, StorageResult};
 use crate::catalog::RootCatalog;
+use crate::storage::index::InMemoryIndexes;
 use crate::storage::secondary::manifest::*;
 use crate::storage::secondary::transaction_manager::TransactionManager;
 use crate::storage::secondary::version_manager::{EpochOp, VersionManager};
@@ -58,6 +59,7 @@ impl SecondaryStorage {
             compactor_handler: Mutex::new((None, None)),
             vacuum_handler: Mutex::new((None, None)),
             txn_mgr: Arc::new(TransactionManager::default()),
+            indexes: Mutex::new(InMemoryIndexes::new()),
         };
 
         info!("applying {} manifest entries", manifest_ops.len());

--- a/tests/sql/catalog.slt
+++ b/tests/sql/catalog.slt
@@ -6,6 +6,15 @@ query ITIT rowsort
 ----
 0 pg_catalog 0 contributors
 0 pg_catalog 1 pg_tables
-0 pg_catalog 2 pg_attribute
-0 pg_catalog 3 pg_stat
+0 pg_catalog 2 pg_indexes
+0 pg_catalog 3 pg_attribute
+0 pg_catalog 4 pg_stat
 1 postgres 0 t
+
+statement ok
+create index i1 on t(v1)
+
+query ITITITT rowsort
+\di
+----
+1 postgres 0 t 1 i1 [0]


### PR DESCRIPTION
part of https://github.com/risinglightdb/risinglight/issues/864

Add `create index` support. No indexes are created for now. It only modifies the catalog. All storage engines now use a shared submodule called `index` to manage in-memory indexes.