### PR TITLE
feat(expression): support repeat function

### DIFF
--- a/src/array/ops.rs
+++ b/src/array/ops.rs
@@ -635,6 +635,26 @@ impl ArrayImpl {
         Ok(A::new_string(unary_op(a.as_ref(), |s| s.replace(from, to))))
     }
 
+    pub fn repeat(&self, num: &Self) -> Result {
+        let (A::String(a), A::Int32(b)) = (self, num) else {
+            return Err(ConvertError::NoBinaryOp(
+                "repeat".into(),
+                self.type_string(),
+                num.type_string(),
+            ));
+        };
+        Ok(A::new_string(binary_op(
+            a.as_ref(),
+            b.as_ref(),
+            |a, b| {
+                if *b < 0 {
+                    return String::new();
+                }
+                a.repeat(*b as usize)
+            },
+        )))
+    }
+
     pub fn vector_l2_distance(&self, other: &ArrayImpl) -> Result {
         let ArrayImpl::Vector(a) = self else {
             return Err(ConvertError::NoBinaryOp(

--- a/src/array/ops.rs
+++ b/src/array/ops.rs
@@ -643,16 +643,13 @@ impl ArrayImpl {
                 num.type_string(),
             ));
         };
-        Ok(A::new_string(binary_op(
-            a.as_ref(),
-            b.as_ref(),
-            |a, b| {
-                if *b < 0 {
-                    return String::new();
-                }
-                a.repeat(*b as usize)
-            },
-        )))
+        Ok(A::new_string(binary_op(a.as_ref(), b.as_ref(), |a, b| {
+            let mut res = String::new();
+            for _ in 0..(*b) {
+                res += a;
+            }
+            res
+        })))
     }
 
     pub fn vector_l2_distance(&self, other: &ArrayImpl) -> Result {

--- a/src/binder/expr.rs
+++ b/src/binder/expr.rs
@@ -447,6 +447,7 @@ impl Binder {
             "first" => Node::First(args[0]),
             "last" => Node::Last(args[0]),
             "replace" => Node::Replace([args[0], args[1], args[2]]),
+            "repeat" => Node::Repeat([args[0], args[1]]),
             "row_number" => Node::RowNumber,
             name => todo!("Unsupported function: {}", name),
         };

--- a/src/executor/evaluator.rs
+++ b/src/executor/evaluator.rs
@@ -132,6 +132,11 @@ impl<'a> Evaluator<'a> {
                 };
                 a.replace(from, to)
             }
+            Repeat([str, num]) => {
+                let str = self.next(*str).eval(chunk)?;
+                let num = self.next(*num).eval(chunk)?;
+                str.repeat(&num)
+            }
             VectorL2Distance([a, b]) => {
                 let a = self.next(*a).eval(chunk)?;
                 let b = self.next(*b).eval(chunk)?;

--- a/src/planner/explain.rs
+++ b/src/planner/explain.rs
@@ -176,6 +176,13 @@ impl<'a> Explain<'a> {
                     ("to", self.expr(c).pretty()),
                 ],
             ),
+            Repeat([str, num]) => Pretty::childless_record(
+                "Repeat",
+                vec![
+                    ("str", self.expr(str).pretty()),
+                    ("num", self.expr(num).pretty()),
+                ],
+            ),
             Substring([str, start, len]) => Pretty::childless_record(
                 "Substring",
                 vec![

--- a/src/planner/mod.rs
+++ b/src/planner/mod.rs
@@ -67,6 +67,7 @@ define_language! {
         "extract" = Extract([Id; 2]),           // (extract field expr)
             Field(DateTimeField),
         "replace" = Replace([Id; 3]),           // (replace expr pattern replacement)
+        "repeat" = Repeat([Id; 2]),             // (repeat expr the specified number of times)
         "substring" = Substring([Id; 3]),       // (substring expr start length)
 
         // vector functions

--- a/src/planner/rules/type_.rs
+++ b/src/planner/rules/type_.rs
@@ -132,7 +132,9 @@ pub fn analyze_type(
                     .then_some(DataType::String)
             })
         }
-
+        Repeat([str, num]) => merge(enode, [x(str)?, x(num)?], |[str, num]| {
+            (str == DataType::String && num == DataType::Int32).then_some(DataType::String)
+        }),
         // number agg
         Max(a) | Min(a) => x(a),
         Sum(a) => check(enode, x(a)?, |a| a.is_number()),

--- a/tests/sql/repeat.slt
+++ b/tests/sql/repeat.slt
@@ -1,0 +1,34 @@
+query I
+select repeat('abc', 3);
+----
+abcabcabc
+
+statement ok
+create table t(v varchar(20));
+
+statement ok
+insert into t values ('test1'), ('test2'), ('test3'), ('test4'), ('test5'), ('test6'), ('test7'), ('test8');
+
+query I
+select repeat(v, 2) from t;
+----
+test1test1
+test2test2
+test3test3
+test4test4
+test5test5
+test6test6
+test7test7
+test8test8
+
+query I
+select repeat(v, -1) from t;
+----
+(empty)
+(empty)
+(empty)
+(empty)
+(empty)
+(empty)
+(empty)
+(empty)


### PR DESCRIPTION
Partly fixed #387.

- support `repeat` function
- add sqllogictest for `repeat`

**WIP**: support `trim`, `length`, `lower`, `upper`.